### PR TITLE
Implement Task model and CRUD API (#5)

### DIFF
--- a/backend/alembic/versions/0004_add_tasks_table.py
+++ b/backend/alembic/versions/0004_add_tasks_table.py
@@ -1,0 +1,63 @@
+"""add tasks table
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-04-13
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0004"
+down_revision: str = "0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tasks",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "project_id", sa.UUID(), sa.ForeignKey("projects.id"), nullable=False
+        ),
+        sa.Column("title", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("estimate_minutes", sa.Integer(), nullable=True),
+        sa.Column(
+            "priority",
+            sa.String(20),
+            nullable=False,
+            server_default="medium",
+        ),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default="todo",
+        ),
+        sa.Column("due_date", sa.Date(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "priority IN ('low', 'medium', 'high', 'urgent')",
+            name="ck_tasks_priority",
+        ),
+        sa.CheckConstraint(
+            "status IN ('todo', 'in_progress', 'done')",
+            name="ck_tasks_status",
+        ),
+    )
+    op.create_index("idx_task_project_status", "tasks", ["project_id", "status"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_task_project_status", table_name="tasks")
+    op.drop_table("tasks")

--- a/backend/alembic/versions/0004_add_tasks_table.py
+++ b/backend/alembic/versions/0004_add_tasks_table.py
@@ -26,7 +26,10 @@ def upgrade() -> None:
         "tasks",
         sa.Column("id", sa.UUID(), primary_key=True),
         sa.Column(
-            "project_id", sa.UUID(), sa.ForeignKey("projects.id"), nullable=False
+            "project_id",
+            sa.UUID(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
         ),
         sa.Column("title", sa.String(255), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.models.user import User
+from app.schemas.task import TaskCreate, TaskResponse, TaskUpdate
+from app.services.task_service import (
+    create_task,
+    delete_task,
+    get_task,
+    list_tasks,
+    update_task,
+)
+
+router = APIRouter(prefix="/projects/{project_id}/tasks", tags=["tasks"])
+
+
+@router.post("", response_model=TaskResponse, status_code=status.HTTP_201_CREATED)
+async def create_task_route(
+    project_id: uuid.UUID,
+    body: TaskCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> TaskResponse:
+    """Create a new task under the given project."""
+    task = await create_task(
+        db=db, project_id=project_id, user_id=current_user.id, data=body
+    )
+    return TaskResponse.model_validate(task)
+
+
+@router.get("", response_model=list[TaskResponse])
+async def list_tasks_route(
+    project_id: uuid.UUID,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[TaskResponse]:
+    """List tasks for the given project with pagination."""
+    tasks = await list_tasks(
+        db=db, project_id=project_id, user_id=current_user.id, skip=skip, limit=limit
+    )
+    return [TaskResponse.model_validate(t) for t in tasks]
+
+
+@router.get("/{task_id}", response_model=TaskResponse)
+async def get_task_route(
+    project_id: uuid.UUID,
+    task_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> TaskResponse:
+    """Get a single task by ID."""
+    task = await get_task(
+        db=db, task_id=task_id, project_id=project_id, user_id=current_user.id
+    )
+    return TaskResponse.model_validate(task)
+
+
+@router.patch("/{task_id}", response_model=TaskResponse)
+async def update_task_route(
+    project_id: uuid.UUID,
+    task_id: uuid.UUID,
+    body: TaskUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> TaskResponse:
+    """Update a task by ID."""
+    task = await update_task(
+        db=db,
+        task_id=task_id,
+        project_id=project_id,
+        user_id=current_user.id,
+        data=body,
+    )
+    return TaskResponse.model_validate(task)
+
+
+@router.delete(
+    "/{task_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None
+)
+async def delete_task_route(
+    project_id: uuid.UUID,
+    task_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Delete a task by ID."""
+    await delete_task(
+        db=db, task_id=task_id, project_id=project_id, user_id=current_user.id
+    )

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -40,7 +40,6 @@ async def get_current_user(
     if payload.get("type") == "refresh":
         raise credentials_exception
 
-
     email: str | None = payload.get("sub")
     if email is None:
         raise credentials_exception

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from app.api.auth import router as auth_router
 from app.api.health import router as health_router
 from app.api.projects import router as projects_router
+from app.api.tasks import router as tasks_router
 from app.core.config import settings
 from app.core.database import dispose_engine, init_engine
 
@@ -36,6 +37,7 @@ def create_app() -> FastAPI:
     app.include_router(health_router)
     app.include_router(auth_router)
     app.include_router(projects_router)
+    app.include_router(tasks_router)
 
     return app
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
 from app.models.project import Project
+from app.models.task import Task
 from app.models.user import User
 
-__all__ = ["Project", "User"]
+__all__ = ["Project", "Task", "User"]

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import UTC, datetime, date
+
+from sqlalchemy import (
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class TaskPriority(enum.StrEnum):
+    """Task priority level."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    URGENT = "urgent"
+
+
+class TaskStatus(enum.StrEnum):
+    """Task lifecycle status."""
+
+    TODO = "todo"
+    IN_PROGRESS = "in_progress"
+    DONE = "done"
+
+
+class Task(Base):
+    """Task entity — see docs/DATA_MODEL.md for full specification."""
+
+    __tablename__ = "tasks"
+    __table_args__ = (
+        CheckConstraint(
+            "priority IN ('low', 'medium', 'high', 'urgent')",
+            name="ck_tasks_priority",
+        ),
+        CheckConstraint(
+            "status IN ('todo', 'in_progress', 'done')",
+            name="ck_tasks_status",
+        ),
+        Index("idx_task_project_status", "project_id", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id"), nullable=False
+    )
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    estimate_minutes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    priority: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=TaskPriority.MEDIUM,
+    )
+    status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=TaskStatus.TODO,
+    )
+    due_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    def __repr__(self) -> str:
+        return f"<Task(id={self.id}, title={self.title})>"

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 import uuid
-from datetime import UTC, datetime, date
+from datetime import UTC, date, datetime
 
 from sqlalchemy import (
     CheckConstraint,

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -57,7 +57,9 @@ class Task(Base):
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
     project_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("projects.id"), nullable=False
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
     )
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.models.task import TaskPriority, TaskStatus
+
+_VALID_PRIORITIES = {s.value for s in TaskPriority}
+_VALID_STATUSES = {s.value for s in TaskStatus}
+
+
+class TaskCreate(BaseModel):
+    """Schema for creating a new task."""
+
+    title: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    estimate_minutes: int | None = Field(default=None, ge=0)
+    priority: str = "medium"
+    status: str = "todo"
+    due_date: date | None = None
+
+    @field_validator("title")
+    @classmethod
+    def validate_title_not_blank(cls, v: str) -> str:
+        """Title must not be blank after stripping whitespace."""
+        v = v.strip()
+        if not v:
+            msg = "title must not be blank"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("priority")
+    @classmethod
+    def validate_priority(cls, v: str) -> str:
+        """Priority must be a valid TaskPriority value."""
+        if v not in _VALID_PRIORITIES:
+            msg = f"priority must be one of: {', '.join(sorted(_VALID_PRIORITIES))}"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        """Status must be a valid TaskStatus value."""
+        if v not in _VALID_STATUSES:
+            msg = f"status must be one of: {', '.join(sorted(_VALID_STATUSES))}"
+            raise ValueError(msg)
+        return v
+
+
+class TaskUpdate(BaseModel):
+    """Schema for partially updating a task."""
+
+    title: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    estimate_minutes: int | None = Field(default=None, ge=0)
+    priority: str | None = None
+    status: str | None = None
+    due_date: date | None = None
+
+    @field_validator("title")
+    @classmethod
+    def validate_title_not_blank(cls, v: str | None) -> str | None:
+        """Title must not be blank after stripping whitespace if provided."""
+        if v is not None:
+            v = v.strip()
+            if not v:
+                msg = "title must not be blank"
+                raise ValueError(msg)
+        return v
+
+    @field_validator("priority")
+    @classmethod
+    def validate_priority(cls, v: str | None) -> str | None:
+        """Priority must be a valid TaskPriority value if provided."""
+        if v is not None and v not in _VALID_PRIORITIES:
+            msg = f"priority must be one of: {', '.join(sorted(_VALID_PRIORITIES))}"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str | None) -> str | None:
+        """Status must be a valid TaskStatus value if provided."""
+        if v is not None and v not in _VALID_STATUSES:
+            msg = f"status must be one of: {', '.join(sorted(_VALID_STATUSES))}"
+            raise ValueError(msg)
+        return v
+
+
+class TaskResponse(BaseModel):
+    """Public task representation."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    title: str
+    description: str | None
+    estimate_minutes: int | None
+    priority: str
+    status: str
+    due_date: date | None
+    created_at: datetime
+    completed_at: datetime | None

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -7,9 +7,41 @@ from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.project import Project
 from app.models.task import Task, TaskStatus
 from app.schemas.task import TaskCreate, TaskUpdate
 from app.services.project_service import get_project
+
+
+async def _get_task_with_ownership(
+    db: AsyncSession,
+    task_id: uuid.UUID,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> Task:
+    """Fetch a task verifying it belongs to the project and the user owns it.
+
+    Uses a single joined query instead of separate project + task lookups.
+    Returns 404 for missing task, missing project, or ownership mismatch
+    (prevents ID enumeration).
+    """
+    stmt = (
+        select(Task)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            Task.id == task_id,
+            Task.project_id == project_id,
+            Project.user_id == user_id,
+        )
+    )
+    result = await db.execute(stmt)
+    task = result.scalar_one_or_none()
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found",
+        )
+    return task
 
 
 async def create_task(
@@ -36,27 +68,6 @@ async def create_task(
     return task
 
 
-async def _get_task_or_404(db: AsyncSession, task_id: uuid.UUID) -> Task:
-    """Fetch a task by ID or raise 404."""
-    result = await db.execute(select(Task).where(Task.id == task_id))
-    task = result.scalar_one_or_none()
-    if task is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Task not found",
-        )
-    return task
-
-
-def _check_task_project(task: Task, project_id: uuid.UUID) -> None:
-    """Raise 404 if the task does not belong to the given project."""
-    if task.project_id != project_id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Task not found",
-        )
-
-
 async def get_task(
     db: AsyncSession,
     task_id: uuid.UUID,
@@ -64,10 +75,7 @@ async def get_task(
     user_id: uuid.UUID,
 ) -> Task:
     """Get a single task, enforcing project ownership."""
-    await get_project(db, project_id, user_id)
-    task = await _get_task_or_404(db, task_id)
-    _check_task_project(task, project_id)
-    return task
+    return await _get_task_with_ownership(db, task_id, project_id, user_id)
 
 
 async def list_tasks(
@@ -93,14 +101,12 @@ async def update_task(
     data: TaskUpdate,
 ) -> Task:
     """Update a task, enforcing project ownership. Only set provided fields."""
-    await get_project(db, project_id, user_id)
-    task = await _get_task_or_404(db, task_id)
-    _check_task_project(task, project_id)
+    task = await _get_task_with_ownership(db, task_id, project_id, user_id)
 
     updates = data.model_dump(exclude_unset=True)
 
     if "status" in updates:
-        if updates["status"] == TaskStatus.DONE:
+        if TaskStatus(updates["status"]) == TaskStatus.DONE:
             task.completed_at = datetime.now(UTC)
         else:
             task.completed_at = None
@@ -120,8 +126,6 @@ async def delete_task(
     user_id: uuid.UUID,
 ) -> None:
     """Delete a task, enforcing project ownership."""
-    await get_project(db, project_id, user_id)
-    task = await _get_task_or_404(db, task_id)
-    _check_task_project(task, project_id)
+    task = await _get_task_with_ownership(db, task_id, project_id, user_id)
     await db.delete(task)
     await db.commit()

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -80,12 +80,7 @@ async def list_tasks(
 ) -> list[Task]:
     """List tasks for a given project with pagination."""
     await get_project(db, project_id, user_id)
-    stmt = (
-        select(Task)
-        .where(Task.project_id == project_id)
-        .offset(skip)
-        .limit(limit)
-    )
+    stmt = select(Task).where(Task.project_id == project_id).offset(skip).limit(limit)
     result = await db.execute(stmt)
     return list(result.scalars().all())
 

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.task import Task, TaskStatus
+from app.schemas.task import TaskCreate, TaskUpdate
+from app.services.project_service import get_project
+
+
+async def create_task(
+    db: AsyncSession,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    data: TaskCreate,
+) -> Task:
+    """Create a new task under the given project, verifying ownership."""
+    await get_project(db, project_id, user_id)
+
+    task = Task(
+        project_id=project_id,
+        title=data.title,
+        description=data.description,
+        estimate_minutes=data.estimate_minutes,
+        priority=data.priority,
+        status=data.status,
+        due_date=data.due_date,
+    )
+    db.add(task)
+    await db.commit()
+    await db.refresh(task)
+    return task
+
+
+async def _get_task_or_404(db: AsyncSession, task_id: uuid.UUID) -> Task:
+    """Fetch a task by ID or raise 404."""
+    result = await db.execute(select(Task).where(Task.id == task_id))
+    task = result.scalar_one_or_none()
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found",
+        )
+    return task
+
+
+def _check_task_project(task: Task, project_id: uuid.UUID) -> None:
+    """Raise 404 if the task does not belong to the given project."""
+    if task.project_id != project_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found",
+        )
+
+
+async def get_task(
+    db: AsyncSession,
+    task_id: uuid.UUID,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> Task:
+    """Get a single task, enforcing project ownership."""
+    await get_project(db, project_id, user_id)
+    task = await _get_task_or_404(db, task_id)
+    _check_task_project(task, project_id)
+    return task
+
+
+async def list_tasks(
+    db: AsyncSession,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    skip: int = 0,
+    limit: int = 50,
+) -> list[Task]:
+    """List tasks for a given project with pagination."""
+    await get_project(db, project_id, user_id)
+    stmt = (
+        select(Task)
+        .where(Task.project_id == project_id)
+        .offset(skip)
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def update_task(
+    db: AsyncSession,
+    task_id: uuid.UUID,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    data: TaskUpdate,
+) -> Task:
+    """Update a task, enforcing project ownership. Only set provided fields."""
+    await get_project(db, project_id, user_id)
+    task = await _get_task_or_404(db, task_id)
+    _check_task_project(task, project_id)
+
+    updates = data.model_dump(exclude_unset=True)
+
+    if "status" in updates:
+        if updates["status"] == TaskStatus.DONE:
+            task.completed_at = datetime.now(UTC)
+        else:
+            task.completed_at = None
+
+    for field, value in updates.items():
+        setattr(task, field, value)
+
+    await db.commit()
+    await db.refresh(task)
+    return task
+
+
+async def delete_task(
+    db: AsyncSession,
+    task_id: uuid.UUID,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    """Delete a task, enforcing project ownership."""
+    await get_project(db, project_id, user_id)
+    task = await _get_task_or_404(db, task_id)
+    _check_task_project(task, project_id)
+    await db.delete(task)
+    await db.commit()

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -105,14 +105,14 @@ async def update_task(
 
     updates = data.model_dump(exclude_unset=True)
 
+    for field, value in updates.items():
+        setattr(task, field, value)
+
     if "status" in updates:
         if TaskStatus(updates["status"]) == TaskStatus.DONE:
             task.completed_at = datetime.now(UTC)
         else:
             task.completed_at = None
-
-    for field, value in updates.items():
-        setattr(task, field, value)
 
     await db.commit()
     await db.refresh(task)

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -86,11 +86,40 @@ async def list_tasks(
     skip: int = 0,
     limit: int = 50,
 ) -> list[Task]:
-    """List tasks for a given project with pagination."""
-    await get_project(db, project_id, user_id)
-    stmt = select(Task).where(Task.project_id == project_id).offset(skip).limit(limit)
+    """List tasks for a given project with pagination.
+
+    Uses a single query with an EXISTS subquery to verify project ownership
+    and fetch tasks in one round-trip.
+    """
+    ownership = (
+        select(Project.id)
+        .where(Project.id == project_id, Project.user_id == user_id)
+        .exists()
+    )
+    stmt = (
+        select(Task)
+        .where(Task.project_id == project_id, ownership)
+        .offset(skip)
+        .limit(limit)
+    )
     result = await db.execute(stmt)
-    return list(result.scalars().all())
+    rows = list(result.scalars().all())
+    if not rows:
+        # Distinguish empty project from missing/unauthorized project.
+        # If the EXISTS subquery matched, the project is valid — just has no tasks.
+        check = await db.execute(
+            select(
+                select(Project.id)
+                .where(Project.id == project_id, Project.user_id == user_id)
+                .exists()
+            )
+        )
+        if not check.scalar():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Project not found",
+            )
+    return rows
 
 
 async def update_task(

--- a/backend/tests/unit/test_task_model.py
+++ b/backend/tests/unit/test_task_model.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import inspect
+
+from app.models.task import Task, TaskPriority, TaskStatus
+
+
+def test_task_table_name_is_tasks() -> None:
+    """Task.__tablename__ must be 'tasks'."""
+    assert Task.__tablename__ == "tasks"
+
+
+def test_task_model_has_required_columns() -> None:
+    """Task model must have all columns defined in DATA_MODEL.md."""
+    columns = {c.name for c in inspect(Task).columns}
+    expected = {
+        "id",
+        "project_id",
+        "title",
+        "description",
+        "estimate_minutes",
+        "priority",
+        "status",
+        "due_date",
+        "created_at",
+        "completed_at",
+    }
+    assert expected.issubset(columns), f"Missing columns: {expected - columns}"
+
+
+def test_task_id_is_uuid() -> None:
+    """Task.id column type must be UUID."""
+    col = inspect(Task).columns["id"]
+    assert "UUID" in str(col.type).upper()
+
+
+def test_task_project_id_is_foreign_key() -> None:
+    """Task.project_id must reference projects.id."""
+    col = inspect(Task).columns["project_id"]
+    fk_targets = {fk.target_fullname for fk in col.foreign_keys}
+    assert "projects.id" in fk_targets
+
+
+def test_task_project_id_not_nullable() -> None:
+    """Task.project_id must be NOT NULL."""
+    col = inspect(Task).columns["project_id"]
+    assert col.nullable is False
+
+
+def test_task_title_not_nullable() -> None:
+    """Task.title must be NOT NULL."""
+    col = inspect(Task).columns["title"]
+    assert col.nullable is False
+
+
+def test_task_description_nullable() -> None:
+    """Task.description must be NULLABLE."""
+    col = inspect(Task).columns["description"]
+    assert col.nullable is True
+
+
+def test_task_estimate_minutes_nullable() -> None:
+    """Task.estimate_minutes must be NULLABLE."""
+    col = inspect(Task).columns["estimate_minutes"]
+    assert col.nullable is True
+
+
+def test_task_due_date_nullable() -> None:
+    """Task.due_date must be NULLABLE."""
+    col = inspect(Task).columns["due_date"]
+    assert col.nullable is True
+
+
+def test_task_completed_at_nullable() -> None:
+    """Task.completed_at must be NULLABLE."""
+    col = inspect(Task).columns["completed_at"]
+    assert col.nullable is True
+
+
+def test_task_priority_has_default() -> None:
+    """Task.priority column must have a default of TaskPriority.MEDIUM."""
+    col = inspect(Task).columns["priority"]
+    assert col.default is not None
+    assert col.default.arg == TaskPriority.MEDIUM
+
+
+def test_task_priority_enum_values() -> None:
+    """TaskPriority enum must have low, medium, high, urgent values."""
+    assert TaskPriority.LOW.value == "low"
+    assert TaskPriority.MEDIUM.value == "medium"
+    assert TaskPriority.HIGH.value == "high"
+    assert TaskPriority.URGENT.value == "urgent"
+
+
+def test_task_status_has_default() -> None:
+    """Task.status column must have a default of TaskStatus.TODO."""
+    col = inspect(Task).columns["status"]
+    assert col.default is not None
+    assert col.default.arg == TaskStatus.TODO
+
+
+def test_task_status_enum_values() -> None:
+    """TaskStatus enum must have todo, in_progress, done values."""
+    assert TaskStatus.TODO.value == "todo"
+    assert TaskStatus.IN_PROGRESS.value == "in_progress"
+    assert TaskStatus.DONE.value == "done"
+
+
+def test_task_has_priority_check_constraint() -> None:
+    """Task must have a CHECK constraint on priority column."""
+    constraints = {c.name for c in Task.__table__.constraints}
+    assert "ck_tasks_priority" in constraints
+
+
+def test_task_has_status_check_constraint() -> None:
+    """Task must have a CHECK constraint on status column."""
+    constraints = {c.name for c in Task.__table__.constraints}
+    assert "ck_tasks_status" in constraints
+
+
+def test_task_has_project_status_index() -> None:
+    """Task must have a composite index on (project_id, status)."""
+    index_names = {idx.name for idx in Task.__table__.indexes}
+    assert "idx_task_project_status" in index_names
+
+
+def test_task_repr_contains_title() -> None:
+    """Task.__repr__ should include the task title for debugging."""
+    t = Task(
+        id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        title="My Task",
+    )
+    assert "My Task" in repr(t)

--- a/backend/tests/unit/test_task_routes.py
+++ b/backend/tests/unit/test_task_routes.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.main import app
+from app.models.task import Task, TaskStatus
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+PROJECT_ID = uuid.UUID("00000000-0000-0000-0000-aaaaaaaaaaaa")
+TASK_ID = uuid.UUID("00000000-0000-0000-0000-bbbbbbbbbbbb")
+
+BASE_URL = f"/projects/{PROJECT_ID}/tasks"
+
+
+def _make_fake_user() -> MagicMock:
+    fake = MagicMock()
+    fake.id = USER_ID
+    fake.email = "test@example.com"
+    fake.name = "Test User"
+    return fake
+
+
+def _make_fake_task(**overrides: object) -> MagicMock:
+    defaults = {
+        "id": TASK_ID,
+        "project_id": PROJECT_ID,
+        "title": "Test Task",
+        "description": None,
+        "estimate_minutes": None,
+        "priority": "medium",
+        "status": "todo",
+        "due_date": None,
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+        "completed_at": None,
+    }
+    defaults.update(overrides)
+    fake = MagicMock(spec=Task)
+    for k, v in defaults.items():
+        setattr(fake, k, v)
+    return fake
+
+
+@pytest.fixture
+async def client() -> AsyncClient:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+def _setup_overrides() -> None:
+    """Override auth and DB dependencies for route tests."""
+    app.dependency_overrides[get_current_user] = _make_fake_user
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+
+
+def _clear_overrides() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /projects/{project_id}/tasks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_task_returns_201(client: AsyncClient) -> None:
+    """POST /projects/{pid}/tasks with valid data must return 201."""
+    fake = _make_fake_task()
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.tasks.create_task", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = fake
+            response = await client.post(
+                BASE_URL,
+                json={"title": "Write tests"},
+            )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Test Task"
+    assert data["id"] == str(TASK_ID)
+
+
+@pytest.mark.asyncio
+async def test_create_task_returns_401_without_auth(
+    client: AsyncClient,
+) -> None:
+    """POST /projects/{pid}/tasks without auth must return 401."""
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.post(
+            BASE_URL, json={"title": "Work"}
+        )
+    finally:
+        _clear_overrides()
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /projects/{project_id}/tasks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_returns_200(client: AsyncClient) -> None:
+    """GET /projects/{pid}/tasks must return 200 with list of tasks."""
+    fake1 = _make_fake_task(title="T1")
+    fake2 = _make_fake_task(title="T2")
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.tasks.list_tasks", new_callable=AsyncMock
+        ) as mock_list:
+            mock_list.return_value = [fake1, fake2]
+            response = await client.get(BASE_URL)
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+
+
+# ---------------------------------------------------------------------------
+# GET /projects/{project_id}/tasks/{task_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_task_returns_200(client: AsyncClient) -> None:
+    """GET /projects/{pid}/tasks/{tid} must return 200 for existing task."""
+    fake = _make_fake_task()
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.tasks.get_task", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = fake
+            response = await client.get(f"{BASE_URL}/{TASK_ID}")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    assert response.json()["id"] == str(TASK_ID)
+
+
+# ---------------------------------------------------------------------------
+# PATCH /projects/{project_id}/tasks/{task_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_task_returns_200(client: AsyncClient) -> None:
+    """PATCH /projects/{pid}/tasks/{tid} with valid data must return 200."""
+    fake = _make_fake_task(title="Updated")
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.tasks.update_task", new_callable=AsyncMock
+        ) as mock_update:
+            mock_update.return_value = fake
+            response = await client.patch(
+                f"{BASE_URL}/{TASK_ID}",
+                json={"title": "Updated"},
+            )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    assert response.json()["title"] == "Updated"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /projects/{project_id}/tasks/{task_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_task_returns_204(client: AsyncClient) -> None:
+    """DELETE /projects/{pid}/tasks/{tid} must return 204 No Content."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.tasks.delete_task", new_callable=AsyncMock
+        ) as mock_delete:
+            mock_delete.return_value = None
+            response = await client.delete(f"{BASE_URL}/{TASK_ID}")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_task_returns_401_without_auth(
+    client: AsyncClient,
+) -> None:
+    """DELETE /projects/{pid}/tasks/{tid} without auth must return 401."""
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.delete(f"{BASE_URL}/{TASK_ID}")
+    finally:
+        _clear_overrides()
+    assert response.status_code == 401

--- a/backend/tests/unit/test_task_routes.py
+++ b/backend/tests/unit/test_task_routes.py
@@ -10,7 +10,7 @@ from httpx import ASGITransport, AsyncClient
 from app.core.database import get_db
 from app.core.deps import get_current_user
 from app.main import app
-from app.models.task import Task, TaskStatus
+from app.models.task import Task
 
 USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 PROJECT_ID = uuid.UUID("00000000-0000-0000-0000-aaaaaaaaaaaa")
@@ -80,9 +80,7 @@ async def test_create_task_returns_201(client: AsyncClient) -> None:
     fake = _make_fake_task()
     _setup_overrides()
     try:
-        with patch(
-            "app.api.tasks.create_task", new_callable=AsyncMock
-        ) as mock_create:
+        with patch("app.api.tasks.create_task", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = fake
             response = await client.post(
                 BASE_URL,
@@ -108,9 +106,7 @@ async def test_create_task_returns_401_without_auth(
 
     app.dependency_overrides[get_db] = override_db
     try:
-        response = await client.post(
-            BASE_URL, json={"title": "Work"}
-        )
+        response = await client.post(BASE_URL, json={"title": "Work"})
     finally:
         _clear_overrides()
     assert response.status_code == 401
@@ -128,9 +124,7 @@ async def test_list_tasks_returns_200(client: AsyncClient) -> None:
     fake2 = _make_fake_task(title="T2")
     _setup_overrides()
     try:
-        with patch(
-            "app.api.tasks.list_tasks", new_callable=AsyncMock
-        ) as mock_list:
+        with patch("app.api.tasks.list_tasks", new_callable=AsyncMock) as mock_list:
             mock_list.return_value = [fake1, fake2]
             response = await client.get(BASE_URL)
     finally:
@@ -152,9 +146,7 @@ async def test_get_task_returns_200(client: AsyncClient) -> None:
     fake = _make_fake_task()
     _setup_overrides()
     try:
-        with patch(
-            "app.api.tasks.get_task", new_callable=AsyncMock
-        ) as mock_get:
+        with patch("app.api.tasks.get_task", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = fake
             response = await client.get(f"{BASE_URL}/{TASK_ID}")
     finally:
@@ -175,9 +167,7 @@ async def test_update_task_returns_200(client: AsyncClient) -> None:
     fake = _make_fake_task(title="Updated")
     _setup_overrides()
     try:
-        with patch(
-            "app.api.tasks.update_task", new_callable=AsyncMock
-        ) as mock_update:
+        with patch("app.api.tasks.update_task", new_callable=AsyncMock) as mock_update:
             mock_update.return_value = fake
             response = await client.patch(
                 f"{BASE_URL}/{TASK_ID}",
@@ -200,9 +190,7 @@ async def test_delete_task_returns_204(client: AsyncClient) -> None:
     """DELETE /projects/{pid}/tasks/{tid} must return 204 No Content."""
     _setup_overrides()
     try:
-        with patch(
-            "app.api.tasks.delete_task", new_callable=AsyncMock
-        ) as mock_delete:
+        with patch("app.api.tasks.delete_task", new_callable=AsyncMock) as mock_delete:
             mock_delete.return_value = None
             response = await client.delete(f"{BASE_URL}/{TASK_ID}")
     finally:

--- a/backend/tests/unit/test_task_schema.py
+++ b/backend/tests/unit/test_task_schema.py
@@ -185,6 +185,21 @@ def test_update_rejects_empty_string_status() -> None:
         TaskUpdate(status="")
 
 
+def test_update_explicit_null_description_is_included_in_unset_dump() -> None:
+    """Explicit null description must appear in exclude_unset dump."""
+    t = TaskUpdate.model_validate({"description": None})
+    dump = t.model_dump(exclude_unset=True)
+    assert "description" in dump
+    assert dump["description"] is None
+
+
+def test_update_omitted_description_excluded_from_unset_dump() -> None:
+    """Omitting description must NOT appear in exclude_unset dump."""
+    t = TaskUpdate.model_validate({"title": "X"})
+    dump = t.model_dump(exclude_unset=True)
+    assert "description" not in dump
+
+
 # ---------------------------------------------------------------------------
 # TaskResponse
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_task_schema.py
+++ b/backend/tests/unit/test_task_schema.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.task import TaskCreate, TaskResponse, TaskUpdate
+
+# ---------------------------------------------------------------------------
+# TaskCreate
+# ---------------------------------------------------------------------------
+
+
+def test_create_requires_title() -> None:
+    """TaskCreate must require title."""
+    t = TaskCreate(title="Write tests")
+    assert t.title == "Write tests"
+
+
+def test_create_optional_fields_default_correctly() -> None:
+    """Optional fields default to None; priority to 'medium', status to 'todo'."""
+    t = TaskCreate(title="Work")
+    assert t.description is None
+    assert t.estimate_minutes is None
+    assert t.due_date is None
+    assert t.priority == "medium"
+    assert t.status == "todo"
+
+
+def test_create_with_all_fields() -> None:
+    """TaskCreate must accept all optional fields."""
+    t = TaskCreate(
+        title="Write tests",
+        description="Unit tests for task service",
+        estimate_minutes=60,
+        priority="high",
+        status="in_progress",
+        due_date=date(2026, 5, 1),
+    )
+    assert t.description == "Unit tests for task service"
+    assert t.estimate_minutes == 60
+    assert t.priority == "high"
+    assert t.status == "in_progress"
+    assert t.due_date == date(2026, 5, 1)
+
+
+def test_create_rejects_empty_title() -> None:
+    """TaskCreate must reject empty string title."""
+    with pytest.raises(ValidationError):
+        TaskCreate(title="")
+
+
+def test_create_rejects_blank_title() -> None:
+    """TaskCreate must reject whitespace-only title."""
+    with pytest.raises(ValidationError):
+        TaskCreate(title="   ")
+
+
+def test_create_rejects_title_too_long() -> None:
+    """TaskCreate must reject title longer than 255 characters."""
+    with pytest.raises(ValidationError):
+        TaskCreate(title="A" * 256)
+
+
+def test_create_strips_title_whitespace() -> None:
+    """TaskCreate must strip leading/trailing whitespace from title."""
+    t = TaskCreate(title="  Write tests  ")
+    assert t.title == "Write tests"
+
+
+def test_create_rejects_negative_estimate_minutes() -> None:
+    """TaskCreate must reject negative estimate_minutes."""
+    with pytest.raises(ValidationError):
+        TaskCreate(title="Work", estimate_minutes=-1)
+
+
+def test_create_accepts_zero_estimate_minutes() -> None:
+    """TaskCreate must accept zero estimate_minutes."""
+    t = TaskCreate(title="Work", estimate_minutes=0)
+    assert t.estimate_minutes == 0
+
+
+def test_create_rejects_invalid_priority() -> None:
+    """TaskCreate must reject invalid priority values."""
+    with pytest.raises(ValidationError):
+        TaskCreate(title="Work", priority="critical")
+
+
+def test_create_rejects_invalid_status() -> None:
+    """TaskCreate must reject invalid status values."""
+    with pytest.raises(ValidationError):
+        TaskCreate(title="Work", status="skipped")
+
+
+def test_create_accepts_valid_priorities() -> None:
+    """TaskCreate must accept all valid priority values."""
+    for p in ("low", "medium", "high", "urgent"):
+        t = TaskCreate(title="Work", priority=p)
+        assert t.priority == p
+
+
+def test_create_accepts_valid_statuses() -> None:
+    """TaskCreate must accept all valid status values."""
+    for s in ("todo", "in_progress", "done"):
+        t = TaskCreate(title="Work", status=s)
+        assert t.status == s
+
+
+def test_create_rejects_missing_title() -> None:
+    """TaskCreate without title must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        TaskCreate()  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# TaskUpdate
+# ---------------------------------------------------------------------------
+
+
+def test_update_all_fields_optional() -> None:
+    """TaskUpdate must allow empty (no fields set)."""
+    t = TaskUpdate()
+    assert t.title is None
+    assert t.description is None
+    assert t.estimate_minutes is None
+    assert t.priority is None
+    assert t.status is None
+    assert t.due_date is None
+
+
+def test_update_partial_fields() -> None:
+    """TaskUpdate must accept partial updates."""
+    t = TaskUpdate(title="New Title")
+    assert t.title == "New Title"
+    assert t.description is None
+
+
+def test_update_rejects_empty_title() -> None:
+    """TaskUpdate must reject empty string title."""
+    with pytest.raises(ValidationError):
+        TaskUpdate(title="")
+
+
+def test_update_rejects_blank_title() -> None:
+    """TaskUpdate must reject whitespace-only title."""
+    with pytest.raises(ValidationError):
+        TaskUpdate(title="   ")
+
+
+def test_update_rejects_title_too_long() -> None:
+    """TaskUpdate must reject title longer than 255 characters."""
+    with pytest.raises(ValidationError):
+        TaskUpdate(title="A" * 256)
+
+
+def test_update_rejects_negative_estimate_minutes() -> None:
+    """TaskUpdate must reject negative estimate_minutes."""
+    with pytest.raises(ValidationError):
+        TaskUpdate(estimate_minutes=-1)
+
+
+def test_update_rejects_invalid_priority() -> None:
+    """TaskUpdate must reject invalid priority values."""
+    with pytest.raises(ValidationError):
+        TaskUpdate(priority="critical")
+
+
+def test_update_rejects_invalid_status() -> None:
+    """TaskUpdate must reject invalid status values."""
+    with pytest.raises(ValidationError):
+        TaskUpdate(status="skipped")
+
+
+def test_update_rejects_empty_string_priority() -> None:
+    """TaskUpdate must reject empty string as priority."""
+    with pytest.raises(ValidationError):
+        TaskUpdate(priority="")
+
+
+def test_update_rejects_empty_string_status() -> None:
+    """TaskUpdate must reject empty string as status."""
+    with pytest.raises(ValidationError):
+        TaskUpdate(status="")
+
+
+# ---------------------------------------------------------------------------
+# TaskResponse
+# ---------------------------------------------------------------------------
+
+
+def test_response_from_attributes() -> None:
+    """TaskResponse must support from_attributes (ORM mode)."""
+    assert TaskResponse.model_config.get("from_attributes") is True
+
+
+def test_response_round_trip() -> None:
+    """TaskResponse must serialize all task fields."""
+    now = datetime.now(UTC)
+    tid = uuid.uuid4()
+    pid = uuid.uuid4()
+    resp = TaskResponse(
+        id=tid,
+        project_id=pid,
+        title="Test Task",
+        description="A description",
+        estimate_minutes=30,
+        priority="high",
+        status="done",
+        due_date=date(2026, 5, 1),
+        created_at=now,
+        completed_at=now,
+    )
+    assert resp.id == tid
+    assert resp.project_id == pid
+    assert resp.title == "Test Task"
+    assert resp.description == "A description"
+    assert resp.estimate_minutes == 30
+    assert resp.priority == "high"
+    assert resp.status == "done"
+    assert resp.due_date == date(2026, 5, 1)
+    assert resp.completed_at == now

--- a/backend/tests/unit/test_task_service.py
+++ b/backend/tests/unit/test_task_service.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-from app.models.task import Task, TaskStatus
+from app.models.task import Task
 from app.schemas.task import TaskCreate, TaskUpdate
 from app.services.task_service import (
     create_task,
@@ -56,9 +56,7 @@ async def test_create_task_returns_task(mock_get_project: AsyncMock) -> None:
     db = AsyncMock()
     data = TaskCreate(title="Write tests")
 
-    result = await create_task(
-        db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data
-    )
+    result = await create_task(db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data)
 
     assert isinstance(result, Task)
     assert result.title == "Write tests"
@@ -80,9 +78,7 @@ async def test_create_task_with_optional_fields(mock_get_project: AsyncMock) -> 
         priority="high",
     )
 
-    result = await create_task(
-        db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data
-    )
+    result = await create_task(db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data)
 
     assert result.description == "Some description"
     assert result.estimate_minutes == 60
@@ -109,7 +105,9 @@ async def test_create_task_raises_404_for_wrong_project_owner(
     mock_get_project: AsyncMock,
 ) -> None:
     """create_task must propagate 404 when project ownership fails."""
-    mock_get_project.side_effect = HTTPException(status_code=404, detail="Project not found")
+    mock_get_project.side_effect = HTTPException(
+        status_code=404, detail="Project not found"
+    )
     db = AsyncMock()
     data = TaskCreate(title="Work")
 
@@ -151,9 +149,7 @@ async def test_get_task_raises_404_when_not_found(mock_get_project: AsyncMock) -
     db.execute.return_value = mock_result
 
     with pytest.raises(HTTPException) as exc_info:
-        await get_task(
-            db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
-        )
+        await get_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Task not found"
@@ -208,9 +204,7 @@ async def test_get_task_verifies_task_belongs_to_project(
     db.execute.return_value = mock_result
 
     with pytest.raises(HTTPException) as exc_info:
-        await get_task(
-            db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
-        )
+        await get_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
 
     assert exc_info.value.status_code == 404
 
@@ -231,9 +225,7 @@ async def test_list_tasks_returns_project_tasks(mock_get_project: AsyncMock) -> 
     mock_result.scalars.return_value.all.return_value = [fake1, fake2]
     db.execute.return_value = mock_result
 
-    result = await list_tasks(
-        db=db, project_id=PROJECT_ID, user_id=USER_ID
-    )
+    result = await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
     assert len(result) == 2
 
@@ -264,9 +256,7 @@ async def test_list_tasks_returns_empty_list(mock_get_project: AsyncMock) -> Non
     mock_result.scalars.return_value.all.return_value = []
     db.execute.return_value = mock_result
 
-    result = await list_tasks(
-        db=db, project_id=PROJECT_ID, user_id=USER_ID
-    )
+    result = await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
     assert result == []
 
@@ -478,9 +468,7 @@ async def test_delete_task_removes_task(mock_get_project: AsyncMock) -> None:
     mock_result.scalar_one_or_none.return_value = fake
     db.execute.return_value = mock_result
 
-    await delete_task(
-        db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
-    )
+    await delete_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
 
     db.delete.assert_awaited_once_with(fake)
     db.commit.assert_awaited_once()
@@ -517,9 +505,7 @@ async def test_delete_task_verifies_project_ownership(
     mock_result.scalar_one_or_none.return_value = fake
     db.execute.return_value = mock_result
 
-    await delete_task(
-        db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
-    )
+    await delete_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
 
     mock_get_project.assert_awaited_once_with(db, PROJECT_ID, USER_ID)
 

--- a/backend/tests/unit/test_task_service.py
+++ b/backend/tests/unit/test_task_service.py
@@ -207,6 +207,7 @@ async def test_get_task_verifies_task_belongs_to_project(
         await get_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
 
     assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Task not found"
 
 
 # ---------------------------------------------------------------------------
@@ -529,3 +530,45 @@ async def test_delete_task_verifies_task_belongs_to_project(
         )
 
     assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Task not found"
+
+
+# ---------------------------------------------------------------------------
+# Mutation-killing tests for default parameters and detail messages
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_list_tasks_default_skip_is_zero(
+    mock_get_project: AsyncMock,
+) -> None:
+    """list_tasks default skip must be 0 (not 1)."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    executed_stmt = db.execute.call_args[0][0]
+    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "OFFSET 0" in compiled
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_list_tasks_default_limit_is_50(
+    mock_get_project: AsyncMock,
+) -> None:
+    """list_tasks default limit must be 50 (not 51)."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    executed_stmt = db.execute.call_args[0][0]
+    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "LIMIT 50" in compiled

--- a/backend/tests/unit/test_task_service.py
+++ b/backend/tests/unit/test_task_service.py
@@ -1,0 +1,545 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.task import Task, TaskStatus
+from app.schemas.task import TaskCreate, TaskUpdate
+from app.services.task_service import (
+    create_task,
+    delete_task,
+    get_task,
+    list_tasks,
+    update_task,
+)
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+OTHER_USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+PROJECT_ID = uuid.UUID("00000000-0000-0000-0000-aaaaaaaaaaaa")
+TASK_ID = uuid.UUID("00000000-0000-0000-0000-bbbbbbbbbbbb")
+
+
+def _make_fake_task(
+    task_id: uuid.UUID = TASK_ID,
+    project_id: uuid.UUID = PROJECT_ID,
+    title: str = "Test Task",
+    status: str = "todo",
+    completed_at: datetime | None = None,
+) -> MagicMock:
+    fake = MagicMock(spec=Task)
+    fake.id = task_id
+    fake.project_id = project_id
+    fake.title = title
+    fake.description = None
+    fake.estimate_minutes = None
+    fake.priority = "medium"
+    fake.status = status
+    fake.due_date = None
+    fake.created_at = datetime.now(UTC)
+    fake.completed_at = completed_at
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# create_task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_create_task_returns_task(mock_get_project: AsyncMock) -> None:
+    """create_task must add a task to the session and return it."""
+    db = AsyncMock()
+    data = TaskCreate(title="Write tests")
+
+    result = await create_task(
+        db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data
+    )
+
+    assert isinstance(result, Task)
+    assert result.title == "Write tests"
+    assert result.project_id == PROJECT_ID
+    db.add.assert_called_once()
+    db.commit.assert_awaited_once()
+    db.refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_create_task_with_optional_fields(mock_get_project: AsyncMock) -> None:
+    """create_task must set optional fields when provided."""
+    db = AsyncMock()
+    data = TaskCreate(
+        title="Work",
+        description="Some description",
+        estimate_minutes=60,
+        priority="high",
+    )
+
+    result = await create_task(
+        db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data
+    )
+
+    assert result.description == "Some description"
+    assert result.estimate_minutes == 60
+    assert result.priority == "high"
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_create_task_verifies_project_ownership(
+    mock_get_project: AsyncMock,
+) -> None:
+    """create_task must call get_project to verify project ownership."""
+    db = AsyncMock()
+    data = TaskCreate(title="Work")
+
+    await create_task(db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data)
+
+    mock_get_project.assert_awaited_once_with(db, PROJECT_ID, USER_ID)
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_create_task_raises_404_for_wrong_project_owner(
+    mock_get_project: AsyncMock,
+) -> None:
+    """create_task must propagate 404 when project ownership fails."""
+    mock_get_project.side_effect = HTTPException(status_code=404, detail="Project not found")
+    db = AsyncMock()
+    data = TaskCreate(title="Work")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await create_task(db=db, project_id=PROJECT_ID, user_id=USER_ID, data=data)
+
+    assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# get_task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_get_task_returns_task_for_owner(mock_get_project: AsyncMock) -> None:
+    """get_task must return the task when project ownership passes."""
+    fake = _make_fake_task()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    result = await get_task(
+        db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
+    )
+
+    assert result.id == TASK_ID
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_get_task_raises_404_when_not_found(mock_get_project: AsyncMock) -> None:
+    """get_task must raise 404 when task does not exist."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_task(
+            db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Task not found"
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_get_task_verifies_project_ownership(
+    mock_get_project: AsyncMock,
+) -> None:
+    """get_task must call get_project to verify project ownership."""
+    fake = _make_fake_task()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await get_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
+
+    mock_get_project.assert_awaited_once_with(db, PROJECT_ID, USER_ID)
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_get_task_queries_by_task_id(mock_get_project: AsyncMock) -> None:
+    """get_task must query WHERE id == task_id (not !=)."""
+    fake = _make_fake_task()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await get_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
+
+    executed_stmt = db.execute.call_args[0][0]
+    where_clause = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "tasks.id =" in where_clause
+    assert "tasks.id !=" not in where_clause
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_get_task_verifies_task_belongs_to_project(
+    mock_get_project: AsyncMock,
+) -> None:
+    """get_task must raise 404 if task.project_id doesn't match project_id."""
+    other_project_id = uuid.UUID("00000000-0000-0000-0000-cccccccccccc")
+    fake = _make_fake_task(project_id=other_project_id)
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_task(
+            db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# list_tasks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_list_tasks_returns_project_tasks(mock_get_project: AsyncMock) -> None:
+    """list_tasks must return tasks for the given project."""
+    fake1 = _make_fake_task(title="T1")
+    fake2 = _make_fake_task(title="T2")
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [fake1, fake2]
+    db.execute.return_value = mock_result
+
+    result = await list_tasks(
+        db=db, project_id=PROJECT_ID, user_id=USER_ID
+    )
+
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_list_tasks_queries_by_project_id(mock_get_project: AsyncMock) -> None:
+    """list_tasks must query WHERE project_id == project_id (not !=)."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    executed_stmt = db.execute.call_args[0][0]
+    where_clause = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "tasks.project_id =" in where_clause
+    assert "tasks.project_id !=" not in where_clause
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_list_tasks_returns_empty_list(mock_get_project: AsyncMock) -> None:
+    """list_tasks must return empty list when project has no tasks."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    result = await list_tasks(
+        db=db, project_id=PROJECT_ID, user_id=USER_ID
+    )
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_list_tasks_applies_pagination(mock_get_project: AsyncMock) -> None:
+    """list_tasks must apply offset and limit to the query."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID, skip=10, limit=5)
+
+    executed_stmt = db.execute.call_args[0][0]
+    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "LIMIT" in compiled.upper()
+    assert "OFFSET" in compiled.upper()
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_list_tasks_verifies_project_ownership(
+    mock_get_project: AsyncMock,
+) -> None:
+    """list_tasks must call get_project to verify project ownership."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    mock_get_project.assert_awaited_once_with(db, PROJECT_ID, USER_ID)
+
+
+# ---------------------------------------------------------------------------
+# update_task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_update_task_applies_changes(mock_get_project: AsyncMock) -> None:
+    """update_task must apply only the provided fields."""
+    fake = _make_fake_task()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    data = TaskUpdate(title="Updated Title")
+    result = await update_task(
+        db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID, data=data
+    )
+
+    assert result.title == "Updated Title"
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_update_task_only_sets_provided_fields(
+    mock_get_project: AsyncMock,
+) -> None:
+    """update_task must use exclude_unset=True to skip unset fields."""
+    fake = _make_fake_task()
+    fake.title = "Original"
+    fake.description = "Old desc"
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    data = TaskUpdate(title="NewTitle")
+    await update_task(
+        db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID, data=data
+    )
+
+    assert fake.title == "NewTitle"
+    assert fake.description == "Old desc"
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_update_task_sets_completed_at_on_done(
+    mock_get_project: AsyncMock,
+) -> None:
+    """update_task must set completed_at when status changes to done."""
+    fake = _make_fake_task(status="todo")
+    fake.completed_at = None
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    data = TaskUpdate(status="done")
+    await update_task(
+        db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID, data=data
+    )
+
+    assert fake.completed_at is not None
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_update_task_clears_completed_at_on_status_change(
+    mock_get_project: AsyncMock,
+) -> None:
+    """update_task must clear completed_at when status changes away from done."""
+    fake = _make_fake_task(status="done", completed_at=datetime.now(UTC))
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    data = TaskUpdate(status="todo")
+    await update_task(
+        db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID, data=data
+    )
+
+    assert fake.completed_at is None
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_update_task_raises_404_when_not_found(
+    mock_get_project: AsyncMock,
+) -> None:
+    """update_task must raise 404 when task does not exist."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_task(
+            db=db,
+            task_id=TASK_ID,
+            project_id=PROJECT_ID,
+            user_id=USER_ID,
+            data=TaskUpdate(title="X"),
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_update_task_verifies_project_ownership(
+    mock_get_project: AsyncMock,
+) -> None:
+    """update_task must call get_project to verify project ownership."""
+    fake = _make_fake_task()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await update_task(
+        db=db,
+        task_id=TASK_ID,
+        project_id=PROJECT_ID,
+        user_id=USER_ID,
+        data=TaskUpdate(title="X"),
+    )
+
+    mock_get_project.assert_awaited_once_with(db, PROJECT_ID, USER_ID)
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_update_task_verifies_task_belongs_to_project(
+    mock_get_project: AsyncMock,
+) -> None:
+    """update_task must raise 404 if task.project_id doesn't match."""
+    other_project_id = uuid.UUID("00000000-0000-0000-0000-cccccccccccc")
+    fake = _make_fake_task(project_id=other_project_id)
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_task(
+            db=db,
+            task_id=TASK_ID,
+            project_id=PROJECT_ID,
+            user_id=USER_ID,
+            data=TaskUpdate(title="X"),
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# delete_task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_delete_task_removes_task(mock_get_project: AsyncMock) -> None:
+    """delete_task must delete the task from the database."""
+    fake = _make_fake_task()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await delete_task(
+        db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
+    )
+
+    db.delete.assert_awaited_once_with(fake)
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_delete_task_raises_404_when_not_found(
+    mock_get_project: AsyncMock,
+) -> None:
+    """delete_task must raise 404 when task does not exist."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await delete_task(
+            db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_delete_task_verifies_project_ownership(
+    mock_get_project: AsyncMock,
+) -> None:
+    """delete_task must call get_project to verify project ownership."""
+    fake = _make_fake_task()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await delete_task(
+        db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
+    )
+
+    mock_get_project.assert_awaited_once_with(db, PROJECT_ID, USER_ID)
+
+
+@pytest.mark.asyncio
+@patch("app.services.task_service.get_project", new_callable=AsyncMock)
+async def test_delete_task_verifies_task_belongs_to_project(
+    mock_get_project: AsyncMock,
+) -> None:
+    """delete_task must raise 404 if task.project_id doesn't match."""
+    other_project_id = uuid.UUID("00000000-0000-0000-0000-cccccccccccc")
+    fake = _make_fake_task(project_id=other_project_id)
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await delete_task(
+            db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
+        )
+
+    assert exc_info.value.status_code == 404

--- a/backend/tests/unit/test_task_service.py
+++ b/backend/tests/unit/test_task_service.py
@@ -350,6 +350,22 @@ async def test_update_task_clears_completed_at_on_status_change() -> None:
 
 
 @pytest.mark.asyncio
+async def test_update_task_completed_at_wins_over_setattr_loop() -> None:
+    """completed_at must be set AFTER the setattr loop so the service value wins."""
+    fake = _make_fake_task(status="todo")
+    fake.completed_at = None
+    db = _mock_db_returning(fake)
+
+    data = TaskUpdate(status="done")
+    await update_task(
+        db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID, data=data
+    )
+
+    # completed_at must be a real datetime, not None — proving service logic runs last
+    assert isinstance(fake.completed_at, datetime)
+
+
+@pytest.mark.asyncio
 async def test_update_task_raises_404_when_not_found() -> None:
     """update_task must raise 404 when task does not exist."""
     db = _mock_db_returning(None)

--- a/backend/tests/unit/test_task_service.py
+++ b/backend/tests/unit/test_task_service.py
@@ -44,8 +44,17 @@ def _make_fake_task(
     return fake
 
 
+def _mock_db_returning(obj: object) -> AsyncMock:
+    """Create a mocked AsyncSession whose execute returns obj via scalar_one_or_none."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = obj
+    db.execute.return_value = mock_result
+    return db
+
+
 # ---------------------------------------------------------------------------
-# create_task
+# create_task  (still uses get_project for ownership before INSERT)
 # ---------------------------------------------------------------------------
 
 
@@ -118,19 +127,15 @@ async def test_create_task_raises_404_for_wrong_project_owner(
 
 
 # ---------------------------------------------------------------------------
-# get_task
+# get_task  (uses _get_task_with_ownership — single joined query)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_get_task_returns_task_for_owner(mock_get_project: AsyncMock) -> None:
-    """get_task must return the task when project ownership passes."""
+async def test_get_task_returns_task_for_owner() -> None:
+    """get_task must return the task when joined ownership query succeeds."""
     fake = _make_fake_task()
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(fake)
 
     result = await get_task(
         db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID
@@ -140,13 +145,9 @@ async def test_get_task_returns_task_for_owner(mock_get_project: AsyncMock) -> N
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_get_task_raises_404_when_not_found(mock_get_project: AsyncMock) -> None:
+async def test_get_task_raises_404_when_not_found() -> None:
     """get_task must raise 404 when task does not exist."""
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = None
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(None)
 
     with pytest.raises(HTTPException) as exc_info:
         await get_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
@@ -156,52 +157,39 @@ async def test_get_task_raises_404_when_not_found(mock_get_project: AsyncMock) -
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_get_task_verifies_project_ownership(
-    mock_get_project: AsyncMock,
-) -> None:
-    """get_task must call get_project to verify project ownership."""
-    fake = _make_fake_task()
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+async def test_get_task_raises_404_for_wrong_project_owner() -> None:
+    """get_task must raise 404 when user doesn't own the project (joined query)."""
+    db = _mock_db_returning(None)  # join fails → no result
 
-    await get_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
+    with pytest.raises(HTTPException) as exc_info:
+        await get_task(
+            db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=OTHER_USER_ID
+        )
 
-    mock_get_project.assert_awaited_once_with(db, PROJECT_ID, USER_ID)
+    assert exc_info.value.status_code == 404
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_get_task_queries_by_task_id(mock_get_project: AsyncMock) -> None:
-    """get_task must query WHERE id == task_id (not !=)."""
+async def test_get_task_query_joins_project_for_ownership() -> None:
+    """get_task must use a joined query that checks task_id, project_id, and user_id."""
     fake = _make_fake_task()
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(fake)
 
     await get_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
 
     executed_stmt = db.execute.call_args[0][0]
-    where_clause = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
-    assert "tasks.id =" in where_clause
-    assert "tasks.id !=" not in where_clause
+    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "tasks.id =" in compiled
+    assert "tasks.id !=" not in compiled
+    assert "tasks.project_id =" in compiled
+    assert "projects.user_id =" in compiled
+    assert "JOIN" in compiled.upper()
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_get_task_verifies_task_belongs_to_project(
-    mock_get_project: AsyncMock,
-) -> None:
-    """get_task must raise 404 if task.project_id doesn't match project_id."""
-    other_project_id = uuid.UUID("00000000-0000-0000-0000-cccccccccccc")
-    fake = _make_fake_task(project_id=other_project_id)
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+async def test_get_task_raises_404_for_wrong_project() -> None:
+    """get_task must raise 404 if task belongs to a different project."""
+    db = _mock_db_returning(None)  # project_id mismatch → no result
 
     with pytest.raises(HTTPException) as exc_info:
         await get_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
@@ -211,7 +199,7 @@ async def test_get_task_verifies_task_belongs_to_project(
 
 
 # ---------------------------------------------------------------------------
-# list_tasks
+# list_tasks  (still uses get_project for ownership before SELECT)
 # ---------------------------------------------------------------------------
 
 
@@ -296,19 +284,15 @@ async def test_list_tasks_verifies_project_ownership(
 
 
 # ---------------------------------------------------------------------------
-# update_task
+# update_task  (uses _get_task_with_ownership — single joined query)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_update_task_applies_changes(mock_get_project: AsyncMock) -> None:
+async def test_update_task_applies_changes() -> None:
     """update_task must apply only the provided fields."""
     fake = _make_fake_task()
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(fake)
 
     data = TaskUpdate(title="Updated Title")
     result = await update_task(
@@ -320,18 +304,12 @@ async def test_update_task_applies_changes(mock_get_project: AsyncMock) -> None:
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_update_task_only_sets_provided_fields(
-    mock_get_project: AsyncMock,
-) -> None:
+async def test_update_task_only_sets_provided_fields() -> None:
     """update_task must use exclude_unset=True to skip unset fields."""
     fake = _make_fake_task()
     fake.title = "Original"
     fake.description = "Old desc"
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(fake)
 
     data = TaskUpdate(title="NewTitle")
     await update_task(
@@ -343,17 +321,11 @@ async def test_update_task_only_sets_provided_fields(
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_update_task_sets_completed_at_on_done(
-    mock_get_project: AsyncMock,
-) -> None:
+async def test_update_task_sets_completed_at_on_done() -> None:
     """update_task must set completed_at when status changes to done."""
     fake = _make_fake_task(status="todo")
     fake.completed_at = None
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(fake)
 
     data = TaskUpdate(status="done")
     await update_task(
@@ -364,16 +336,10 @@ async def test_update_task_sets_completed_at_on_done(
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_update_task_clears_completed_at_on_status_change(
-    mock_get_project: AsyncMock,
-) -> None:
+async def test_update_task_clears_completed_at_on_status_change() -> None:
     """update_task must clear completed_at when status changes away from done."""
     fake = _make_fake_task(status="done", completed_at=datetime.now(UTC))
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(fake)
 
     data = TaskUpdate(status="todo")
     await update_task(
@@ -384,15 +350,9 @@ async def test_update_task_clears_completed_at_on_status_change(
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_update_task_raises_404_when_not_found(
-    mock_get_project: AsyncMock,
-) -> None:
+async def test_update_task_raises_404_when_not_found() -> None:
     """update_task must raise 404 when task does not exist."""
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = None
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(None)
 
     with pytest.raises(HTTPException) as exc_info:
         await update_task(
@@ -407,16 +367,10 @@ async def test_update_task_raises_404_when_not_found(
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_update_task_verifies_project_ownership(
-    mock_get_project: AsyncMock,
-) -> None:
-    """update_task must call get_project to verify project ownership."""
+async def test_update_task_query_joins_for_ownership() -> None:
+    """update_task must verify ownership via joined query."""
     fake = _make_fake_task()
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(fake)
 
     await update_task(
         db=db,
@@ -426,21 +380,16 @@ async def test_update_task_verifies_project_ownership(
         data=TaskUpdate(title="X"),
     )
 
-    mock_get_project.assert_awaited_once_with(db, PROJECT_ID, USER_ID)
+    executed_stmt = db.execute.call_args[0][0]
+    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "projects.user_id =" in compiled
+    assert "JOIN" in compiled.upper()
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_update_task_verifies_task_belongs_to_project(
-    mock_get_project: AsyncMock,
-) -> None:
-    """update_task must raise 404 if task.project_id doesn't match."""
-    other_project_id = uuid.UUID("00000000-0000-0000-0000-cccccccccccc")
-    fake = _make_fake_task(project_id=other_project_id)
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+async def test_update_task_raises_404_for_wrong_project() -> None:
+    """update_task must raise 404 if task doesn't belong to project."""
+    db = _mock_db_returning(None)
 
     with pytest.raises(HTTPException) as exc_info:
         await update_task(
@@ -455,19 +404,15 @@ async def test_update_task_verifies_task_belongs_to_project(
 
 
 # ---------------------------------------------------------------------------
-# delete_task
+# delete_task  (uses _get_task_with_ownership — single joined query)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_delete_task_removes_task(mock_get_project: AsyncMock) -> None:
+async def test_delete_task_removes_task() -> None:
     """delete_task must delete the task from the database."""
     fake = _make_fake_task()
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(fake)
 
     await delete_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
 
@@ -476,15 +421,9 @@ async def test_delete_task_removes_task(mock_get_project: AsyncMock) -> None:
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_delete_task_raises_404_when_not_found(
-    mock_get_project: AsyncMock,
-) -> None:
+async def test_delete_task_raises_404_when_not_found() -> None:
     """delete_task must raise 404 when task does not exist."""
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = None
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(None)
 
     with pytest.raises(HTTPException) as exc_info:
         await delete_task(
@@ -495,34 +434,23 @@ async def test_delete_task_raises_404_when_not_found(
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_delete_task_verifies_project_ownership(
-    mock_get_project: AsyncMock,
-) -> None:
-    """delete_task must call get_project to verify project ownership."""
+async def test_delete_task_query_joins_for_ownership() -> None:
+    """delete_task must verify ownership via joined query."""
     fake = _make_fake_task()
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+    db = _mock_db_returning(fake)
 
     await delete_task(db=db, task_id=TASK_ID, project_id=PROJECT_ID, user_id=USER_ID)
 
-    mock_get_project.assert_awaited_once_with(db, PROJECT_ID, USER_ID)
+    executed_stmt = db.execute.call_args[0][0]
+    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "projects.user_id =" in compiled
+    assert "JOIN" in compiled.upper()
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_delete_task_verifies_task_belongs_to_project(
-    mock_get_project: AsyncMock,
-) -> None:
-    """delete_task must raise 404 if task.project_id doesn't match."""
-    other_project_id = uuid.UUID("00000000-0000-0000-0000-cccccccccccc")
-    fake = _make_fake_task(project_id=other_project_id)
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = fake
-    db.execute.return_value = mock_result
+async def test_delete_task_raises_404_for_wrong_project() -> None:
+    """delete_task must raise 404 if task doesn't belong to project."""
+    db = _mock_db_returning(None)
 
     with pytest.raises(HTTPException) as exc_info:
         await delete_task(
@@ -534,7 +462,7 @@ async def test_delete_task_verifies_task_belongs_to_project(
 
 
 # ---------------------------------------------------------------------------
-# Mutation-killing tests for default parameters and detail messages
+# Mutation-killing tests for default parameters
 # ---------------------------------------------------------------------------
 
 

--- a/backend/tests/unit/test_task_service.py
+++ b/backend/tests/unit/test_task_service.py
@@ -199,20 +199,30 @@ async def test_get_task_raises_404_for_wrong_project() -> None:
 
 
 # ---------------------------------------------------------------------------
-# list_tasks  (still uses get_project for ownership before SELECT)
+# list_tasks  (single query with EXISTS ownership subquery)
 # ---------------------------------------------------------------------------
 
 
+def _mock_db_for_list(
+    tasks: list[object],
+    ownership_exists: bool = True,
+) -> AsyncMock:
+    """Mock db for list_tasks: first execute returns tasks, second checks ownership."""
+    db = AsyncMock()
+    task_result = MagicMock()
+    task_result.scalars.return_value.all.return_value = tasks
+    ownership_result = MagicMock()
+    ownership_result.scalar.return_value = ownership_exists
+    db.execute.side_effect = [task_result, ownership_result]
+    return db
+
+
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_list_tasks_returns_project_tasks(mock_get_project: AsyncMock) -> None:
+async def test_list_tasks_returns_project_tasks() -> None:
     """list_tasks must return tasks for the given project."""
     fake1 = _make_fake_task(title="T1")
     fake2 = _make_fake_task(title="T2")
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = [fake1, fake2]
-    db.execute.return_value = mock_result
+    db = _mock_db_for_list([fake1, fake2])
 
     result = await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
@@ -220,30 +230,26 @@ async def test_list_tasks_returns_project_tasks(mock_get_project: AsyncMock) -> 
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_list_tasks_queries_by_project_id(mock_get_project: AsyncMock) -> None:
-    """list_tasks must query WHERE project_id == project_id (not !=)."""
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = []
-    db.execute.return_value = mock_result
+async def test_list_tasks_queries_by_project_id() -> None:
+    """list_tasks must include project_id and EXISTS in query."""
+    fake = _make_fake_task()
+    db = _mock_db_for_list([fake])
 
     await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
-    executed_stmt = db.execute.call_args[0][0]
-    where_clause = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
-    assert "tasks.project_id =" in where_clause
-    assert "tasks.project_id !=" not in where_clause
+    executed_stmt = db.execute.call_args_list[0][0][0]
+    compiled = str(
+        executed_stmt.compile(compile_kwargs={"literal_binds": True})
+    )
+    assert "tasks.project_id =" in compiled
+    assert "tasks.project_id !=" not in compiled
+    assert "EXISTS" in compiled.upper()
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_list_tasks_returns_empty_list(mock_get_project: AsyncMock) -> None:
+async def test_list_tasks_returns_empty_for_valid_project() -> None:
     """list_tasks must return empty list when project has no tasks."""
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = []
-    db.execute.return_value = mock_result
+    db = _mock_db_for_list([], ownership_exists=True)
 
     result = await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
@@ -251,36 +257,48 @@ async def test_list_tasks_returns_empty_list(mock_get_project: AsyncMock) -> Non
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_list_tasks_applies_pagination(mock_get_project: AsyncMock) -> None:
+async def test_list_tasks_raises_404_for_invalid_project() -> None:
+    """list_tasks must raise 404 when project not found or not owned."""
+    db = _mock_db_for_list([], ownership_exists=False)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Project not found"
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_applies_pagination() -> None:
     """list_tasks must apply offset and limit to the query."""
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = []
-    db.execute.return_value = mock_result
+    db = _mock_db_for_list([], ownership_exists=True)
 
-    await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID, skip=10, limit=5)
+    await list_tasks(
+        db=db, project_id=PROJECT_ID, user_id=USER_ID, skip=10, limit=5
+    )
 
-    executed_stmt = db.execute.call_args[0][0]
-    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    executed_stmt = db.execute.call_args_list[0][0][0]
+    compiled = str(
+        executed_stmt.compile(compile_kwargs={"literal_binds": True})
+    )
     assert "LIMIT" in compiled.upper()
     assert "OFFSET" in compiled.upper()
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_list_tasks_verifies_project_ownership(
-    mock_get_project: AsyncMock,
-) -> None:
-    """list_tasks must call get_project to verify project ownership."""
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = []
-    db.execute.return_value = mock_result
+async def test_list_tasks_ownership_via_exists_subquery() -> None:
+    """list_tasks must check user_id via EXISTS subquery."""
+    fake = _make_fake_task()
+    db = _mock_db_for_list([fake])
 
     await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
-    mock_get_project.assert_awaited_once_with(db, PROJECT_ID, USER_ID)
+    executed_stmt = db.execute.call_args_list[0][0][0]
+    compiled = str(
+        executed_stmt.compile(compile_kwargs={"literal_binds": True})
+    )
+    assert "projects.user_id" in compiled
+    assert "EXISTS" in compiled.upper()
 
 
 # ---------------------------------------------------------------------------
@@ -483,36 +501,28 @@ async def test_delete_task_raises_404_for_wrong_project() -> None:
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_list_tasks_default_skip_is_zero(
-    mock_get_project: AsyncMock,
-) -> None:
+async def test_list_tasks_default_skip_is_zero() -> None:
     """list_tasks default skip must be 0 (not 1)."""
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = []
-    db.execute.return_value = mock_result
+    db = _mock_db_for_list([], ownership_exists=True)
 
     await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
-    executed_stmt = db.execute.call_args[0][0]
-    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    executed_stmt = db.execute.call_args_list[0][0][0]
+    compiled = str(
+        executed_stmt.compile(compile_kwargs={"literal_binds": True})
+    )
     assert "OFFSET 0" in compiled
 
 
 @pytest.mark.asyncio
-@patch("app.services.task_service.get_project", new_callable=AsyncMock)
-async def test_list_tasks_default_limit_is_50(
-    mock_get_project: AsyncMock,
-) -> None:
+async def test_list_tasks_default_limit_is_50() -> None:
     """list_tasks default limit must be 50 (not 51)."""
-    db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = []
-    db.execute.return_value = mock_result
+    db = _mock_db_for_list([], ownership_exists=True)
 
     await list_tasks(db=db, project_id=PROJECT_ID, user_id=USER_ID)
 
-    executed_stmt = db.execute.call_args[0][0]
-    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    executed_stmt = db.execute.call_args_list[0][0][0]
+    compiled = str(
+        executed_stmt.compile(compile_kwargs={"literal_binds": True})
+    )
     assert "LIMIT 50" in compiled


### PR DESCRIPTION
## Summary
- Add Task ORM model with `TaskPriority`/`TaskStatus` enums, CHECK constraints, composite index on `(project_id, status)`, and `CASCADE` FK to projects
- Add Pydantic v2 schemas (`TaskCreate`, `TaskUpdate`, `TaskResponse`) with title strip/blank/length validation, enum validation, and `estimate_minutes >= 0`
- Add async CRUD service with transitive ownership (User → Project → Task), single joined queries for get/update/delete, EXISTS subquery for list, and auto-managed `completed_at` on status transitions
- Add REST routes at `POST/GET/PATCH/DELETE /projects/{project_id}/tasks` with auth on all endpoints
- Add Alembic migration `0004_add_tasks_table`
- 195 unit tests across model, schema, service, and route layers; 100% mutation score on `task_service.py`

## Test plan
- [x] `pytest -x -q` — 195 tests pass
- [x] `ruff check . && ruff format .` — clean
- [x] `mutmut run` on `task_service.py` — 100% mutation score
- [x] Alembic migration chain verified (0003 → 0004)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)