### PR TITLE
feat: implement Project model and CRUD API (#4)

### DIFF
--- a/backend/alembic/versions/0003_add_projects_table.py
+++ b/backend/alembic/versions/0003_add_projects_table.py
@@ -34,9 +34,12 @@ def upgrade() -> None:
             "status",
             sa.String(20),
             nullable=False,
-            server_default="ACTIVE",
+            server_default="active",
         ),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('active', 'archived')", name="ck_projects_status"
+        ),
     )
 
 

--- a/backend/alembic/versions/0003_add_projects_table.py
+++ b/backend/alembic/versions/0003_add_projects_table.py
@@ -1,0 +1,44 @@
+"""add projects table
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-13
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0003"
+down_revision: str = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "projects",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("color", sa.String(7), nullable=False),
+        sa.Column("client_name", sa.String(100), nullable=True),
+        sa.Column("hourly_rate", sa.Numeric(10, 2), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default="ACTIVE",
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("projects")

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.models.user import User
+from app.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
+from app.services.project_service import (
+    create_project,
+    delete_project,
+    get_project,
+    list_projects,
+    update_project,
+)
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+@router.post("", response_model=ProjectResponse, status_code=status.HTTP_201_CREATED)
+async def create_project_route(
+    body: ProjectCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectResponse:
+    """Create a new project for the authenticated user."""
+    project = await create_project(db=db, user_id=current_user.id, data=body)
+    return ProjectResponse.model_validate(project)
+
+
+@router.get("", response_model=list[ProjectResponse])
+async def list_projects_route(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[ProjectResponse]:
+    """List all projects for the authenticated user."""
+    projects = await list_projects(db=db, user_id=current_user.id)
+    return [ProjectResponse.model_validate(p) for p in projects]
+
+
+@router.get("/{project_id}", response_model=ProjectResponse)
+async def get_project_route(
+    project_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectResponse:
+    """Get a single project by ID."""
+    project = await get_project(
+        db=db, project_id=project_id, user_id=current_user.id
+    )
+    return ProjectResponse.model_validate(project)
+
+
+@router.patch("/{project_id}", response_model=ProjectResponse)
+async def update_project_route(
+    project_id: uuid.UUID,
+    body: ProjectUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectResponse:
+    """Update a project by ID."""
+    project = await update_project(
+        db=db, project_id=project_id, user_id=current_user.id, data=body
+    )
+    return ProjectResponse.model_validate(project)
+
+
+@router.delete(
+    "/{project_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None
+)
+async def delete_project_route(
+    project_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Delete a project by ID."""
+    await delete_project(db=db, project_id=project_id, user_id=current_user.id)

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
@@ -33,11 +33,15 @@ async def create_project_route(
 
 @router.get("", response_model=list[ProjectResponse])
 async def list_projects_route(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[ProjectResponse]:
-    """List all projects for the authenticated user."""
-    projects = await list_projects(db=db, user_id=current_user.id)
+    """List projects for the authenticated user with pagination."""
+    projects = await list_projects(
+        db=db, user_id=current_user.id, skip=skip, limit=limit
+    )
     return [ProjectResponse.model_validate(p) for p in projects]
 
 

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -48,9 +48,7 @@ async def get_project_route(
     db: AsyncSession = Depends(get_db),
 ) -> ProjectResponse:
     """Get a single project by ID."""
-    project = await get_project(
-        db=db, project_id=project_id, user_id=current_user.id
-    )
+    project = await get_project(db=db, project_id=project_id, user_id=current_user.id)
     return ProjectResponse.model_validate(project)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 
 from app.api.auth import router as auth_router
 from app.api.health import router as health_router
+from app.api.projects import router as projects_router
 from app.core.config import settings
 from app.core.database import dispose_engine, init_engine
 
@@ -34,6 +35,7 @@ def create_app() -> FastAPI:
 
     app.include_router(health_router)
     app.include_router(auth_router)
+    app.include_router(projects_router)
 
     return app
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.project import Project
 from app.models.user import User
 
-__all__ = ["User"]
+__all__ = ["Project", "User"]

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
 
-from sqlalchemy import DateTime, ForeignKey, Numeric, String
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Numeric, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -23,6 +23,9 @@ class Project(Base):
     """Project entity — see docs/DATA_MODEL.md for full specification."""
 
     __tablename__ = "projects"
+    __table_args__ = (
+        CheckConstraint("status IN ('active', 'archived')", name="ck_projects_status"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Numeric, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class ProjectStatus(str, enum.Enum):
+    """Project lifecycle status."""
+
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+
+
+class Project(Base):
+    """Project entity — see docs/DATA_MODEL.md for full specification."""
+
+    __tablename__ = "projects"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    color: Mapped[str] = mapped_column(String(7), nullable=False)
+    client_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    hourly_rate: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 2), nullable=True
+    )
+    status: Mapped[ProjectStatus] = mapped_column(
+        Enum(ProjectStatus, name="projectstatus"),
+        nullable=False,
+        default=ProjectStatus.ACTIVE,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    def __repr__(self) -> str:
+        return f"<Project(id={self.id}, name={self.name})>"

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.models.base import Base
 
 
-class ProjectStatus(str, enum.Enum):
+class ProjectStatus(enum.StrEnum):
     """Project lifecycle status."""
 
     ACTIVE = "active"
@@ -33,9 +33,7 @@ class Project(Base):
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     color: Mapped[str] = mapped_column(String(7), nullable=False)
     client_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
-    hourly_rate: Mapped[Decimal | None] = mapped_column(
-        Numeric(10, 2), nullable=True
-    )
+    hourly_rate: Mapped[Decimal | None] = mapped_column(Numeric(10, 2), nullable=True)
     status: Mapped[ProjectStatus] = mapped_column(
         Enum(ProjectStatus, name="projectstatus"),
         nullable=False,

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
 
-from sqlalchemy import DateTime, Enum, ForeignKey, Numeric, String
+from sqlalchemy import DateTime, ForeignKey, Numeric, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -34,8 +34,8 @@ class Project(Base):
     color: Mapped[str] = mapped_column(String(7), nullable=False)
     client_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     hourly_rate: Mapped[Decimal | None] = mapped_column(Numeric(10, 2), nullable=True)
-    status: Mapped[ProjectStatus] = mapped_column(
-        Enum(ProjectStatus, name="projectstatus"),
+    status: Mapped[str] = mapped_column(
+        String(20),
         nullable=False,
         default=ProjectStatus.ACTIVE,
     )

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -24,10 +24,16 @@ class ProjectCreate(BaseModel):
     @field_validator("color")
     @classmethod
     def validate_hex_color(cls, v: str) -> str:
-        """Color must be a valid hex color code (#RGB or #RRGGBB)."""
+        """Color must be a valid hex color code (#RGB or #RRGGBB).
+
+        Normalizes 3-char hex (#FFF) to 6-char (#FFFFFF) for consistency
+        with the String(7) DB column.
+        """
         if not _HEX_COLOR_RE.match(v):
             msg = "color must be a hex color code (e.g. #FF0000 or #FFF)"
             raise ValueError(msg)
+        if len(v) == 4:
+            v = "#" + "".join(c * 2 for c in v[1:])
         return v
 
 
@@ -43,10 +49,15 @@ class ProjectUpdate(BaseModel):
     @field_validator("color")
     @classmethod
     def validate_hex_color(cls, v: str | None) -> str | None:
-        """Color must be a valid hex color code if provided."""
+        """Color must be a valid hex color code if provided.
+
+        Normalizes 3-char hex (#FFF) to 6-char (#FFFFFF).
+        """
         if v is not None and not _HEX_COLOR_RE.match(v):
             msg = "color must be a hex color code (e.g. #FF0000 or #FFF)"
             raise ValueError(msg)
+        if v is not None and len(v) == 4:
+            v = "#" + "".join(c * 2 for c in v[1:])
         return v
 
     @field_validator("status")

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+_HEX_COLOR_RE = re.compile(r"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+
+
+class ProjectCreate(BaseModel):
+    """Schema for creating a new project."""
+
+    name: str
+    color: str
+    client_name: str | None = None
+    hourly_rate: Decimal | None = None
+
+    @field_validator("color")
+    @classmethod
+    def validate_hex_color(cls, v: str) -> str:
+        """Color must be a valid hex color code (#RGB or #RRGGBB)."""
+        if not _HEX_COLOR_RE.match(v):
+            msg = "color must be a hex color code (e.g. #FF0000 or #FFF)"
+            raise ValueError(msg)
+        return v
+
+
+class ProjectUpdate(BaseModel):
+    """Schema for partially updating a project."""
+
+    name: str | None = None
+    color: str | None = None
+    client_name: str | None = None
+    hourly_rate: Decimal | None = None
+    status: str | None = None
+
+    @field_validator("color")
+    @classmethod
+    def validate_hex_color(cls, v: str | None) -> str | None:
+        """Color must be a valid hex color code if provided."""
+        if v is not None and not _HEX_COLOR_RE.match(v):
+            msg = "color must be a hex color code (e.g. #FF0000 or #FFF)"
+            raise ValueError(msg)
+        return v
+
+
+class ProjectResponse(BaseModel):
+    """Public project representation."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    user_id: uuid.UUID
+    name: str
+    color: str
+    client_name: str | None
+    hourly_rate: Decimal | None
+    status: str
+    created_at: datetime

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.models.project import ProjectStatus
 
@@ -16,10 +16,20 @@ _VALID_STATUSES = {s.value for s in ProjectStatus}
 class ProjectCreate(BaseModel):
     """Schema for creating a new project."""
 
-    name: str
+    name: str = Field(min_length=1, max_length=100)
     color: str
     client_name: str | None = None
-    hourly_rate: Decimal | None = None
+    hourly_rate: Decimal | None = Field(default=None, ge=0)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name_not_blank(cls, v: str) -> str:
+        """Name must not be blank after stripping whitespace."""
+        v = v.strip()
+        if not v:
+            msg = "name must not be blank"
+            raise ValueError(msg)
+        return v
 
     @field_validator("color")
     @classmethod
@@ -40,11 +50,22 @@ class ProjectCreate(BaseModel):
 class ProjectUpdate(BaseModel):
     """Schema for partially updating a project."""
 
-    name: str | None = None
+    name: str | None = Field(default=None, min_length=1, max_length=100)
     color: str | None = None
     client_name: str | None = None
-    hourly_rate: Decimal | None = None
+    hourly_rate: Decimal | None = Field(default=None, ge=0)
     status: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name_not_blank(cls, v: str | None) -> str | None:
+        """Name must not be blank after stripping whitespace if provided."""
+        if v is not None:
+            v = v.strip()
+            if not v:
+                msg = "name must not be blank"
+                raise ValueError(msg)
+        return v
 
     @field_validator("color")
     @classmethod

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -18,7 +18,7 @@ class ProjectCreate(BaseModel):
 
     name: str = Field(min_length=1, max_length=100)
     color: str
-    client_name: str | None = None
+    client_name: str | None = Field(default=None, max_length=100)
     hourly_rate: Decimal | None = Field(default=None, ge=0)
 
     @field_validator("name")
@@ -52,7 +52,7 @@ class ProjectUpdate(BaseModel):
 
     name: str | None = Field(default=None, min_length=1, max_length=100)
     color: str | None = None
-    client_name: str | None = None
+    client_name: str | None = Field(default=None, max_length=100)
     hourly_rate: Decimal | None = Field(default=None, ge=0)
     status: str | None = None
 

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -7,7 +7,10 @@ from decimal import Decimal
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
+from app.models.project import ProjectStatus
+
 _HEX_COLOR_RE = re.compile(r"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+_VALID_STATUSES = {s.value for s in ProjectStatus}
 
 
 class ProjectCreate(BaseModel):
@@ -43,6 +46,15 @@ class ProjectUpdate(BaseModel):
         """Color must be a valid hex color code if provided."""
         if v is not None and not _HEX_COLOR_RE.match(v):
             msg = "color must be a hex color code (e.g. #FF0000 or #FFF)"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str | None) -> str | None:
+        """Status must be a valid ProjectStatus value if provided."""
+        if v is not None and v not in _VALID_STATUSES:
+            msg = f"status must be one of: {', '.join(sorted(_VALID_STATUSES))}"
             raise ValueError(msg)
         return v
 

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -61,9 +61,16 @@ async def get_project(
     return project
 
 
-async def list_projects(db: AsyncSession, user_id: uuid.UUID) -> list[Project]:
-    """List all projects for a given user."""
-    result = await db.execute(select(Project).where(Project.user_id == user_id))
+async def list_projects(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    skip: int = 0,
+    limit: int = 50,
+) -> list[Project]:
+    """List projects for a given user with pagination."""
+    stmt = select(Project).where(Project.user_id == user_id).offset(skip).limit(limit)
+    result = await db.execute(stmt)
     return list(result.scalars().all())
 
 

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project import Project
+from app.schemas.project import ProjectCreate, ProjectUpdate
+
+
+async def create_project(
+    db: AsyncSession, user_id: uuid.UUID, data: ProjectCreate
+) -> Project:
+    """Create a new project owned by user_id."""
+    project = Project(
+        user_id=user_id,
+        name=data.name,
+        color=data.color,
+        client_name=data.client_name,
+        hourly_rate=data.hourly_rate,
+    )
+    db.add(project)
+    await db.commit()
+    await db.refresh(project)
+    return project
+
+
+async def _get_project_or_404(
+    db: AsyncSession, project_id: uuid.UUID
+) -> Project:
+    """Fetch a project by ID or raise 404."""
+    result = await db.execute(
+        select(Project).where(Project.id == project_id)
+    )
+    project = result.scalar_one_or_none()
+    if project is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project not found",
+        )
+    return project
+
+
+def _check_ownership(project: Project, user_id: uuid.UUID) -> None:
+    """Raise 403 if the project does not belong to user_id."""
+    if project.user_id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access this project",
+        )
+
+
+async def get_project(
+    db: AsyncSession, project_id: uuid.UUID, user_id: uuid.UUID
+) -> Project:
+    """Get a single project, enforcing ownership."""
+    project = await _get_project_or_404(db, project_id)
+    _check_ownership(project, user_id)
+    return project
+
+
+async def list_projects(
+    db: AsyncSession, user_id: uuid.UUID
+) -> list[Project]:
+    """List all projects for a given user."""
+    result = await db.execute(
+        select(Project).where(Project.user_id == user_id)
+    )
+    return list(result.scalars().all())
+
+
+async def update_project(
+    db: AsyncSession,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    data: ProjectUpdate,
+) -> Project:
+    """Update a project, enforcing ownership. Only set provided fields."""
+    project = await _get_project_or_404(db, project_id)
+    _check_ownership(project, user_id)
+
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(project, field, value)
+
+    await db.commit()
+    await db.refresh(project)
+    return project
+
+
+async def delete_project(
+    db: AsyncSession, project_id: uuid.UUID, user_id: uuid.UUID
+) -> None:
+    """Delete a project, enforcing ownership."""
+    project = await _get_project_or_404(db, project_id)
+    _check_ownership(project, user_id)
+    await db.delete(project)
+    await db.commit()

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -40,11 +40,15 @@ async def _get_project_or_404(db: AsyncSession, project_id: uuid.UUID) -> Projec
 
 
 def _check_ownership(project: Project, user_id: uuid.UUID) -> None:
-    """Raise 403 if the project does not belong to user_id."""
+    """Raise 404 if the project does not belong to user_id.
+
+    Returns 404 (not 403) to avoid revealing that a project with this
+    ID exists but belongs to another user (prevents ID enumeration).
+    """
     if project.user_id != user_id:
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not authorized to access this project",
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project not found",
         )
 
 

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -27,13 +27,9 @@ async def create_project(
     return project
 
 
-async def _get_project_or_404(
-    db: AsyncSession, project_id: uuid.UUID
-) -> Project:
+async def _get_project_or_404(db: AsyncSession, project_id: uuid.UUID) -> Project:
     """Fetch a project by ID or raise 404."""
-    result = await db.execute(
-        select(Project).where(Project.id == project_id)
-    )
+    result = await db.execute(select(Project).where(Project.id == project_id))
     project = result.scalar_one_or_none()
     if project is None:
         raise HTTPException(
@@ -61,13 +57,9 @@ async def get_project(
     return project
 
 
-async def list_projects(
-    db: AsyncSession, user_id: uuid.UUID
-) -> list[Project]:
+async def list_projects(db: AsyncSession, user_id: uuid.UUID) -> list[Project]:
     """List all projects for a given user."""
-    result = await db.execute(
-        select(Project).where(Project.user_id == user_id)
-    )
+    result = await db.execute(select(Project).where(Project.user_id == user_id))
     return list(result.scalars().all())
 
 

--- a/backend/tests/unit/test_project_model.py
+++ b/backend/tests/unit/test_project_model.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import inspect
+
+from app.models.project import Project, ProjectStatus
+
+
+def test_project_table_name_is_projects() -> None:
+    """Project.__tablename__ must be 'projects'."""
+    assert Project.__tablename__ == "projects"
+
+
+def test_project_model_has_required_columns() -> None:
+    """Project model must have all columns defined in DATA_MODEL.md."""
+    columns = {c.name for c in inspect(Project).columns}
+    expected = {
+        "id",
+        "user_id",
+        "name",
+        "color",
+        "client_name",
+        "hourly_rate",
+        "status",
+        "created_at",
+    }
+    assert expected.issubset(columns), f"Missing columns: {expected - columns}"
+
+
+def test_project_id_is_uuid() -> None:
+    """Project.id column type must be UUID."""
+    col = inspect(Project).columns["id"]
+    assert "UUID" in str(col.type).upper()
+
+
+def test_project_user_id_is_foreign_key() -> None:
+    """Project.user_id must reference users.id."""
+    col = inspect(Project).columns["user_id"]
+    fk_targets = {fk.target_fullname for fk in col.foreign_keys}
+    assert "users.id" in fk_targets
+
+
+def test_project_user_id_not_nullable() -> None:
+    """Project.user_id must be NOT NULL."""
+    col = inspect(Project).columns["user_id"]
+    assert col.nullable is False
+
+
+def test_project_name_not_nullable() -> None:
+    """Project.name must be NOT NULL."""
+    col = inspect(Project).columns["name"]
+    assert col.nullable is False
+
+
+def test_project_color_not_nullable() -> None:
+    """Project.color must be NOT NULL."""
+    col = inspect(Project).columns["color"]
+    assert col.nullable is False
+
+
+def test_project_client_name_nullable() -> None:
+    """Project.client_name must be NULLABLE."""
+    col = inspect(Project).columns["client_name"]
+    assert col.nullable is True
+
+
+def test_project_hourly_rate_nullable() -> None:
+    """Project.hourly_rate must be NULLABLE."""
+    col = inspect(Project).columns["hourly_rate"]
+    assert col.nullable is True
+
+
+def test_project_status_has_default() -> None:
+    """Project.status column must have a default of ProjectStatus.ACTIVE."""
+    col = inspect(Project).columns["status"]
+    assert col.default is not None
+    assert col.default.arg == ProjectStatus.ACTIVE
+
+
+def test_project_status_enum_values() -> None:
+    """ProjectStatus enum must have active and archived values."""
+    assert ProjectStatus.ACTIVE.value == "active"
+    assert ProjectStatus.ARCHIVED.value == "archived"
+
+
+def test_project_repr_contains_name() -> None:
+    """Project.__repr__ should include the project name for debugging."""
+    p = Project(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        name="My Project",
+        color="#FF0000",
+    )
+    assert "My Project" in repr(p)

--- a/backend/tests/unit/test_project_model.py
+++ b/backend/tests/unit/test_project_model.py
@@ -84,6 +84,12 @@ def test_project_status_enum_values() -> None:
     assert ProjectStatus.ARCHIVED.value == "archived"
 
 
+def test_project_has_status_check_constraint() -> None:
+    """Project must have a CHECK constraint on status column."""
+    constraints = {c.name for c in Project.__table__.constraints}
+    assert "ck_projects_status" in constraints
+
+
 def test_project_repr_contains_name() -> None:
     """Project.__repr__ should include the project name for debugging."""
     p = Project(

--- a/backend/tests/unit/test_project_routes.py
+++ b/backend/tests/unit/test_project_routes.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.main import app
+from app.models.project import Project, ProjectStatus
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+OTHER_USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+PROJECT_ID = uuid.UUID("00000000-0000-0000-0000-aaaaaaaaaaaa")
+
+
+def _make_fake_user() -> MagicMock:
+    fake = MagicMock()
+    fake.id = USER_ID
+    fake.email = "test@example.com"
+    fake.name = "Test User"
+    return fake
+
+
+def _make_fake_project(**overrides: object) -> MagicMock:
+    defaults = {
+        "id": PROJECT_ID,
+        "user_id": USER_ID,
+        "name": "Test Project",
+        "color": "#FF0000",
+        "client_name": None,
+        "hourly_rate": None,
+        "status": ProjectStatus.ACTIVE,
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    fake = MagicMock(spec=Project)
+    for k, v in defaults.items():
+        setattr(fake, k, v)
+    return fake
+
+
+@pytest.fixture
+async def client() -> AsyncClient:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+def _override_auth() -> None:
+    app.dependency_overrides[get_current_user] = _make_fake_user
+
+
+def _override_db(mock_db: AsyncMock) -> None:
+    async def override() -> AsyncMock:  # type: ignore[misc]
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override
+
+
+def _clear_overrides() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /projects
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_project_returns_201(client: AsyncClient) -> None:
+    """POST /projects with valid data must return 201."""
+    fake = _make_fake_project()
+    _override_auth()
+    try:
+        with patch(
+            "app.api.projects.create_project", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = fake
+            response = await client.post(
+                "/projects",
+                json={"name": "Work", "color": "#00FF00"},
+            )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Test Project"
+    assert data["id"] == str(PROJECT_ID)
+
+
+@pytest.mark.asyncio
+async def test_create_project_returns_401_without_auth(
+    client: AsyncClient,
+) -> None:
+    """POST /projects without auth must return 401."""
+    response = await client.post(
+        "/projects", json={"name": "Work", "color": "#FF0000"}
+    )
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /projects
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_projects_returns_200(client: AsyncClient) -> None:
+    """GET /projects must return 200 with list of projects."""
+    fake1 = _make_fake_project(name="P1")
+    fake2 = _make_fake_project(name="P2")
+    _override_auth()
+    try:
+        with patch(
+            "app.api.projects.list_projects", new_callable=AsyncMock
+        ) as mock_list:
+            mock_list.return_value = [fake1, fake2]
+            response = await client.get("/projects")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+
+
+# ---------------------------------------------------------------------------
+# GET /projects/{project_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_project_returns_200(client: AsyncClient) -> None:
+    """GET /projects/{id} must return 200 for existing project."""
+    fake = _make_fake_project()
+    _override_auth()
+    try:
+        with patch(
+            "app.api.projects.get_project", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = fake
+            response = await client.get(f"/projects/{PROJECT_ID}")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    assert response.json()["id"] == str(PROJECT_ID)
+
+
+# ---------------------------------------------------------------------------
+# PATCH /projects/{project_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_project_returns_200(client: AsyncClient) -> None:
+    """PATCH /projects/{id} with valid data must return 200."""
+    fake = _make_fake_project(name="Updated")
+    _override_auth()
+    try:
+        with patch(
+            "app.api.projects.update_project", new_callable=AsyncMock
+        ) as mock_update:
+            mock_update.return_value = fake
+            response = await client.patch(
+                f"/projects/{PROJECT_ID}",
+                json={"name": "Updated"},
+            )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "Updated"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /projects/{project_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_project_returns_204(client: AsyncClient) -> None:
+    """DELETE /projects/{id} must return 204 No Content."""
+    _override_auth()
+    try:
+        with patch(
+            "app.api.projects.delete_project", new_callable=AsyncMock
+        ) as mock_delete:
+            mock_delete.return_value = None
+            response = await client.delete(f"/projects/{PROJECT_ID}")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_project_returns_401_without_auth(
+    client: AsyncClient,
+) -> None:
+    """DELETE /projects/{id} without auth must return 401."""
+    response = await client.delete(f"/projects/{PROJECT_ID}")
+    assert response.status_code == 401

--- a/backend/tests/unit/test_project_routes.py
+++ b/backend/tests/unit/test_project_routes.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
-from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -52,15 +51,14 @@ async def client() -> AsyncClient:
         yield ac
 
 
-def _override_auth() -> None:
+def _setup_overrides() -> None:
+    """Override auth and DB dependencies for route tests."""
     app.dependency_overrides[get_current_user] = _make_fake_user
 
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
 
-def _override_db(mock_db: AsyncMock) -> None:
-    async def override() -> AsyncMock:  # type: ignore[misc]
-        yield mock_db
-
-    app.dependency_overrides[get_db] = override
+    app.dependency_overrides[get_db] = override_db
 
 
 def _clear_overrides() -> None:
@@ -76,7 +74,7 @@ def _clear_overrides() -> None:
 async def test_create_project_returns_201(client: AsyncClient) -> None:
     """POST /projects with valid data must return 201."""
     fake = _make_fake_project()
-    _override_auth()
+    _setup_overrides()
     try:
         with patch(
             "app.api.projects.create_project", new_callable=AsyncMock
@@ -100,9 +98,17 @@ async def test_create_project_returns_401_without_auth(
     client: AsyncClient,
 ) -> None:
     """POST /projects without auth must return 401."""
-    response = await client.post(
-        "/projects", json={"name": "Work", "color": "#FF0000"}
-    )
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.post(
+            "/projects", json={"name": "Work", "color": "#FF0000"}
+        )
+    finally:
+        _clear_overrides()
     assert response.status_code == 401
 
 
@@ -116,7 +122,7 @@ async def test_list_projects_returns_200(client: AsyncClient) -> None:
     """GET /projects must return 200 with list of projects."""
     fake1 = _make_fake_project(name="P1")
     fake2 = _make_fake_project(name="P2")
-    _override_auth()
+    _setup_overrides()
     try:
         with patch(
             "app.api.projects.list_projects", new_callable=AsyncMock
@@ -140,11 +146,9 @@ async def test_list_projects_returns_200(client: AsyncClient) -> None:
 async def test_get_project_returns_200(client: AsyncClient) -> None:
     """GET /projects/{id} must return 200 for existing project."""
     fake = _make_fake_project()
-    _override_auth()
+    _setup_overrides()
     try:
-        with patch(
-            "app.api.projects.get_project", new_callable=AsyncMock
-        ) as mock_get:
+        with patch("app.api.projects.get_project", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = fake
             response = await client.get(f"/projects/{PROJECT_ID}")
     finally:
@@ -163,7 +167,7 @@ async def test_get_project_returns_200(client: AsyncClient) -> None:
 async def test_update_project_returns_200(client: AsyncClient) -> None:
     """PATCH /projects/{id} with valid data must return 200."""
     fake = _make_fake_project(name="Updated")
-    _override_auth()
+    _setup_overrides()
     try:
         with patch(
             "app.api.projects.update_project", new_callable=AsyncMock
@@ -188,7 +192,7 @@ async def test_update_project_returns_200(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_delete_project_returns_204(client: AsyncClient) -> None:
     """DELETE /projects/{id} must return 204 No Content."""
-    _override_auth()
+    _setup_overrides()
     try:
         with patch(
             "app.api.projects.delete_project", new_callable=AsyncMock
@@ -206,5 +210,13 @@ async def test_delete_project_returns_401_without_auth(
     client: AsyncClient,
 ) -> None:
     """DELETE /projects/{id} without auth must return 401."""
-    response = await client.delete(f"/projects/{PROJECT_ID}")
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.delete(f"/projects/{PROJECT_ID}")
+    finally:
+        _clear_overrides()
     assert response.status_code == 401

--- a/backend/tests/unit/test_project_schema.py
+++ b/backend/tests/unit/test_project_schema.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
+
+
+# ---------------------------------------------------------------------------
+# ProjectCreate
+# ---------------------------------------------------------------------------
+
+
+def test_create_requires_name_and_color() -> None:
+    """ProjectCreate must require name and color."""
+    p = ProjectCreate(name="Work", color="#FF0000")
+    assert p.name == "Work"
+    assert p.color == "#FF0000"
+
+
+def test_create_optional_fields_default_to_none() -> None:
+    """client_name and hourly_rate must default to None."""
+    p = ProjectCreate(name="Work", color="#FF0000")
+    assert p.client_name is None
+    assert p.hourly_rate is None
+
+
+def test_create_with_all_fields() -> None:
+    """ProjectCreate must accept all optional fields."""
+    p = ProjectCreate(
+        name="Work",
+        color="#00FF00",
+        client_name="Acme Corp",
+        hourly_rate=Decimal("150.00"),
+    )
+    assert p.client_name == "Acme Corp"
+    assert p.hourly_rate == Decimal("150.00")
+
+
+def test_create_rejects_missing_name() -> None:
+    """ProjectCreate without name must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        ProjectCreate(color="#FF0000")  # type: ignore[call-arg]
+
+
+def test_create_rejects_missing_color() -> None:
+    """ProjectCreate without color must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        ProjectCreate(name="Work")  # type: ignore[call-arg]
+
+
+def test_create_rejects_invalid_hex_color() -> None:
+    """ProjectCreate must reject non-hex color strings."""
+    with pytest.raises(ValidationError):
+        ProjectCreate(name="Work", color="red")
+
+
+def test_create_accepts_valid_hex_colors() -> None:
+    """ProjectCreate must accept 4-char and 7-char hex colors."""
+    p3 = ProjectCreate(name="A", color="#FFF")
+    assert p3.color == "#FFF"
+    p6 = ProjectCreate(name="B", color="#FF00FF")
+    assert p6.color == "#FF00FF"
+
+
+# ---------------------------------------------------------------------------
+# ProjectUpdate
+# ---------------------------------------------------------------------------
+
+
+def test_update_all_fields_optional() -> None:
+    """ProjectUpdate must allow empty (no fields set)."""
+    p = ProjectUpdate()
+    assert p.name is None
+    assert p.color is None
+    assert p.client_name is None
+    assert p.hourly_rate is None
+    assert p.status is None
+
+
+def test_update_partial_fields() -> None:
+    """ProjectUpdate must accept partial updates."""
+    p = ProjectUpdate(name="New Name")
+    assert p.name == "New Name"
+    assert p.color is None
+
+
+def test_update_rejects_invalid_hex_color() -> None:
+    """ProjectUpdate must reject non-hex color if provided."""
+    with pytest.raises(ValidationError):
+        ProjectUpdate(color="not-hex")
+
+
+# ---------------------------------------------------------------------------
+# ProjectResponse
+# ---------------------------------------------------------------------------
+
+
+def test_response_from_attributes() -> None:
+    """ProjectResponse must support from_attributes (ORM mode)."""
+    assert ProjectResponse.model_config.get("from_attributes") is True
+
+
+def test_response_round_trip() -> None:
+    """ProjectResponse must serialize all project fields."""
+    now = datetime.now(UTC)
+    uid = uuid.uuid4()
+    pid = uuid.uuid4()
+    resp = ProjectResponse(
+        id=pid,
+        user_id=uid,
+        name="Test",
+        color="#ABCDEF",
+        client_name="Client",
+        hourly_rate=Decimal("99.50"),
+        status="active",
+        created_at=now,
+    )
+    assert resp.id == pid
+    assert resp.user_id == uid
+    assert resp.status == "active"
+    assert resp.hourly_rate == Decimal("99.50")

--- a/backend/tests/unit/test_project_schema.py
+++ b/backend/tests/unit/test_project_schema.py
@@ -59,11 +59,17 @@ def test_create_rejects_invalid_hex_color() -> None:
 
 
 def test_create_accepts_valid_hex_colors() -> None:
-    """ProjectCreate must accept 4-char and 7-char hex colors."""
+    """ProjectCreate must accept and normalize hex colors."""
     p3 = ProjectCreate(name="A", color="#FFF")
-    assert p3.color == "#FFF"
+    assert p3.color == "#FFFFFF"  # 3-char normalized to 6-char
     p6 = ProjectCreate(name="B", color="#FF00FF")
     assert p6.color == "#FF00FF"
+
+
+def test_update_normalizes_short_hex_color() -> None:
+    """ProjectUpdate must normalize 3-char hex to 6-char."""
+    p = ProjectUpdate(color="#ABC")
+    assert p.color == "#AABBCC"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_project_schema.py
+++ b/backend/tests/unit/test_project_schema.py
@@ -40,6 +40,42 @@ def test_create_with_all_fields() -> None:
     assert p.hourly_rate == Decimal("150.00")
 
 
+def test_create_rejects_empty_name() -> None:
+    """ProjectCreate must reject empty string name."""
+    with pytest.raises(ValidationError):
+        ProjectCreate(name="", color="#FF0000")
+
+
+def test_create_rejects_blank_name() -> None:
+    """ProjectCreate must reject whitespace-only name."""
+    with pytest.raises(ValidationError):
+        ProjectCreate(name="   ", color="#FF0000")
+
+
+def test_create_rejects_name_too_long() -> None:
+    """ProjectCreate must reject name longer than 100 characters."""
+    with pytest.raises(ValidationError):
+        ProjectCreate(name="A" * 101, color="#FF0000")
+
+
+def test_create_strips_name_whitespace() -> None:
+    """ProjectCreate must strip leading/trailing whitespace from name."""
+    p = ProjectCreate(name="  Work  ", color="#FF0000")
+    assert p.name == "Work"
+
+
+def test_create_rejects_negative_hourly_rate() -> None:
+    """ProjectCreate must reject negative hourly_rate."""
+    with pytest.raises(ValidationError):
+        ProjectCreate(name="Work", color="#FF0000", hourly_rate=Decimal("-10.00"))
+
+
+def test_create_accepts_zero_hourly_rate() -> None:
+    """ProjectCreate must accept zero hourly_rate."""
+    p = ProjectCreate(name="Work", color="#FF0000", hourly_rate=Decimal("0"))
+    assert p.hourly_rate == Decimal("0")
+
+
 def test_create_rejects_missing_name() -> None:
     """ProjectCreate without name must raise ValidationError."""
     with pytest.raises(ValidationError):
@@ -92,6 +128,30 @@ def test_update_partial_fields() -> None:
     p = ProjectUpdate(name="New Name")
     assert p.name == "New Name"
     assert p.color is None
+
+
+def test_update_rejects_empty_name() -> None:
+    """ProjectUpdate must reject empty string name."""
+    with pytest.raises(ValidationError):
+        ProjectUpdate(name="")
+
+
+def test_update_rejects_blank_name() -> None:
+    """ProjectUpdate must reject whitespace-only name."""
+    with pytest.raises(ValidationError):
+        ProjectUpdate(name="   ")
+
+
+def test_update_rejects_name_too_long() -> None:
+    """ProjectUpdate must reject name longer than 100 characters."""
+    with pytest.raises(ValidationError):
+        ProjectUpdate(name="A" * 101)
+
+
+def test_update_rejects_negative_hourly_rate() -> None:
+    """ProjectUpdate must reject negative hourly_rate."""
+    with pytest.raises(ValidationError):
+        ProjectUpdate(hourly_rate=Decimal("-5.00"))
 
 
 def test_update_rejects_invalid_hex_color() -> None:

--- a/backend/tests/unit/test_project_schema.py
+++ b/backend/tests/unit/test_project_schema.py
@@ -40,6 +40,18 @@ def test_create_with_all_fields() -> None:
     assert p.hourly_rate == Decimal("150.00")
 
 
+def test_create_rejects_client_name_too_long() -> None:
+    """ProjectCreate must reject client_name longer than 100 characters."""
+    with pytest.raises(ValidationError):
+        ProjectCreate(name="Work", color="#FF0000", client_name="A" * 101)
+
+
+def test_update_rejects_client_name_too_long() -> None:
+    """ProjectUpdate must reject client_name longer than 100 characters."""
+    with pytest.raises(ValidationError):
+        ProjectUpdate(client_name="A" * 101)
+
+
 def test_create_rejects_empty_name() -> None:
     """ProjectCreate must reject empty string name."""
     with pytest.raises(ValidationError):

--- a/backend/tests/unit/test_project_schema.py
+++ b/backend/tests/unit/test_project_schema.py
@@ -94,6 +94,26 @@ def test_update_rejects_invalid_hex_color() -> None:
         ProjectUpdate(color="not-hex")
 
 
+def test_update_accepts_valid_status() -> None:
+    """ProjectUpdate must accept valid status values."""
+    p = ProjectUpdate(status="active")
+    assert p.status == "active"
+    p2 = ProjectUpdate(status="archived")
+    assert p2.status == "archived"
+
+
+def test_update_rejects_invalid_status() -> None:
+    """ProjectUpdate must reject invalid status values."""
+    with pytest.raises(ValidationError):
+        ProjectUpdate(status="deleted")
+
+
+def test_update_rejects_empty_string_status() -> None:
+    """ProjectUpdate must reject empty string as status."""
+    with pytest.raises(ValidationError):
+        ProjectUpdate(status="")
+
+
 # ---------------------------------------------------------------------------
 # ProjectResponse
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_project_schema.py
+++ b/backend/tests/unit/test_project_schema.py
@@ -9,7 +9,6 @@ from pydantic import ValidationError
 
 from app.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
 
-
 # ---------------------------------------------------------------------------
 # ProjectCreate
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_project_service.py
+++ b/backend/tests/unit/test_project_service.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.project import Project, ProjectStatus
+from app.schemas.project import ProjectCreate, ProjectUpdate
+from app.services.project_service import (
+    create_project,
+    delete_project,
+    get_project,
+    list_projects,
+    update_project,
+)
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+OTHER_USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+PROJECT_ID = uuid.UUID("00000000-0000-0000-0000-aaaaaaaaaaaa")
+
+
+def _make_fake_project(
+    project_id: uuid.UUID = PROJECT_ID,
+    user_id: uuid.UUID = USER_ID,
+    name: str = "Test Project",
+    color: str = "#FF0000",
+    status: ProjectStatus = ProjectStatus.ACTIVE,
+) -> MagicMock:
+    fake = MagicMock(spec=Project)
+    fake.id = project_id
+    fake.user_id = user_id
+    fake.name = name
+    fake.color = color
+    fake.client_name = None
+    fake.hourly_rate = None
+    fake.status = status
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# create_project
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_project_returns_project() -> None:
+    """create_project must add a project to the session and return it."""
+    db = AsyncMock()
+    data = ProjectCreate(name="Work", color="#00FF00")
+
+    result = await create_project(db=db, user_id=USER_ID, data=data)
+
+    assert isinstance(result, Project)
+    assert result.name == "Work"
+    assert result.color == "#00FF00"
+    assert result.user_id == USER_ID
+    db.add.assert_called_once()
+    db.commit.assert_awaited_once()
+    db.refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_project_with_optional_fields() -> None:
+    """create_project must set optional fields when provided."""
+    db = AsyncMock()
+    data = ProjectCreate(
+        name="Consulting",
+        color="#0000FF",
+        client_name="Acme",
+        hourly_rate=Decimal("200.00"),
+    )
+
+    result = await create_project(db=db, user_id=USER_ID, data=data)
+
+    assert result.client_name == "Acme"
+    assert result.hourly_rate == Decimal("200.00")
+
+
+# ---------------------------------------------------------------------------
+# get_project
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_project_returns_project_for_owner() -> None:
+    """get_project must return the project when user_id matches."""
+    fake = _make_fake_project()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    result = await get_project(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    assert result.id == PROJECT_ID
+
+
+@pytest.mark.asyncio
+async def test_get_project_raises_404_when_not_found() -> None:
+    """get_project must raise 404 when project does not exist."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_project(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_project_raises_403_for_wrong_user() -> None:
+    """get_project must raise 403 when user_id does not match."""
+    fake = _make_fake_project(user_id=OTHER_USER_ID)
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_project(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    assert exc_info.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# list_projects
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_projects_returns_user_projects() -> None:
+    """list_projects must return only projects for the given user."""
+    fake1 = _make_fake_project(name="P1")
+    fake2 = _make_fake_project(name="P2")
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [fake1, fake2]
+    db.execute.return_value = mock_result
+
+    result = await list_projects(db=db, user_id=USER_ID)
+
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_projects_returns_empty_list() -> None:
+    """list_projects must return empty list when user has no projects."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    result = await list_projects(db=db, user_id=USER_ID)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# update_project
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_project_applies_changes() -> None:
+    """update_project must apply only the provided fields."""
+    fake = _make_fake_project()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    data = ProjectUpdate(name="Updated Name")
+    result = await update_project(
+        db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data
+    )
+
+    assert result.name == "Updated Name"
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_project_raises_403_for_wrong_user() -> None:
+    """update_project must raise 403 when user_id does not match."""
+    fake = _make_fake_project(user_id=OTHER_USER_ID)
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_project(
+            db=db,
+            project_id=PROJECT_ID,
+            user_id=USER_ID,
+            data=ProjectUpdate(name="X"),
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_project_raises_404_when_not_found() -> None:
+    """update_project must raise 404 when project does not exist."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_project(
+            db=db,
+            project_id=PROJECT_ID,
+            user_id=USER_ID,
+            data=ProjectUpdate(name="X"),
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# delete_project
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_project_removes_project() -> None:
+    """delete_project must delete the project from the database."""
+    fake = _make_fake_project()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await delete_project(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    db.delete.assert_awaited_once_with(fake)
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_project_raises_403_for_wrong_user() -> None:
+    """delete_project must raise 403 when user_id does not match."""
+    fake = _make_fake_project(user_id=OTHER_USER_ID)
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await delete_project(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_project_raises_404_when_not_found() -> None:
+    """delete_project must raise 404 when project does not exist."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await delete_project(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    assert exc_info.value.status_code == 404

--- a/backend/tests/unit/test_project_service.py
+++ b/backend/tests/unit/test_project_service.py
@@ -233,9 +233,7 @@ async def test_update_project_only_sets_provided_fields() -> None:
 
     # Only update name — color, client_name, etc. should NOT be touched
     data = ProjectUpdate(name="NewName")
-    await update_project(
-        db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data
-    )
+    await update_project(db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data)
 
     # name was set, but color and client_name should remain unchanged
     assert fake.name == "NewName"

--- a/backend/tests/unit/test_project_service.py
+++ b/backend/tests/unit/test_project_service.py
@@ -99,6 +99,24 @@ async def test_get_project_returns_project_for_owner() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_project_queries_by_project_id() -> None:
+    """get_project must query WHERE id == project_id (not !=)."""
+    fake = _make_fake_project()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await get_project(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    # Verify the WHERE clause uses == (not !=)
+    executed_stmt = db.execute.call_args[0][0]
+    where_clause = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "projects.id =" in where_clause
+    assert "projects.id !=" not in where_clause
+
+
+@pytest.mark.asyncio
 async def test_get_project_raises_404_when_not_found() -> None:
     """get_project must raise 404 when project does not exist."""
     db = AsyncMock()
@@ -110,6 +128,7 @@ async def test_get_project_raises_404_when_not_found() -> None:
         await get_project(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
     assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Project not found"
 
 
 @pytest.mark.asyncio
@@ -125,6 +144,7 @@ async def test_get_project_raises_403_for_wrong_user() -> None:
         await get_project(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
     assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Not authorized to access this project"
 
 
 # ---------------------------------------------------------------------------
@@ -145,6 +165,22 @@ async def test_list_projects_returns_user_projects() -> None:
     result = await list_projects(db=db, user_id=USER_ID)
 
     assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_projects_queries_by_user_id() -> None:
+    """list_projects must query WHERE user_id == user_id (not !=)."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_projects(db=db, user_id=USER_ID)
+
+    executed_stmt = db.execute.call_args[0][0]
+    where_clause = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "projects.user_id =" in where_clause
+    assert "projects.user_id !=" not in where_clause
 
 
 @pytest.mark.asyncio
@@ -181,6 +217,30 @@ async def test_update_project_applies_changes() -> None:
 
     assert result.name == "Updated Name"
     db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_project_only_sets_provided_fields() -> None:
+    """update_project must use exclude_unset=True to skip unset fields."""
+    fake = _make_fake_project()
+    fake.name = "Original"
+    fake.color = "#FF0000"
+    fake.client_name = "OldClient"
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    # Only update name — color, client_name, etc. should NOT be touched
+    data = ProjectUpdate(name="NewName")
+    await update_project(
+        db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data
+    )
+
+    # name was set, but color and client_name should remain unchanged
+    assert fake.name == "NewName"
+    assert fake.color == "#FF0000"
+    assert fake.client_name == "OldClient"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_project_service.py
+++ b/backend/tests/unit/test_project_service.py
@@ -132,8 +132,8 @@ async def test_get_project_raises_404_when_not_found() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_project_raises_403_for_wrong_user() -> None:
-    """get_project must raise 403 when user_id does not match."""
+async def test_get_project_raises_404_for_wrong_user() -> None:
+    """get_project must raise 404 (not 403) to prevent ID enumeration."""
     fake = _make_fake_project(user_id=OTHER_USER_ID)
     db = AsyncMock()
     mock_result = MagicMock()
@@ -143,8 +143,8 @@ async def test_get_project_raises_403_for_wrong_user() -> None:
     with pytest.raises(HTTPException) as exc_info:
         await get_project(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
-    assert exc_info.value.status_code == 403
-    assert exc_info.value.detail == "Not authorized to access this project"
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Project not found"
 
 
 # ---------------------------------------------------------------------------
@@ -242,8 +242,8 @@ async def test_update_project_only_sets_provided_fields() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_project_raises_403_for_wrong_user() -> None:
-    """update_project must raise 403 when user_id does not match."""
+async def test_update_project_raises_404_for_wrong_user() -> None:
+    """update_project must raise 404 (not 403) to prevent ID enumeration."""
     fake = _make_fake_project(user_id=OTHER_USER_ID)
     db = AsyncMock()
     mock_result = MagicMock()
@@ -258,7 +258,8 @@ async def test_update_project_raises_403_for_wrong_user() -> None:
             data=ProjectUpdate(name="X"),
         )
 
-    assert exc_info.value.status_code == 403
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Project not found"
 
 
 @pytest.mark.asyncio
@@ -301,8 +302,8 @@ async def test_delete_project_removes_project() -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete_project_raises_403_for_wrong_user() -> None:
-    """delete_project must raise 403 when user_id does not match."""
+async def test_delete_project_raises_404_for_wrong_user() -> None:
+    """delete_project must raise 404 (not 403) to prevent ID enumeration."""
     fake = _make_fake_project(user_id=OTHER_USER_ID)
     db = AsyncMock()
     mock_result = MagicMock()
@@ -312,7 +313,8 @@ async def test_delete_project_raises_403_for_wrong_user() -> None:
     with pytest.raises(HTTPException) as exc_info:
         await delete_project(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
-    assert exc_info.value.status_code == 403
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Project not found"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_project_service.py
+++ b/backend/tests/unit/test_project_service.py
@@ -196,6 +196,22 @@ async def test_list_projects_returns_empty_list() -> None:
     assert result == []
 
 
+@pytest.mark.asyncio
+async def test_list_projects_applies_pagination() -> None:
+    """list_projects must apply offset and limit to the query."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_projects(db=db, user_id=USER_ID, skip=10, limit=5)
+
+    executed_stmt = db.execute.call_args[0][0]
+    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "LIMIT" in compiled.upper()
+    assert "OFFSET" in compiled.upper()
+
+
 # ---------------------------------------------------------------------------
 # update_project
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add Project SQLAlchemy model with UUID PK, FK to users, status enum (active/archived), check constraint, and all DATA_MODEL.md columns
- Add Pydantic v2 schemas (Create/Update/Response) with hex color validation & normalization, name length/blank checks, non-negative hourly_rate, and status validation
- Add async service layer with user-scoped CRUD, 404-based ownership enforcement (prevents ID enumeration), and paginated list
- Add REST routes: `POST /projects` (201), `GET /projects` (paginated), `GET /projects/{id}`, `PATCH /projects/{id}`, `DELETE /projects/{id}` (204) — all auth-gated
- Add Alembic migration `0003_add_projects_table`
- 65 unit tests across model, schema, service, and route layers
- 100% mutation score on service layer (14/14 mutants killed)

## Test plan
- [x] `pytest -x -q` — 65 tests pass
- [x] `ruff check . && ruff format .` — no lint issues
- [x] `mutmut run` — 100% mutation score on service layer
- [x] PR review (`/review-pr-v2`) — APPROVE, zero findings

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)