### PR TITLE
Add Sentry error tracking and health monitoring (#8)

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -21,37 +21,48 @@ from app.schemas.health import (
 router = APIRouter()
 
 
+async def _check_db(db: AsyncSession) -> tuple[str, float]:
+    """Check database connectivity. Returns (status, latency_ms)."""
+    start = time.monotonic()
+    try:
+        await db.execute(text("SELECT 1"))
+        status = "healthy"
+    except Exception:
+        status = "unhealthy"
+    latency = round((time.monotonic() - start) * 1000, 2)
+    return status, latency
+
+
+async def _check_redis() -> tuple[str, float]:
+    """Check Redis connectivity. Returns (status, latency_ms)."""
+    start = time.monotonic()
+    try:
+        redis = get_redis()
+        await redis.ping()
+        status = "healthy"
+    except Exception:
+        status = "unhealthy"
+    latency = round((time.monotonic() - start) * 1000, 2)
+    return status, latency
+
+
 @router.get("/health", response_model=HealthResponse, tags=["health"])
 async def health_check(
     db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Return application health status including DB and Redis connectivity."""
-    db_status = "healthy"
-    redis_status = "healthy"
-    all_healthy = True
+    db_status, _ = await _check_db(db)
+    redis_status, _ = await _check_redis()
 
-    # Check database
-    try:
-        await db.execute(text("SELECT 1"))
-    except Exception:
-        db_status = "unhealthy"
-        all_healthy = False
-
-    # Check Redis
-    try:
-        redis = get_redis()
-        await redis.ping()
-    except Exception:
-        redis_status = "unhealthy"
-        all_healthy = False
-
-    status_code = 200 if all_healthy else 503
+    all_healthy = db_status == "healthy" and redis_status == "healthy"
     body = HealthResponse(
         status="ok" if all_healthy else "degraded",
         database=db_status,
         redis=redis_status,
     )
-    return JSONResponse(content=body.model_dump(), status_code=status_code)
+    return JSONResponse(
+        content=body.model_dump(), status_code=200 if all_healthy else 503
+    )
 
 
 @router.get(
@@ -64,29 +75,10 @@ async def health_detailed(
     _user: User = Depends(get_current_user),
 ) -> JSONResponse:
     """Return detailed health with latency measurements. Requires authentication."""
-    all_healthy = True
+    db_status, db_latency = await _check_db(db)
+    redis_status, redis_latency = await _check_redis()
 
-    # Check database with latency
-    db_status = "healthy"
-    start = time.monotonic()
-    try:
-        await db.execute(text("SELECT 1"))
-    except Exception:
-        db_status = "unhealthy"
-        all_healthy = False
-    db_latency = round((time.monotonic() - start) * 1000, 2)
-
-    # Check Redis with latency
-    redis_status = "healthy"
-    start = time.monotonic()
-    try:
-        redis = get_redis()
-        await redis.ping()
-    except Exception:
-        redis_status = "unhealthy"
-        all_healthy = False
-    redis_latency = round((time.monotonic() - start) * 1000, 2)
-
+    all_healthy = db_status == "healthy" and redis_status == "healthy"
     body = DetailedHealthResponse(
         status="ok" if all_healthy else "degraded",
         database=DependencyDetail(status=db_status, latency_ms=db_latency),
@@ -94,4 +86,6 @@ async def health_detailed(
         sentry_enabled=bool(settings.SENTRY_DSN),
         version="0.1.0",
     )
-    return JSONResponse(content=body.model_dump(), status_code=200 if all_healthy else 503)
+    return JSONResponse(
+        content=body.model_dump(), status_code=200 if all_healthy else 503
+    )

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import logging
 import time
+from importlib.metadata import version
 
 from fastapi import APIRouter, Depends
 from sqlalchemy import text
@@ -18,7 +20,11 @@ from app.schemas.health import (
     HealthResponse,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+_HEALTH_CHECK_ERRORS = (OSError, ConnectionError, TimeoutError, RuntimeError)
 
 
 async def _check_db(db: AsyncSession) -> tuple[str, float]:
@@ -27,7 +33,8 @@ async def _check_db(db: AsyncSession) -> tuple[str, float]:
     try:
         await db.execute(text("SELECT 1"))
         status = "healthy"
-    except Exception:
+    except _HEALTH_CHECK_ERRORS:
+        logger.warning("Database health check failed", exc_info=True)
         status = "unhealthy"
     latency = round((time.monotonic() - start) * 1000, 2)
     return status, latency
@@ -38,11 +45,10 @@ async def _check_redis() -> tuple[str, float]:
     start = time.monotonic()
     try:
         redis = get_redis()
-        result = redis.ping()
-        if hasattr(result, "__await__"):
-            await result
+        await redis.ping()  # type: ignore[misc]
         status = "healthy"
-    except Exception:
+    except _HEALTH_CHECK_ERRORS:
+        logger.warning("Redis health check failed", exc_info=True)
         status = "unhealthy"
     latency = round((time.monotonic() - start) * 1000, 2)
     return status, latency
@@ -86,7 +92,7 @@ async def health_detailed(
         database=DependencyDetail(status=db_status, latency_ms=db_latency),
         redis=DependencyDetail(status=redis_status, latency_ms=redis_latency),
         sentry_enabled=bool(settings.SENTRY_DSN),
-        version="0.1.0",
+        version=version("flowday-backend"),
     )
     return JSONResponse(
         content=body.model_dump(), status_code=200 if all_healthy else 503

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -38,7 +38,9 @@ async def _check_redis() -> tuple[str, float]:
     start = time.monotonic()
     try:
         redis = get_redis()
-        await redis.ping()
+        result = redis.ping()
+        if hasattr(result, "__await__"):
+            await result
         status = "healthy"
     except Exception:
         status = "unhealthy"

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+import time
+
 from fastapi import APIRouter, Depends
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import JSONResponse
 
+from app.core.config import settings
 from app.core.database import get_db
+from app.core.deps import get_current_user
 from app.core.redis import get_redis
-from app.schemas.health import HealthResponse
+from app.models.user import User
+from app.schemas.health import (
+    DependencyDetail,
+    DetailedHealthResponse,
+    HealthResponse,
+)
 
 router = APIRouter()
 
@@ -43,3 +52,46 @@ async def health_check(
         redis=redis_status,
     )
     return JSONResponse(content=body.model_dump(), status_code=status_code)
+
+
+@router.get(
+    "/health/detailed",
+    response_model=DetailedHealthResponse,
+    tags=["health"],
+)
+async def health_detailed(
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+) -> JSONResponse:
+    """Return detailed health with latency measurements. Requires authentication."""
+    all_healthy = True
+
+    # Check database with latency
+    db_status = "healthy"
+    start = time.monotonic()
+    try:
+        await db.execute(text("SELECT 1"))
+    except Exception:
+        db_status = "unhealthy"
+        all_healthy = False
+    db_latency = round((time.monotonic() - start) * 1000, 2)
+
+    # Check Redis with latency
+    redis_status = "healthy"
+    start = time.monotonic()
+    try:
+        redis = get_redis()
+        await redis.ping()
+    except Exception:
+        redis_status = "unhealthy"
+        all_healthy = False
+    redis_latency = round((time.monotonic() - start) * 1000, 2)
+
+    body = DetailedHealthResponse(
+        status="ok" if all_healthy else "degraded",
+        database=DependencyDetail(status=db_status, latency_ms=db_latency),
+        redis=DependencyDetail(status=redis_status, latency_ms=redis_latency),
+        sentry_enabled=bool(settings.SENTRY_DSN),
+        version="0.1.0",
+    )
+    return JSONResponse(content=body.model_dump(), status_code=200 if all_healthy else 503)

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,13 +1,45 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import JSONResponse
 
+from app.core.database import get_db
+from app.core.redis import get_redis
 from app.schemas.health import HealthResponse
 
 router = APIRouter()
 
 
 @router.get("/health", response_model=HealthResponse, tags=["health"])
-async def health_check() -> HealthResponse:
-    """Return application health status."""
-    return HealthResponse(status="ok")
+async def health_check(
+    db: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """Return application health status including DB and Redis connectivity."""
+    db_status = "healthy"
+    redis_status = "healthy"
+    all_healthy = True
+
+    # Check database
+    try:
+        await db.execute(text("SELECT 1"))
+    except Exception:
+        db_status = "unhealthy"
+        all_healthy = False
+
+    # Check Redis
+    try:
+        redis = get_redis()
+        await redis.ping()
+    except Exception:
+        redis_status = "unhealthy"
+        all_healthy = False
+
+    status_code = 200 if all_healthy else 503
+    body = HealthResponse(
+        status="ok" if all_healthy else "degraded",
+        database=db_status,
+        redis=redis_status,
+    )
+    return JSONResponse(content=body.model_dump(), status_code=status_code)

--- a/backend/app/core/redis.py
+++ b/backend/app/core/redis.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from redis.asyncio import Redis, from_url
+
+_redis: Redis | None = None
+
+
+async def init_redis(url: str) -> None:
+    """Create the async Redis client. Called once from the FastAPI lifespan."""
+    global _redis
+    _redis = from_url(url)
+
+
+async def close_redis() -> None:
+    """Close the async Redis client. Called once from the FastAPI lifespan."""
+    global _redis
+    if _redis is not None:
+        await _redis.aclose()
+        _redis = None
+
+
+def get_redis() -> Redis:
+    """Return the Redis client or raise if not initialised."""
+    if _redis is None:
+        raise RuntimeError("Redis client not initialised. Call init_redis() first.")
+    return _redis

--- a/backend/app/core/sentry.py
+++ b/backend/app/core/sentry.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sentry_sdk
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+def configure_sentry(dsn: str | None) -> None:
+    """Initialise Sentry if a DSN is provided; silently skip otherwise."""
+    if not dsn:
+        return
+    sentry_sdk.init(dsn=dsn, traces_sample_rate=1.0)
+
+
+class SentryBreadcrumbMiddleware(BaseHTTPMiddleware):
+    """Add a Sentry breadcrumb for every incoming HTTP request."""
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        sentry_sdk.add_breadcrumb(
+            category="http",
+            message=f"{request.method} {request.url.path}",
+            level="info",
+        )
+        response = await call_next(request)
+        return response

--- a/backend/app/core/sentry.py
+++ b/backend/app/core/sentry.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
 import sentry_sdk
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-from starlette.requests import Request
-from starlette.responses import Response
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 
 def configure_sentry(dsn: str | None) -> None:
@@ -13,16 +13,19 @@ def configure_sentry(dsn: str | None) -> None:
     sentry_sdk.init(dsn=dsn, traces_sample_rate=1.0)
 
 
-class SentryBreadcrumbMiddleware(BaseHTTPMiddleware):
-    """Add a Sentry breadcrumb for every incoming HTTP request."""
+class SentryBreadcrumbMiddleware:
+    """Raw ASGI middleware that adds a Sentry breadcrumb for every HTTP request."""
 
-    async def dispatch(
-        self, request: Request, call_next: RequestResponseEndpoint
-    ) -> Response:
-        sentry_sdk.add_breadcrumb(
-            category="http",
-            message=f"{request.method} {request.url.path}",
-            level="info",
-        )
-        response = await call_next(request)
-        return response
+    def __init__(self, app: ASGIApp, **_kwargs: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            method = scope.get("method", "")
+            path = scope.get("path", "")
+            sentry_sdk.add_breadcrumb(
+                category="http",
+                message=f"{method} {path}",
+                level="info",
+            )
+        await self.app(scope, receive, send)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
-import sentry_sdk
 from fastapi import FastAPI
 
 from app.api.auth import router as auth_router
@@ -12,6 +11,7 @@ from app.api.projects import router as projects_router
 from app.api.tasks import router as tasks_router
 from app.core.config import settings
 from app.core.database import dispose_engine, init_engine
+from app.core.sentry import SentryBreadcrumbMiddleware, configure_sentry
 
 
 @asynccontextmanager
@@ -24,8 +24,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
-    if settings.SENTRY_DSN:
-        sentry_sdk.init(dsn=settings.SENTRY_DSN, traces_sample_rate=1.0)
+    configure_sentry(settings.SENTRY_DSN)
 
     app = FastAPI(
         title="FlowDay API",
@@ -33,6 +32,8 @@ def create_app() -> FastAPI:
         version="0.1.0",
         lifespan=lifespan,
     )
+
+    app.add_middleware(SentryBreadcrumbMiddleware)
 
     app.include_router(health_router)
     app.include_router(auth_router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,7 +19,11 @@ from app.core.sentry import SentryBreadcrumbMiddleware, configure_sentry
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Manage startup and shutdown of shared resources."""
     init_engine()
-    await init_redis(settings.REDIS_URL)
+    try:
+        await init_redis(settings.REDIS_URL)
+    except Exception:
+        await dispose_engine()
+        raise
     yield
     await close_redis()
     await dispose_engine()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,7 +40,7 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    app.add_middleware(SentryBreadcrumbMiddleware)
+    app.add_middleware(SentryBreadcrumbMiddleware)  # type: ignore[arg-type]
 
     app.include_router(health_router)
     app.include_router(auth_router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from app.api.projects import router as projects_router
 from app.api.tasks import router as tasks_router
 from app.core.config import settings
 from app.core.database import dispose_engine, init_engine
+from app.core.redis import close_redis, init_redis
 from app.core.sentry import SentryBreadcrumbMiddleware, configure_sentry
 
 
@@ -18,7 +19,9 @@ from app.core.sentry import SentryBreadcrumbMiddleware, configure_sentry
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Manage startup and shutdown of shared resources."""
     init_engine()
+    await init_redis(settings.REDIS_URL)
     yield
+    await close_redis()
     await dispose_engine()
 
 

--- a/backend/app/schemas/health.py
+++ b/backend/app/schemas/health.py
@@ -7,3 +7,5 @@ class HealthResponse(BaseModel):
     """Response schema for the health check endpoint."""
 
     status: str
+    database: str
+    redis: str

--- a/backend/app/schemas/health.py
+++ b/backend/app/schemas/health.py
@@ -9,3 +9,20 @@ class HealthResponse(BaseModel):
     status: str
     database: str
     redis: str
+
+
+class DependencyDetail(BaseModel):
+    """Health detail for a single dependency."""
+
+    status: str
+    latency_ms: float
+
+
+class DetailedHealthResponse(BaseModel):
+    """Response schema for the detailed health check endpoint."""
+
+    status: str
+    database: DependencyDetail
+    redis: DependencyDetail
+    sentry_enabled: bool
+    version: str

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -51,8 +51,8 @@ ignore_missing_imports = true
 exclude = ["mutants/"]
 
 [tool.mutmut]
-paths_to_mutate = "app/core/database.py"
-runner = "python3.12 -m pytest tests/unit/ tests/test_health.py -x -q --tb=no"
+paths_to_mutate = "app/core/database.py:app/core/redis.py:app/core/sentry.py:app/api/health.py"
+runner = "python -m pytest tests/unit/ tests/test_health.py -x -q --tb=no"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,13 +1,31 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import AsyncClient
+
+from app.core.database import get_db
+from app.main import app
 
 
 async def test_health_returns_ok_with_dependencies(client: AsyncClient) -> None:
     """GET /health returns 200 with database and redis status when both are up."""
-    response = await client.get("/health")
+    mock_session = MagicMock()
+    mock_session.execute = AsyncMock(return_value=None)
+
+    async def _ok_db():  # type: ignore[no-untyped-def]
+        yield mock_session
+
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(return_value=True)
+
+    app.dependency_overrides[get_db] = _ok_db
+    try:
+        with patch("app.api.health.get_redis", return_value=mock_redis):
+            response = await client.get("/health")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
@@ -17,11 +35,22 @@ async def test_health_returns_ok_with_dependencies(client: AsyncClient) -> None:
 
 async def test_health_returns_503_when_db_down(client: AsyncClient) -> None:
     """GET /health returns 503 when database is unreachable."""
-    with patch(
-        "app.api.health.get_db",
-        return_value=_failing_db_gen(),
-    ):
-        response = await client.get("/health")
+    mock_session = MagicMock()
+    mock_session.execute = AsyncMock(side_effect=ConnectionError("DB down"))
+
+    async def _failing_db():  # type: ignore[no-untyped-def]
+        yield mock_session
+
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(return_value=True)
+
+    app.dependency_overrides[get_db] = _failing_db
+    try:
+        with patch("app.api.health.get_redis", return_value=mock_redis):
+            response = await client.get("/health")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
     assert response.status_code == 503
     data = response.json()
     assert data["database"] == "unhealthy"
@@ -29,16 +58,22 @@ async def test_health_returns_503_when_db_down(client: AsyncClient) -> None:
 
 async def test_health_returns_503_when_redis_down(client: AsyncClient) -> None:
     """GET /health returns 503 when Redis is unreachable."""
+    mock_session = MagicMock()
+    mock_session.execute = AsyncMock(return_value=None)
+
+    async def _ok_db():  # type: ignore[no-untyped-def]
+        yield mock_session
+
     mock_redis = AsyncMock()
     mock_redis.ping = AsyncMock(side_effect=ConnectionError("Redis down"))
-    with patch("app.api.health.get_redis", return_value=mock_redis):
-        response = await client.get("/health")
+
+    app.dependency_overrides[get_db] = _ok_db
+    try:
+        with patch("app.api.health.get_redis", return_value=mock_redis):
+            response = await client.get("/health")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
     assert response.status_code == 503
     data = response.json()
     assert data["redis"] == "unhealthy"
-
-
-async def _failing_db_gen():  # type: ignore[no-untyped-def]
-    """Async generator that simulates a DB failure."""
-    raise ConnectionError("DB down")
-    yield  # noqa: RUF027 — make this an async generator

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,10 +1,44 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 from httpx import AsyncClient
 
 
-async def test_health_returns_ok(client: AsyncClient) -> None:
-    """GET /health must return 200 with status ok."""
+async def test_health_returns_ok_with_dependencies(client: AsyncClient) -> None:
+    """GET /health returns 200 with database and redis status when both are up."""
     response = await client.get("/health")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["database"] == "healthy"
+    assert data["redis"] == "healthy"
+
+
+async def test_health_returns_503_when_db_down(client: AsyncClient) -> None:
+    """GET /health returns 503 when database is unreachable."""
+    with patch(
+        "app.api.health.get_db",
+        return_value=_failing_db_gen(),
+    ):
+        response = await client.get("/health")
+    assert response.status_code == 503
+    data = response.json()
+    assert data["database"] == "unhealthy"
+
+
+async def test_health_returns_503_when_redis_down(client: AsyncClient) -> None:
+    """GET /health returns 503 when Redis is unreachable."""
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(side_effect=ConnectionError("Redis down"))
+    with patch("app.api.health.get_redis", return_value=mock_redis):
+        response = await client.get("/health")
+    assert response.status_code == 503
+    data = response.json()
+    assert data["redis"] == "unhealthy"
+
+
+async def _failing_db_gen():  # type: ignore[no-untyped-def]
+    """Async generator that simulates a DB failure."""
+    raise ConnectionError("DB down")
+    yield  # noqa: RUF027 — make this an async generator

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -53,6 +53,7 @@ async def test_health_returns_503_when_db_down(client: AsyncClient) -> None:
 
     assert response.status_code == 503
     data = response.json()
+    assert data["status"] == "degraded"
     assert data["database"] == "unhealthy"
 
 
@@ -76,26 +77,35 @@ async def test_health_returns_503_when_redis_down(client: AsyncClient) -> None:
 
     assert response.status_code == 503
     data = response.json()
+    assert data["status"] == "degraded"
     assert data["redis"] == "unhealthy"
 
 
 async def test_health_detailed_requires_auth(client: AsyncClient) -> None:
     """GET /health/detailed without a token must return 401."""
-    response = await client.get("/health/detailed")
+    mock_session = MagicMock()
+    mock_session.execute = AsyncMock(return_value=None)
+
+    async def _ok_db():  # type: ignore[no-untyped-def]
+        yield mock_session
+
+    app.dependency_overrides[get_db] = _ok_db
+    try:
+        response = await client.get("/health/detailed")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
     assert response.status_code == 401
 
 
 async def test_health_detailed_returns_dependency_info(client: AsyncClient) -> None:
     """GET /health/detailed with valid auth returns latency and status details."""
-    from unittest.mock import MagicMock as MM
-
     from app.core.deps import get_current_user
 
-    mock_user = MM()
+    mock_user = MagicMock()
     mock_user.id = 1
     mock_user.email = "test@example.com"
 
-    mock_session = MM()
+    mock_session = MagicMock()
     mock_session.execute = AsyncMock(return_value=None)
 
     async def _ok_db():  # type: ignore[no-untyped-def]
@@ -116,9 +126,40 @@ async def test_health_detailed_returns_dependency_info(client: AsyncClient) -> N
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert "database" in data
-    assert "latency_ms" in data["database"]
-    assert "redis" in data
-    assert "latency_ms" in data["redis"]
-    assert "sentry_enabled" in data
-    assert "version" in data
+    assert data["database"]["status"] == "healthy"
+    assert data["database"]["latency_ms"] >= 0
+    assert data["redis"]["status"] == "healthy"
+    assert data["redis"]["latency_ms"] >= 0
+    assert data["sentry_enabled"] is False
+    assert data["version"] == "0.1.0"
+
+
+async def test_health_detailed_returns_503_when_db_down(client: AsyncClient) -> None:
+    """GET /health/detailed returns 503 with degraded status when DB is down."""
+    from app.core.deps import get_current_user
+
+    mock_user = MagicMock()
+
+    mock_session = MagicMock()
+    mock_session.execute = AsyncMock(side_effect=ConnectionError("DB down"))
+
+    async def _failing_db():  # type: ignore[no-untyped-def]
+        yield mock_session
+
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(return_value=True)
+
+    app.dependency_overrides[get_db] = _failing_db
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    try:
+        with patch("app.api.health.get_redis", return_value=mock_redis):
+            response = await client.get("/health/detailed")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["status"] == "degraded"
+    assert data["database"]["status"] == "unhealthy"
+    assert data["redis"]["status"] == "healthy"

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -77,3 +77,48 @@ async def test_health_returns_503_when_redis_down(client: AsyncClient) -> None:
     assert response.status_code == 503
     data = response.json()
     assert data["redis"] == "unhealthy"
+
+
+async def test_health_detailed_requires_auth(client: AsyncClient) -> None:
+    """GET /health/detailed without a token must return 401."""
+    response = await client.get("/health/detailed")
+    assert response.status_code == 401
+
+
+async def test_health_detailed_returns_dependency_info(client: AsyncClient) -> None:
+    """GET /health/detailed with valid auth returns latency and status details."""
+    from unittest.mock import MagicMock as MM
+
+    from app.core.deps import get_current_user
+
+    mock_user = MM()
+    mock_user.id = 1
+    mock_user.email = "test@example.com"
+
+    mock_session = MM()
+    mock_session.execute = AsyncMock(return_value=None)
+
+    async def _ok_db():  # type: ignore[no-untyped-def]
+        yield mock_session
+
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(return_value=True)
+
+    app.dependency_overrides[get_db] = _ok_db
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    try:
+        with patch("app.api.health.get_redis", return_value=mock_redis):
+            response = await client.get("/health/detailed")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert "database" in data
+    assert "latency_ms" in data["database"]
+    assert "redis" in data
+    assert "latency_ms" in data["redis"]
+    assert "sentry_enabled" in data
+    assert "version" in data

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -131,7 +131,7 @@ async def test_health_detailed_returns_dependency_info(client: AsyncClient) -> N
     assert data["redis"]["status"] == "healthy"
     assert data["redis"]["latency_ms"] >= 0
     assert data["sentry_enabled"] is False
-    assert data["version"] == "0.1.0"
+    assert data["version"]  # non-empty version string
 
 
 async def test_health_detailed_returns_503_when_db_down(client: AsyncClient) -> None:

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,31 +1,88 @@
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator, Generator
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from httpx import AsyncClient
 
 from app.core.database import get_db
+from app.core.deps import get_current_user
 from app.main import app
 
+# ---------------------------------------------------------------------------
+# Fixtures — reduce mock boilerplate across health tests
+# ---------------------------------------------------------------------------
 
-async def test_health_returns_ok_with_dependencies(client: AsyncClient) -> None:
-    """GET /health returns 200 with database and redis status when both are up."""
+
+@pytest.fixture
+def mock_healthy_db() -> Generator[None, None, None]:
+    """Override get_db with a mock session that succeeds on execute."""
     mock_session = MagicMock()
     mock_session.execute = AsyncMock(return_value=None)
 
-    async def _ok_db():  # type: ignore[no-untyped-def]
+    async def _ok_db() -> AsyncGenerator[Any, None]:
         yield mock_session
 
+    app.dependency_overrides[get_db] = _ok_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture
+def mock_failing_db() -> Generator[None, None, None]:
+    """Override get_db with a mock session that raises on execute."""
+    mock_session = MagicMock()
+    mock_session.execute = AsyncMock(side_effect=ConnectionError("DB down"))
+
+    async def _failing_db() -> AsyncGenerator[Any, None]:
+        yield mock_session
+
+    app.dependency_overrides[get_db] = _failing_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture
+def mock_healthy_redis() -> Generator[Any, None, None]:
+    """Patch get_redis to return a mock that pings successfully."""
     mock_redis = AsyncMock()
     mock_redis.ping = AsyncMock(return_value=True)
+    with patch("app.api.health.get_redis", return_value=mock_redis):
+        yield mock_redis
 
-    app.dependency_overrides[get_db] = _ok_db
-    try:
-        with patch("app.api.health.get_redis", return_value=mock_redis):
-            response = await client.get("/health")
-    finally:
-        app.dependency_overrides.pop(get_db, None)
 
+@pytest.fixture
+def mock_failing_redis() -> Generator[Any, None, None]:
+    """Patch get_redis to return a mock that raises on ping."""
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(side_effect=ConnectionError("Redis down"))
+    with patch("app.api.health.get_redis", return_value=mock_redis):
+        yield mock_redis
+
+
+@pytest.fixture
+def mock_auth_user() -> Generator[None, None, None]:
+    """Override get_current_user with a fake authenticated user."""
+    mock_user = MagicMock()
+    mock_user.id = 1
+    mock_user.email = "test@example.com"
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+# ---------------------------------------------------------------------------
+# GET /health
+# ---------------------------------------------------------------------------
+
+
+async def test_health_returns_ok_with_dependencies(
+    client: AsyncClient, mock_healthy_db: None, mock_healthy_redis: Any
+) -> None:
+    """GET /health returns 200 with database and redis status when both are up."""
+    response = await client.get("/health")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
@@ -33,96 +90,49 @@ async def test_health_returns_ok_with_dependencies(client: AsyncClient) -> None:
     assert data["redis"] == "healthy"
 
 
-async def test_health_returns_503_when_db_down(client: AsyncClient) -> None:
+async def test_health_returns_503_when_db_down(
+    client: AsyncClient, mock_failing_db: None, mock_healthy_redis: Any
+) -> None:
     """GET /health returns 503 when database is unreachable."""
-    mock_session = MagicMock()
-    mock_session.execute = AsyncMock(side_effect=ConnectionError("DB down"))
-
-    async def _failing_db():  # type: ignore[no-untyped-def]
-        yield mock_session
-
-    mock_redis = AsyncMock()
-    mock_redis.ping = AsyncMock(return_value=True)
-
-    app.dependency_overrides[get_db] = _failing_db
-    try:
-        with patch("app.api.health.get_redis", return_value=mock_redis):
-            response = await client.get("/health")
-    finally:
-        app.dependency_overrides.pop(get_db, None)
-
+    response = await client.get("/health")
     assert response.status_code == 503
     data = response.json()
     assert data["status"] == "degraded"
     assert data["database"] == "unhealthy"
 
 
-async def test_health_returns_503_when_redis_down(client: AsyncClient) -> None:
+async def test_health_returns_503_when_redis_down(
+    client: AsyncClient, mock_healthy_db: None, mock_failing_redis: Any
+) -> None:
     """GET /health returns 503 when Redis is unreachable."""
-    mock_session = MagicMock()
-    mock_session.execute = AsyncMock(return_value=None)
-
-    async def _ok_db():  # type: ignore[no-untyped-def]
-        yield mock_session
-
-    mock_redis = AsyncMock()
-    mock_redis.ping = AsyncMock(side_effect=ConnectionError("Redis down"))
-
-    app.dependency_overrides[get_db] = _ok_db
-    try:
-        with patch("app.api.health.get_redis", return_value=mock_redis):
-            response = await client.get("/health")
-    finally:
-        app.dependency_overrides.pop(get_db, None)
-
+    response = await client.get("/health")
     assert response.status_code == 503
     data = response.json()
     assert data["status"] == "degraded"
     assert data["redis"] == "unhealthy"
 
 
-async def test_health_detailed_requires_auth(client: AsyncClient) -> None:
+# ---------------------------------------------------------------------------
+# GET /health/detailed
+# ---------------------------------------------------------------------------
+
+
+async def test_health_detailed_requires_auth(
+    client: AsyncClient, mock_healthy_db: None
+) -> None:
     """GET /health/detailed without a token must return 401."""
-    mock_session = MagicMock()
-    mock_session.execute = AsyncMock(return_value=None)
-
-    async def _ok_db():  # type: ignore[no-untyped-def]
-        yield mock_session
-
-    app.dependency_overrides[get_db] = _ok_db
-    try:
-        response = await client.get("/health/detailed")
-    finally:
-        app.dependency_overrides.pop(get_db, None)
+    response = await client.get("/health/detailed")
     assert response.status_code == 401
 
 
-async def test_health_detailed_returns_dependency_info(client: AsyncClient) -> None:
+async def test_health_detailed_returns_dependency_info(
+    client: AsyncClient,
+    mock_healthy_db: None,
+    mock_healthy_redis: Any,
+    mock_auth_user: None,
+) -> None:
     """GET /health/detailed with valid auth returns latency and status details."""
-    from app.core.deps import get_current_user
-
-    mock_user = MagicMock()
-    mock_user.id = 1
-    mock_user.email = "test@example.com"
-
-    mock_session = MagicMock()
-    mock_session.execute = AsyncMock(return_value=None)
-
-    async def _ok_db():  # type: ignore[no-untyped-def]
-        yield mock_session
-
-    mock_redis = AsyncMock()
-    mock_redis.ping = AsyncMock(return_value=True)
-
-    app.dependency_overrides[get_db] = _ok_db
-    app.dependency_overrides[get_current_user] = lambda: mock_user
-    try:
-        with patch("app.api.health.get_redis", return_value=mock_redis):
-            response = await client.get("/health/detailed")
-    finally:
-        app.dependency_overrides.pop(get_db, None)
-        app.dependency_overrides.pop(get_current_user, None)
-
+    response = await client.get("/health/detailed")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
@@ -134,30 +144,14 @@ async def test_health_detailed_returns_dependency_info(client: AsyncClient) -> N
     assert data["version"]  # non-empty version string
 
 
-async def test_health_detailed_returns_503_when_db_down(client: AsyncClient) -> None:
+async def test_health_detailed_returns_503_when_db_down(
+    client: AsyncClient,
+    mock_failing_db: None,
+    mock_healthy_redis: Any,
+    mock_auth_user: None,
+) -> None:
     """GET /health/detailed returns 503 with degraded status when DB is down."""
-    from app.core.deps import get_current_user
-
-    mock_user = MagicMock()
-
-    mock_session = MagicMock()
-    mock_session.execute = AsyncMock(side_effect=ConnectionError("DB down"))
-
-    async def _failing_db():  # type: ignore[no-untyped-def]
-        yield mock_session
-
-    mock_redis = AsyncMock()
-    mock_redis.ping = AsyncMock(return_value=True)
-
-    app.dependency_overrides[get_db] = _failing_db
-    app.dependency_overrides[get_current_user] = lambda: mock_user
-    try:
-        with patch("app.api.health.get_redis", return_value=mock_redis):
-            response = await client.get("/health/detailed")
-    finally:
-        app.dependency_overrides.pop(get_db, None)
-        app.dependency_overrides.pop(get_current_user, None)
-
+    response = await client.get("/health/detailed")
     assert response.status_code == 503
     data = response.json()
     assert data["status"] == "degraded"

--- a/backend/tests/unit/test_redis.py
+++ b/backend/tests/unit/test_redis.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from app.core.redis import close_redis, get_redis, init_redis
@@ -14,18 +16,23 @@ def test_get_redis_before_init_raises() -> None:
 @pytest.mark.anyio
 async def test_init_redis_creates_client() -> None:
     """After init_redis(), get_redis() must return a Redis client."""
-    try:
-        await init_redis("redis://localhost:6379/0")
-        client = get_redis()
-        assert client is not None
-    finally:
-        await close_redis()
+    mock_client = AsyncMock()
+    with patch("app.core.redis.from_url", return_value=mock_client):
+        try:
+            await init_redis("redis://localhost:6379/0")
+            client = get_redis()
+            assert client is mock_client
+        finally:
+            await close_redis()
 
 
 @pytest.mark.anyio
 async def test_close_redis_clears_client() -> None:
     """After close_redis(), get_redis() must raise RuntimeError again."""
-    await init_redis("redis://localhost:6379/0")
-    await close_redis()
+    mock_client = AsyncMock()
+    with patch("app.core.redis.from_url", return_value=mock_client):
+        await init_redis("redis://localhost:6379/0")
+        await close_redis()
+        mock_client.aclose.assert_called_once()
     with pytest.raises(RuntimeError, match="Redis client not initialised"):
         get_redis()

--- a/backend/tests/unit/test_redis.py
+++ b/backend/tests/unit/test_redis.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.redis import close_redis, get_redis, init_redis
+
+
+def test_get_redis_before_init_raises() -> None:
+    """get_redis() must raise RuntimeError when called before init_redis()."""
+    with pytest.raises(RuntimeError, match="Redis client not initialised"):
+        get_redis()
+
+
+@pytest.mark.anyio
+async def test_init_redis_creates_client() -> None:
+    """After init_redis(), get_redis() must return a Redis client."""
+    try:
+        await init_redis("redis://localhost:6379/0")
+        client = get_redis()
+        assert client is not None
+    finally:
+        await close_redis()
+
+
+@pytest.mark.anyio
+async def test_close_redis_clears_client() -> None:
+    """After close_redis(), get_redis() must raise RuntimeError again."""
+    await init_redis("redis://localhost:6379/0")
+    await close_redis()
+    with pytest.raises(RuntimeError, match="Redis client not initialised"):
+        get_redis()

--- a/backend/tests/unit/test_sentry.py
+++ b/backend/tests/unit/test_sentry.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.sentry import SentryBreadcrumbMiddleware, configure_sentry
+
+
+def test_configure_sentry_with_dsn_calls_init() -> None:
+    """When a DSN is provided, sentry_sdk.init must be called."""
+    with patch("app.core.sentry.sentry_sdk") as mock_sdk:
+        configure_sentry("https://examplePublicKey@o0.ingest.sentry.io/0")
+        mock_sdk.init.assert_called_once()
+        call_kwargs = mock_sdk.init.call_args
+        assert call_kwargs[1]["dsn"] == "https://examplePublicKey@o0.ingest.sentry.io/0"
+
+
+def test_configure_sentry_without_dsn_skips_init() -> None:
+    """When DSN is None, sentry_sdk.init must NOT be called."""
+    with patch("app.core.sentry.sentry_sdk") as mock_sdk:
+        configure_sentry(None)
+        mock_sdk.init.assert_not_called()
+
+
+def test_configure_sentry_with_empty_dsn_skips_init() -> None:
+    """When DSN is empty string, sentry_sdk.init must NOT be called."""
+    with patch("app.core.sentry.sentry_sdk") as mock_sdk:
+        configure_sentry("")
+        mock_sdk.init.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_breadcrumb_middleware_adds_crumb() -> None:
+    """Middleware must add a breadcrumb with method and path for each request."""
+    from fastapi import FastAPI
+
+    test_app = FastAPI()
+
+    @test_app.get("/ping")
+    async def ping() -> dict[str, str]:
+        return {"pong": "ok"}
+
+    test_app.add_middleware(SentryBreadcrumbMiddleware)
+
+    with patch("app.core.sentry.sentry_sdk") as mock_sdk:
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            response = await client.get("/ping")
+
+        assert response.status_code == 200
+        mock_sdk.add_breadcrumb.assert_called()
+        crumb = mock_sdk.add_breadcrumb.call_args[1]
+        assert crumb["category"] == "http"
+        assert "GET" in crumb["message"]
+        assert "/ping" in crumb["message"]

--- a/backend/tests/unit/test_sentry.py
+++ b/backend/tests/unit/test_sentry.py
@@ -15,6 +15,7 @@ def test_configure_sentry_with_dsn_calls_init() -> None:
         mock_sdk.init.assert_called_once()
         call_kwargs = mock_sdk.init.call_args
         assert call_kwargs[1]["dsn"] == "https://examplePublicKey@o0.ingest.sentry.io/0"
+        assert call_kwargs[1]["traces_sample_rate"] == 1.0
 
 
 def test_configure_sentry_without_dsn_skips_init() -> None:
@@ -54,5 +55,5 @@ async def test_breadcrumb_middleware_adds_crumb() -> None:
         mock_sdk.add_breadcrumb.assert_called()
         crumb = mock_sdk.add_breadcrumb.call_args[1]
         assert crumb["category"] == "http"
-        assert "GET" in crumb["message"]
-        assert "/ping" in crumb["message"]
+        assert crumb["message"] == "GET /ping"
+        assert crumb["level"] == "info"

--- a/backend/tests/unit/test_sentry.py
+++ b/backend/tests/unit/test_sentry.py
@@ -43,7 +43,7 @@ async def test_breadcrumb_middleware_adds_crumb() -> None:
     async def ping() -> dict[str, str]:
         return {"pong": "ok"}
 
-    test_app.add_middleware(SentryBreadcrumbMiddleware)
+    test_app.add_middleware(SentryBreadcrumbMiddleware)  # type: ignore[arg-type]
 
     with patch("app.core.sentry.sentry_sdk") as mock_sdk:
         async with AsyncClient(

--- a/backend/tests/unit/test_sentry.py
+++ b/backend/tests/unit/test_sentry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient

--- a/docs/plans/issue-8-sentry-health-monitoring.md
+++ b/docs/plans/issue-8-sentry-health-monitoring.md
@@ -1,0 +1,119 @@
+# Issue #8 — Add Sentry Error Tracking and Health Monitoring
+
+## Phase 1: Explore
+
+### What exists
+- **Sentry**: `sentry-sdk[fastapi]` in deps; conditional init in `app/main.py:27-28` via `SENTRY_DSN`
+- **Health**: `GET /health` returns `{"status": "ok"}` — no dependency checks (`app/api/health.py`)
+- **Redis**: `REDIS_URL` in config, `redis>=5.0.0` in deps — **no connection code yet**
+- **Database**: Async SQLAlchemy with `get_db()`, pool pre-ping enabled (`app/core/database.py`)
+- **Auth**: `get_current_user()` dependency in `app/core/deps.py` — needed for gated endpoint
+- **Tests**: `tests/test_health.py` has one test; `tests/conftest.py` has `db_engine` + `client` fixtures
+
+### Impact analysis
+- **No new pip deps** — `sentry-sdk[fastapi]` and `redis` already installed
+- **No migrations** — no schema changes, only runtime health checks
+- **Files to create**: `app/core/sentry.py`, `app/core/redis.py`, `tests/unit/test_sentry.py`, `tests/unit/test_redis.py`
+- **Files to modify**: `app/main.py`, `app/api/health.py`, `app/schemas/health.py`, `tests/test_health.py`
+
+---
+
+## Phase 2: Plan
+
+### Acceptance criteria
+1. Sentry breadcrumb middleware logs request method + path on every request; missing `SENTRY_DSN` silently disables Sentry
+2. Redis connection module provides `init_redis()` / `close_redis()` / `get_redis()` lifecycle
+3. `GET /health` returns 200 with `database: "healthy"` + `redis: "healthy"` when both up; returns 503 when either is down
+4. `GET /health/detailed` requires authentication and returns dependency latencies + Sentry status
+
+---
+
+### Cycle 1 — Sentry breadcrumb middleware
+
+**RED tests** (`tests/unit/test_sentry.py`):
+- `test_configure_sentry_with_dsn_calls_init` — mock `sentry_sdk.init`, verify it's called with DSN
+- `test_configure_sentry_without_dsn_skips_init` — no DSN → `sentry_sdk.init` not called, no error
+- `test_breadcrumb_middleware_adds_crumb` — mock `sentry_sdk.add_breadcrumb`, send request through middleware, verify breadcrumb added with method + path
+
+**GREEN implementation**:
+- Create `app/core/sentry.py`:
+  - `configure_sentry(dsn: str | None)` — wraps `sentry_sdk.init` with guard
+  - `SentryBreadcrumbMiddleware(BaseHTTPMiddleware)` — adds breadcrumb with `category="http"`, `message="{method} {path}"`, `level="info"` on each request
+- Modify `app/main.py`:
+  - Replace inline `sentry_sdk.init` with `configure_sentry(settings.SENTRY_DSN)`
+  - Add `SentryBreadcrumbMiddleware` to app
+
+**REFACTOR**:
+- Remove direct `sentry_sdk` import from `main.py`
+
+---
+
+### Cycle 2 — Redis connection module
+
+**RED tests** (`tests/unit/test_redis.py`):
+- `test_get_redis_before_init_raises` — calling `get_redis()` before `init_redis()` raises `RuntimeError`
+- `test_init_redis_creates_client` — after `init_redis()`, `get_redis()` returns a Redis client
+- `test_close_redis_clears_client` — after `close_redis()`, `get_redis()` raises again
+
+**GREEN implementation**:
+- Create `app/core/redis.py`:
+  - Module-level `_redis: Redis | None = None`
+  - `init_redis(url: str) -> None` — creates `redis.asyncio.from_url(url)`
+  - `close_redis() -> None` — calls `await _redis.aclose()`, sets to `None`
+  - `get_redis() -> Redis` — returns client or raises `RuntimeError`
+- Modify `app/main.py` lifespan:
+  - Add `init_redis(settings.REDIS_URL)` at startup
+  - Add `await close_redis()` at shutdown
+
+**REFACTOR**:
+- Ensure `redis.py` mirrors `database.py` module pattern (init/dispose/get)
+
+---
+
+### Cycle 3 — Enhanced `/health` with DB + Redis checks
+
+**RED tests** (`tests/test_health.py`):
+- `test_health_returns_ok_with_dependencies` — returns 200, body includes `status`, `database`, `redis` fields all "healthy"
+- `test_health_returns_503_when_db_down` — mock DB to raise, returns 503, `database: "unhealthy"`
+- `test_health_returns_503_when_redis_down` — mock Redis ping to raise, returns 503, `redis: "unhealthy"`
+
+**GREEN implementation**:
+- Modify `app/schemas/health.py`:
+  - Add `database: str` and `redis: str` fields to `HealthResponse`
+- Modify `app/api/health.py`:
+  - Inject `db: AsyncSession = Depends(get_db)` and get Redis via `get_redis()`
+  - Check DB: `await db.execute(text("SELECT 1"))`
+  - Check Redis: `await redis.ping()`
+  - Return 200 if both pass, 503 if either fails
+  - Wrap each check in try/except to report individual status
+
+**REFACTOR**:
+- Extract health check logic into helper functions if needed
+
+---
+
+### Cycle 4 — Auth-gated `/health/detailed`
+
+**RED tests** (`tests/test_health.py`):
+- `test_health_detailed_requires_auth` — no token → 401
+- `test_health_detailed_returns_dependency_info` — with valid auth, returns db latency, redis latency, sentry enabled flag, app version
+
+**GREEN implementation**:
+- Modify `app/schemas/health.py`:
+  - Add `DetailedHealthResponse` with fields: `status`, `database` (dict with status + latency_ms), `redis` (dict with status + latency_ms), `sentry_enabled: bool`, `version: str`
+- Modify `app/api/health.py`:
+  - Add `GET /health/detailed` with `Depends(get_current_user)`
+  - Measure DB + Redis latency with `time.monotonic()`
+  - Return detailed response
+
+**REFACTOR**:
+- Clean up shared logic between `/health` and `/health/detailed`
+
+---
+
+### Post-implementation
+- Run `ruff check . && ruff format .`
+- Run `mypy .`
+- Run `pytest -x -q`
+- Run `mutmut run` — target ≥ 80% mutation score
+- Open PR `feature/8-sentry-health-monitoring → main`, link Issue #8


### PR DESCRIPTION
## Summary
- Add `configure_sentry()` + raw ASGI breadcrumb middleware (`app/core/sentry.py`)
- Add Redis connection lifecycle: `init_redis()` / `close_redis()` / `get_redis()` (`app/core/redis.py`)
- Enhance `GET /health` to check DB (`SELECT 1`) + Redis (`ping`), return 200/503
- Add auth-gated `GET /health/detailed` with per-dependency latency, Sentry status, app version
- Safe lifespan: `dispose_engine()` cleanup if `init_redis()` fails on startup
- Narrow exception handling with logging, dynamic version from package metadata

## Test plan
- [x] 207 tests pass (`pytest -x -q`)
- [x] `ruff check .` + `ruff format .` clean
- [x] `mypy --strict` clean
- [x] Mutation score: 81% (68/84 killed, target ≥ 80%)
- [x] `/health` returns 200 when DB+Redis healthy, 503 when either is down
- [x] `/health/detailed` returns 401 without auth, 200 with auth + latency info
- [x] Missing `SENTRY_DSN` silently disables Sentry (no crash)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)