### PR TITLE
feat: implement ScheduleBlock model and CRUD API (#19)

### DIFF
--- a/backend/alembic/versions/0005_add_schedule_blocks_table.py
+++ b/backend/alembic/versions/0005_add_schedule_blocks_table.py
@@ -50,9 +50,7 @@ def upgrade() -> None:
             name="ck_schedule_blocks_end_gt_start",
         ),
     )
-    op.create_index(
-        "idx_schedule_block_date", "schedule_blocks", ["date", "task_id"]
-    )
+    op.create_index("idx_schedule_block_date", "schedule_blocks", ["date", "task_id"])
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0005_add_schedule_blocks_table.py
+++ b/backend/alembic/versions/0005_add_schedule_blocks_table.py
@@ -1,0 +1,60 @@
+"""add schedule_blocks table
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-04-15
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0005"
+down_revision: str = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "schedule_blocks",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "task_id",
+            sa.UUID(),
+            sa.ForeignKey("tasks.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("start_hour", sa.Numeric(4, 2), nullable=False),
+        sa.Column("end_hour", sa.Numeric(4, 2), nullable=False),
+        sa.Column(
+            "source",
+            sa.String(20),
+            nullable=False,
+            server_default="manual",
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "source IN ('manual', 'google_calendar')",
+            name="ck_schedule_blocks_source",
+        ),
+        sa.CheckConstraint(
+            "end_hour > start_hour",
+            name="ck_schedule_blocks_end_gt_start",
+        ),
+    )
+    op.create_index(
+        "idx_schedule_block_date", "schedule_blocks", ["date", "task_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_schedule_block_date", table_name="schedule_blocks")
+    op.drop_table("schedule_blocks")

--- a/backend/app/api/schedule_blocks.py
+++ b/backend/app/api/schedule_blocks.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.models.user import User
+from app.schemas.schedule_block import (
+    ScheduleBlockCreate,
+    ScheduleBlockResponse,
+    ScheduleBlockUpdate,
+)
+from app.services.schedule_block_service import (
+    create_schedule_block,
+    delete_schedule_block,
+    get_schedule_block,
+    list_schedule_blocks,
+    update_schedule_block,
+)
+
+router = APIRouter(prefix="/schedule-blocks", tags=["schedule-blocks"])
+
+
+@router.post(
+    "", response_model=ScheduleBlockResponse, status_code=status.HTTP_201_CREATED
+)
+async def create_schedule_block_route(
+    body: ScheduleBlockCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ScheduleBlockResponse:
+    """Create a new schedule block."""
+    block = await create_schedule_block(db=db, user_id=current_user.id, data=body)
+    return ScheduleBlockResponse.model_validate(block)
+
+
+@router.get("", response_model=list[ScheduleBlockResponse])
+async def list_schedule_blocks_route(
+    date: date = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[ScheduleBlockResponse]:
+    """List schedule blocks for a given date."""
+    blocks = await list_schedule_blocks(
+        db=db, user_id=current_user.id, query_date=date
+    )
+    return [ScheduleBlockResponse.model_validate(b) for b in blocks]
+
+
+@router.get("/{block_id}", response_model=ScheduleBlockResponse)
+async def get_schedule_block_route(
+    block_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ScheduleBlockResponse:
+    """Get a single schedule block by ID."""
+    block = await get_schedule_block(
+        db=db, block_id=block_id, user_id=current_user.id
+    )
+    return ScheduleBlockResponse.model_validate(block)
+
+
+@router.put("/{block_id}", response_model=ScheduleBlockResponse)
+async def update_schedule_block_route(
+    block_id: uuid.UUID,
+    body: ScheduleBlockUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ScheduleBlockResponse:
+    """Update a schedule block (resize/move)."""
+    block = await update_schedule_block(
+        db=db, block_id=block_id, user_id=current_user.id, data=body
+    )
+    return ScheduleBlockResponse.model_validate(block)
+
+
+@router.delete(
+    "/{block_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None
+)
+async def delete_schedule_block_route(
+    block_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Delete a schedule block."""
+    await delete_schedule_block(
+        db=db, block_id=block_id, user_id=current_user.id
+    )

--- a/backend/app/api/schedule_blocks.py
+++ b/backend/app/api/schedule_blocks.py
@@ -45,9 +45,7 @@ async def list_schedule_blocks_route(
     db: AsyncSession = Depends(get_db),
 ) -> list[ScheduleBlockResponse]:
     """List schedule blocks for a given date."""
-    blocks = await list_schedule_blocks(
-        db=db, user_id=current_user.id, query_date=date
-    )
+    blocks = await list_schedule_blocks(db=db, user_id=current_user.id, query_date=date)
     return [ScheduleBlockResponse.model_validate(b) for b in blocks]
 
 
@@ -58,9 +56,7 @@ async def get_schedule_block_route(
     db: AsyncSession = Depends(get_db),
 ) -> ScheduleBlockResponse:
     """Get a single schedule block by ID."""
-    block = await get_schedule_block(
-        db=db, block_id=block_id, user_id=current_user.id
-    )
+    block = await get_schedule_block(db=db, block_id=block_id, user_id=current_user.id)
     return ScheduleBlockResponse.model_validate(block)
 
 
@@ -87,6 +83,4 @@ async def delete_schedule_block_route(
     db: AsyncSession = Depends(get_db),
 ) -> None:
     """Delete a schedule block."""
-    await delete_schedule_block(
-        db=db, block_id=block_id, user_id=current_user.id
-    )
+    await delete_schedule_block(db=db, block_id=block_id, user_id=current_user.id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from app.api.auth import router as auth_router
 from app.api.health import router as health_router
 from app.api.projects import router as projects_router
+from app.api.schedule_blocks import router as schedule_blocks_router
 from app.api.tasks import router as tasks_router
 from app.core.config import settings
 from app.core.database import dispose_engine, init_engine
@@ -46,6 +47,7 @@ def create_app() -> FastAPI:
     app.include_router(auth_router)
     app.include_router(projects_router)
     app.include_router(tasks_router)
+    app.include_router(schedule_blocks_router)
 
     return app
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.project import Project
+from app.models.schedule_block import ScheduleBlock
 from app.models.task import Task
 from app.models.user import User
 
-__all__ = ["Project", "Task", "User"]
+__all__ = ["Project", "ScheduleBlock", "Task", "User"]

--- a/backend/app/models/schedule_block.py
+++ b/backend/app/models/schedule_block.py
@@ -5,7 +5,15 @@ import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
 
-from sqlalchemy import CheckConstraint, Date, DateTime, ForeignKey, Index, Numeric, String
+from sqlalchemy import (
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    String,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 

--- a/backend/app/models/schedule_block.py
+++ b/backend/app/models/schedule_block.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from sqlalchemy import CheckConstraint, Date, DateTime, ForeignKey, Index, Numeric, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class ScheduleBlockSource(enum.StrEnum):
+    """Source of the schedule block."""
+
+    MANUAL = "manual"
+    GOOGLE_CALENDAR = "google_calendar"
+
+
+class ScheduleBlock(Base):
+    """Schedule block entity — see docs/DATA_MODEL.md for full specification."""
+
+    __tablename__ = "schedule_blocks"
+    __table_args__ = (
+        CheckConstraint(
+            "source IN ('manual', 'google_calendar')",
+            name="ck_schedule_blocks_source",
+        ),
+        CheckConstraint(
+            "end_hour > start_hour",
+            name="ck_schedule_blocks_end_gt_start",
+        ),
+        Index("idx_schedule_block_date", "date", "task_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    task_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tasks.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    date: Mapped[datetime] = mapped_column(Date, nullable=False)
+    start_hour: Mapped[Decimal] = mapped_column(Numeric(4, 2), nullable=False)
+    end_hour: Mapped[Decimal] = mapped_column(Numeric(4, 2), nullable=False)
+    source: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=ScheduleBlockSource.MANUAL,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    def __repr__(self) -> str:
+        return f"<ScheduleBlock(id={self.id})>"

--- a/backend/app/models/schedule_block.py
+++ b/backend/app/models/schedule_block.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 
 from sqlalchemy import (
@@ -51,7 +51,7 @@ class ScheduleBlock(Base):
         ForeignKey("tasks.id", ondelete="CASCADE"),
         nullable=False,
     )
-    date: Mapped[datetime] = mapped_column(Date, nullable=False)
+    date: Mapped[date] = mapped_column(Date, nullable=False)
     start_hour: Mapped[Decimal] = mapped_column(Numeric(4, 2), nullable=False)
     end_hour: Mapped[Decimal] = mapped_column(Numeric(4, 2), nullable=False)
     source: Mapped[str] = mapped_column(

--- a/backend/app/schemas/schedule_block.py
+++ b/backend/app/schemas/schedule_block.py
@@ -1,0 +1,82 @@
+import uuid
+from datetime import date as date_type
+from datetime import datetime
+from decimal import Decimal
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.models.schedule_block import ScheduleBlockSource
+
+_VALID_SOURCES = {s.value for s in ScheduleBlockSource}
+
+
+class ScheduleBlockCreate(BaseModel):
+    """Schema for creating a new schedule block."""
+
+    task_id: uuid.UUID
+    date: date_type
+    start_hour: Decimal = Field(ge=0, le=24)
+    end_hour: Decimal = Field(ge=0, le=24)
+    source: str = "manual"
+
+    @model_validator(mode="after")
+    def validate_end_gt_start(self) -> Self:
+        """end_hour must be greater than start_hour."""
+        if self.end_hour <= self.start_hour:
+            msg = "end_hour must be greater than start_hour"
+            raise ValueError(msg)
+        return self
+
+    @field_validator("source")
+    @classmethod
+    def validate_source(cls, v: str) -> str:
+        """Source must be a valid ScheduleBlockSource value."""
+        if v not in _VALID_SOURCES:
+            msg = f"source must be one of: {', '.join(sorted(_VALID_SOURCES))}"
+            raise ValueError(msg)
+        return v
+
+
+class ScheduleBlockUpdate(BaseModel):
+    """Schema for updating a schedule block (PUT — resize/move)."""
+
+    date: date_type | None = None
+    start_hour: Decimal | None = Field(default=None, ge=0, le=24)
+    end_hour: Decimal | None = Field(default=None, ge=0, le=24)
+    source: str | None = None
+
+    @model_validator(mode="after")
+    def validate_end_gt_start(self) -> Self:
+        """When both hours are provided, end_hour must be > start_hour."""
+        if (
+            self.start_hour is not None
+            and self.end_hour is not None
+            and self.end_hour <= self.start_hour
+        ):
+            msg = "end_hour must be greater than start_hour"
+            raise ValueError(msg)
+        return self
+
+    @field_validator("source")
+    @classmethod
+    def validate_source(cls, v: str | None) -> str | None:
+        """Source must be a valid ScheduleBlockSource value if provided."""
+        if v is not None and v not in _VALID_SOURCES:
+            msg = f"source must be one of: {', '.join(sorted(_VALID_SOURCES))}"
+            raise ValueError(msg)
+        return v
+
+
+class ScheduleBlockResponse(BaseModel):
+    """Public schedule block representation."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    task_id: uuid.UUID
+    date: date_type
+    start_hour: Decimal
+    end_hour: Decimal
+    source: str
+    created_at: datetime

--- a/backend/app/services/schedule_block_service.py
+++ b/backend/app/services/schedule_block_service.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project import Project
+from app.models.schedule_block import ScheduleBlock
+from app.models.task import Task
+from app.schemas.schedule_block import ScheduleBlockCreate, ScheduleBlockUpdate
+
+
+async def _get_block_with_ownership(
+    db: AsyncSession,
+    block_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> ScheduleBlock:
+    """Fetch a schedule block verifying the user owns it via Task → Project.
+
+    Returns 404 for missing block or ownership mismatch (prevents ID enumeration).
+    """
+    stmt = (
+        select(ScheduleBlock)
+        .join(Task, ScheduleBlock.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            ScheduleBlock.id == block_id,
+            Project.user_id == user_id,
+        )
+    )
+    result = await db.execute(stmt)
+    block = result.scalar_one_or_none()
+    if block is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Schedule block not found",
+        )
+    return block
+
+
+async def _verify_task_ownership(
+    db: AsyncSession,
+    task_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    """Verify that the task exists and belongs to the user via Project."""
+    stmt = (
+        select(Task)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            Task.id == task_id,
+            Project.user_id == user_id,
+        )
+    )
+    result = await db.execute(stmt)
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found",
+        )
+
+
+async def _check_overlap(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    block_date: date,
+    start_hour: object,
+    end_hour: object,
+    exclude_id: uuid.UUID | None = None,
+) -> None:
+    """Raise 409 if an overlapping block exists for the same user and date."""
+    stmt = (
+        select(ScheduleBlock)
+        .join(Task, ScheduleBlock.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            Project.user_id == user_id,
+            ScheduleBlock.date == block_date,
+            ScheduleBlock.start_hour < end_hour,
+            ScheduleBlock.end_hour > start_hour,
+        )
+    )
+    if exclude_id is not None:
+        stmt = stmt.where(ScheduleBlock.id != exclude_id)
+    result = await db.execute(stmt)
+    if result.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Schedule block overlaps with an existing block",
+        )
+
+
+async def create_schedule_block(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    data: ScheduleBlockCreate,
+) -> ScheduleBlock:
+    """Create a new schedule block, verifying task ownership and no overlap."""
+    await _verify_task_ownership(db, data.task_id, user_id)
+    await _check_overlap(db, user_id, data.date, data.start_hour, data.end_hour)
+
+    block = ScheduleBlock(
+        task_id=data.task_id,
+        date=data.date,
+        start_hour=data.start_hour,
+        end_hour=data.end_hour,
+        source=data.source,
+    )
+    db.add(block)
+    await db.commit()
+    await db.refresh(block)
+    return block
+
+
+async def get_schedule_block(
+    db: AsyncSession,
+    block_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> ScheduleBlock:
+    """Get a single schedule block, enforcing ownership."""
+    return await _get_block_with_ownership(db, block_id, user_id)
+
+
+async def list_schedule_blocks(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    query_date: date,
+) -> list[ScheduleBlock]:
+    """List schedule blocks for a given user and date."""
+    stmt = (
+        select(ScheduleBlock)
+        .join(Task, ScheduleBlock.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            Project.user_id == user_id,
+            ScheduleBlock.date == query_date,
+        )
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def update_schedule_block(
+    db: AsyncSession,
+    block_id: uuid.UUID,
+    user_id: uuid.UUID,
+    data: ScheduleBlockUpdate,
+) -> ScheduleBlock:
+    """Update a schedule block, enforcing ownership and overlap check."""
+    block = await _get_block_with_ownership(db, block_id, user_id)
+
+    updates = data.model_dump(exclude_unset=True)
+
+    # Determine effective values for overlap check
+    effective_date = updates.get("date", block.date)
+    effective_start = updates.get("start_hour", block.start_hour)
+    effective_end = updates.get("end_hour", block.end_hour)
+
+    if "date" in updates or "start_hour" in updates or "end_hour" in updates:
+        await _check_overlap(
+            db, user_id, effective_date, effective_start, effective_end,
+            exclude_id=block_id,
+        )
+
+    for field, value in updates.items():
+        setattr(block, field, value)
+
+    await db.commit()
+    await db.refresh(block)
+    return block
+
+
+async def delete_schedule_block(
+    db: AsyncSession,
+    block_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    """Delete a schedule block, enforcing ownership."""
+    block = await _get_block_with_ownership(db, block_id, user_id)
+    await db.delete(block)
+    await db.commit()

--- a/backend/app/services/schedule_block_service.py
+++ b/backend/app/services/schedule_block_service.py
@@ -86,7 +86,7 @@ async def _check_overlap(
     if exclude_id is not None:
         stmt = stmt.where(ScheduleBlock.id != exclude_id)
     result = await db.execute(stmt)
-    if result.scalar_one_or_none() is not None:
+    if result.scalars().first() is not None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Schedule block overlaps with an existing block",
@@ -158,6 +158,12 @@ async def update_schedule_block(
     effective_date = updates.get("date", block.date)
     effective_start = updates.get("start_hour", block.start_hour)
     effective_end = updates.get("end_hour", block.end_hour)
+
+    if effective_end <= effective_start:
+        raise HTTPException(
+            status_code=422,
+            detail="end_hour must be greater than start_hour",
+        )
 
     if "date" in updates or "start_hour" in updates or "end_hour" in updates:
         await _check_overlap(

--- a/backend/app/services/schedule_block_service.py
+++ b/backend/app/services/schedule_block_service.py
@@ -161,7 +161,11 @@ async def update_schedule_block(
 
     if "date" in updates or "start_hour" in updates or "end_hour" in updates:
         await _check_overlap(
-            db, user_id, effective_date, effective_start, effective_end,
+            db,
+            user_id,
+            effective_date,
+            effective_start,
+            effective_end,
             exclude_id=block_id,
         )
 

--- a/backend/tests/unit/test_schedule_block_model.py
+++ b/backend/tests/unit/test_schedule_block_model.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import inspect
+
+from app.models.schedule_block import ScheduleBlock, ScheduleBlockSource
+
+
+def test_schedule_block_table_name() -> None:
+    """ScheduleBlock.__tablename__ must be 'schedule_blocks'."""
+    assert ScheduleBlock.__tablename__ == "schedule_blocks"
+
+
+def test_schedule_block_has_required_columns() -> None:
+    """ScheduleBlock must have all columns from DATA_MODEL.md."""
+    columns = {c.name for c in inspect(ScheduleBlock).columns}
+    expected = {"id", "task_id", "date", "start_hour", "end_hour", "source", "created_at"}
+    assert expected.issubset(columns), f"Missing columns: {expected - columns}"
+
+
+def test_schedule_block_id_is_uuid() -> None:
+    """ScheduleBlock.id column type must be UUID."""
+    col = inspect(ScheduleBlock).columns["id"]
+    assert "UUID" in str(col.type).upper()
+
+
+def test_schedule_block_task_id_is_foreign_key() -> None:
+    """ScheduleBlock.task_id must reference tasks.id."""
+    col = inspect(ScheduleBlock).columns["task_id"]
+    fk_targets = {fk.target_fullname for fk in col.foreign_keys}
+    assert "tasks.id" in fk_targets
+
+
+def test_schedule_block_task_id_cascade_delete() -> None:
+    """ScheduleBlock.task_id FK must have ondelete CASCADE."""
+    col = inspect(ScheduleBlock).columns["task_id"]
+    for fk in col.foreign_keys:
+        if fk.target_fullname == "tasks.id":
+            assert fk.ondelete == "CASCADE"
+
+
+def test_schedule_block_task_id_not_nullable() -> None:
+    """ScheduleBlock.task_id must be NOT NULL."""
+    col = inspect(ScheduleBlock).columns["task_id"]
+    assert col.nullable is False
+
+
+def test_schedule_block_date_not_nullable() -> None:
+    """ScheduleBlock.date must be NOT NULL."""
+    col = inspect(ScheduleBlock).columns["date"]
+    assert col.nullable is False
+
+
+def test_schedule_block_start_hour_not_nullable() -> None:
+    """ScheduleBlock.start_hour must be NOT NULL."""
+    col = inspect(ScheduleBlock).columns["start_hour"]
+    assert col.nullable is False
+
+
+def test_schedule_block_start_hour_is_numeric() -> None:
+    """ScheduleBlock.start_hour column type must be Numeric."""
+    col = inspect(ScheduleBlock).columns["start_hour"]
+    assert "NUMERIC" in str(col.type).upper()
+
+
+def test_schedule_block_end_hour_not_nullable() -> None:
+    """ScheduleBlock.end_hour must be NOT NULL."""
+    col = inspect(ScheduleBlock).columns["end_hour"]
+    assert col.nullable is False
+
+
+def test_schedule_block_end_hour_is_numeric() -> None:
+    """ScheduleBlock.end_hour column type must be Numeric."""
+    col = inspect(ScheduleBlock).columns["end_hour"]
+    assert "NUMERIC" in str(col.type).upper()
+
+
+def test_schedule_block_source_has_default() -> None:
+    """ScheduleBlock.source column must default to MANUAL."""
+    col = inspect(ScheduleBlock).columns["source"]
+    assert col.default is not None
+    assert col.default.arg == ScheduleBlockSource.MANUAL  # type: ignore[attr-defined]
+
+
+def test_schedule_block_source_enum_values() -> None:
+    """ScheduleBlockSource enum must have manual and google_calendar values."""
+    assert ScheduleBlockSource.MANUAL.value == "manual"
+    assert ScheduleBlockSource.GOOGLE_CALENDAR.value == "google_calendar"
+
+
+def test_schedule_block_has_source_check_constraint() -> None:
+    """ScheduleBlock must have a CHECK constraint on source."""
+    constraints = {c.name for c in ScheduleBlock.__table__.constraints}  # type: ignore[attr-defined]
+    assert "ck_schedule_blocks_source" in constraints
+
+
+def test_schedule_block_has_end_gt_start_check_constraint() -> None:
+    """ScheduleBlock must have a CHECK constraint end_hour > start_hour."""
+    constraints = {c.name for c in ScheduleBlock.__table__.constraints}  # type: ignore[attr-defined]
+    assert "ck_schedule_blocks_end_gt_start" in constraints
+
+
+def test_schedule_block_has_date_task_index() -> None:
+    """ScheduleBlock must have an index on (date, task_id)."""
+    indexes = {idx.name for idx in inspect(ScheduleBlock).mapped_table.indexes}
+    assert "idx_schedule_block_date" in indexes
+
+
+def test_schedule_block_repr_contains_id() -> None:
+    """ScheduleBlock.__repr__ should include the block id."""
+    block_id = uuid.uuid4()
+    block = ScheduleBlock(id=block_id, task_id=uuid.uuid4())
+    assert str(block_id) in repr(block)

--- a/backend/tests/unit/test_schedule_block_model.py
+++ b/backend/tests/unit/test_schedule_block_model.py
@@ -15,7 +15,15 @@ def test_schedule_block_table_name() -> None:
 def test_schedule_block_has_required_columns() -> None:
     """ScheduleBlock must have all columns from DATA_MODEL.md."""
     columns = {c.name for c in inspect(ScheduleBlock).columns}
-    expected = {"id", "task_id", "date", "start_hour", "end_hour", "source", "created_at"}
+    expected = {
+        "id",
+        "task_id",
+        "date",
+        "start_hour",
+        "end_hour",
+        "source",
+        "created_at",
+    }
     assert expected.issubset(columns), f"Missing columns: {expected - columns}"
 
 

--- a/backend/tests/unit/test_schedule_block_routes.py
+++ b/backend/tests/unit/test_schedule_block_routes.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.main import app
+from app.models.schedule_block import ScheduleBlock, ScheduleBlockSource
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+TASK_ID = uuid.UUID("00000000-0000-0000-0000-bbbbbbbbbbbb")
+BLOCK_ID = uuid.UUID("00000000-0000-0000-0000-cccccccccccc")
+
+
+def _make_fake_user() -> MagicMock:
+    fake = MagicMock()
+    fake.id = USER_ID
+    fake.email = "test@example.com"
+    fake.name = "Test User"
+    return fake
+
+
+def _make_fake_block(**overrides: object) -> MagicMock:
+    defaults = {
+        "id": BLOCK_ID,
+        "task_id": TASK_ID,
+        "date": date(2026, 5, 1),
+        "start_hour": Decimal("9.00"),
+        "end_hour": Decimal("10.00"),
+        "source": ScheduleBlockSource.MANUAL,
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    fake = MagicMock(spec=ScheduleBlock)
+    for k, v in defaults.items():
+        setattr(fake, k, v)
+    return fake
+
+
+@pytest.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+def _setup_overrides() -> None:
+    app.dependency_overrides[get_current_user] = _make_fake_user
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+
+
+def _clear_overrides() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /schedule-blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_block_returns_201(client: AsyncClient) -> None:
+    """POST /schedule-blocks with valid data must return 201."""
+    fake = _make_fake_block()
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.schedule_blocks.create_schedule_block",
+            new_callable=AsyncMock,
+        ) as mock_create:
+            mock_create.return_value = fake
+            response = await client.post(
+                "/schedule-blocks",
+                json={
+                    "task_id": str(TASK_ID),
+                    "date": "2026-05-01",
+                    "start_hour": "9.00",
+                    "end_hour": "10.00",
+                },
+            )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] == str(BLOCK_ID)
+
+
+@pytest.mark.asyncio
+async def test_create_block_returns_401_without_auth(client: AsyncClient) -> None:
+    """POST /schedule-blocks without auth must return 401."""
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.post(
+            "/schedule-blocks",
+            json={
+                "task_id": str(TASK_ID),
+                "date": "2026-05-01",
+                "start_hour": "9.00",
+                "end_hour": "10.00",
+            },
+        )
+    finally:
+        _clear_overrides()
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /schedule-blocks?date=YYYY-MM-DD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_blocks_returns_200(client: AsyncClient) -> None:
+    """GET /schedule-blocks?date=2026-05-01 must return 200 with list."""
+    fake = _make_fake_block()
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.schedule_blocks.list_schedule_blocks",
+            new_callable=AsyncMock,
+        ) as mock_list:
+            mock_list.return_value = [fake]
+            response = await client.get("/schedule-blocks?date=2026-05-01")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_blocks_requires_date_param(client: AsyncClient) -> None:
+    """GET /schedule-blocks without date must return 422."""
+    _setup_overrides()
+    try:
+        response = await client.get("/schedule-blocks")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PUT /schedule-blocks/{block_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_block_returns_200(client: AsyncClient) -> None:
+    """PUT /schedule-blocks/{id} with valid data must return 200."""
+    fake = _make_fake_block(start_hour=Decimal("8"), end_hour=Decimal("11"))
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.schedule_blocks.update_schedule_block",
+            new_callable=AsyncMock,
+        ) as mock_update:
+            mock_update.return_value = fake
+            response = await client.put(
+                f"/schedule-blocks/{BLOCK_ID}",
+                json={"start_hour": "8.00", "end_hour": "11.00"},
+            )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# DELETE /schedule-blocks/{block_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_block_returns_204(client: AsyncClient) -> None:
+    """DELETE /schedule-blocks/{id} must return 204."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.schedule_blocks.delete_schedule_block",
+            new_callable=AsyncMock,
+        ) as mock_delete:
+            mock_delete.return_value = None
+            response = await client.delete(f"/schedule-blocks/{BLOCK_ID}")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_block_returns_401_without_auth(client: AsyncClient) -> None:
+    """DELETE /schedule-blocks/{id} without auth must return 401."""
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.delete(f"/schedule-blocks/{BLOCK_ID}")
+    finally:
+        _clear_overrides()
+    assert response.status_code == 401

--- a/backend/tests/unit/test_schedule_block_schema.py
+++ b/backend/tests/unit/test_schedule_block_schema.py
@@ -37,7 +37,10 @@ def test_create_with_required_fields() -> None:
 def test_create_defaults_source_to_manual() -> None:
     """ScheduleBlockCreate.source must default to 'manual'."""
     b = ScheduleBlockCreate(
-        task_id=TASK_ID, date=date(2026, 5, 1), start_hour=Decimal("9"), end_hour=Decimal("10"),
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9"),
+        end_hour=Decimal("10"),
     )
     assert b.source == "manual"
 
@@ -45,33 +48,51 @@ def test_create_defaults_source_to_manual() -> None:
 def test_create_rejects_missing_task_id() -> None:
     """ScheduleBlockCreate without task_id must raise ValidationError."""
     with pytest.raises(ValidationError):
-        ScheduleBlockCreate(date=date(2026, 5, 1), start_hour=Decimal("9"), end_hour=Decimal("10"))  # type: ignore[call-arg]
+        ScheduleBlockCreate(  # type: ignore[call-arg]
+            date=date(2026, 5, 1),
+            start_hour=Decimal("9"),
+            end_hour=Decimal("10"),
+        )
 
 
 def test_create_rejects_missing_date() -> None:
     """ScheduleBlockCreate without date must raise ValidationError."""
     with pytest.raises(ValidationError):
-        ScheduleBlockCreate(task_id=TASK_ID, start_hour=Decimal("9"), end_hour=Decimal("10"))  # type: ignore[call-arg]
+        ScheduleBlockCreate(  # type: ignore[call-arg]
+            task_id=TASK_ID,
+            start_hour=Decimal("9"),
+            end_hour=Decimal("10"),
+        )
 
 
 def test_create_rejects_missing_start_hour() -> None:
     """ScheduleBlockCreate without start_hour must raise ValidationError."""
     with pytest.raises(ValidationError):
-        ScheduleBlockCreate(task_id=TASK_ID, date=date(2026, 5, 1), end_hour=Decimal("10"))  # type: ignore[call-arg]
+        ScheduleBlockCreate(  # type: ignore[call-arg]
+            task_id=TASK_ID,
+            date=date(2026, 5, 1),
+            end_hour=Decimal("10"),
+        )
 
 
 def test_create_rejects_missing_end_hour() -> None:
     """ScheduleBlockCreate without end_hour must raise ValidationError."""
     with pytest.raises(ValidationError):
-        ScheduleBlockCreate(task_id=TASK_ID, date=date(2026, 5, 1), start_hour=Decimal("9"))  # type: ignore[call-arg]
+        ScheduleBlockCreate(  # type: ignore[call-arg]
+            task_id=TASK_ID,
+            date=date(2026, 5, 1),
+            start_hour=Decimal("9"),
+        )
 
 
 def test_create_rejects_start_equal_end() -> None:
     """ScheduleBlockCreate must reject start_hour == end_hour."""
     with pytest.raises(ValidationError):
         ScheduleBlockCreate(
-            task_id=TASK_ID, date=date(2026, 5, 1),
-            start_hour=Decimal("10"), end_hour=Decimal("10"),
+            task_id=TASK_ID,
+            date=date(2026, 5, 1),
+            start_hour=Decimal("10"),
+            end_hour=Decimal("10"),
         )
 
 
@@ -79,8 +100,10 @@ def test_create_rejects_start_gt_end() -> None:
     """ScheduleBlockCreate must reject start_hour > end_hour."""
     with pytest.raises(ValidationError):
         ScheduleBlockCreate(
-            task_id=TASK_ID, date=date(2026, 5, 1),
-            start_hour=Decimal("15"), end_hour=Decimal("10"),
+            task_id=TASK_ID,
+            date=date(2026, 5, 1),
+            start_hour=Decimal("15"),
+            end_hour=Decimal("10"),
         )
 
 
@@ -88,8 +111,10 @@ def test_create_rejects_negative_start_hour() -> None:
     """ScheduleBlockCreate must reject negative start_hour."""
     with pytest.raises(ValidationError):
         ScheduleBlockCreate(
-            task_id=TASK_ID, date=date(2026, 5, 1),
-            start_hour=Decimal("-1"), end_hour=Decimal("10"),
+            task_id=TASK_ID,
+            date=date(2026, 5, 1),
+            start_hour=Decimal("-1"),
+            end_hour=Decimal("10"),
         )
 
 
@@ -97,8 +122,10 @@ def test_create_rejects_start_hour_above_24() -> None:
     """ScheduleBlockCreate must reject start_hour > 24."""
     with pytest.raises(ValidationError):
         ScheduleBlockCreate(
-            task_id=TASK_ID, date=date(2026, 5, 1),
-            start_hour=Decimal("24.01"), end_hour=Decimal("25"),
+            task_id=TASK_ID,
+            date=date(2026, 5, 1),
+            start_hour=Decimal("24.01"),
+            end_hour=Decimal("25"),
         )
 
 
@@ -106,16 +133,20 @@ def test_create_rejects_end_hour_above_24() -> None:
     """ScheduleBlockCreate must reject end_hour > 24."""
     with pytest.raises(ValidationError):
         ScheduleBlockCreate(
-            task_id=TASK_ID, date=date(2026, 5, 1),
-            start_hour=Decimal("9"), end_hour=Decimal("24.01"),
+            task_id=TASK_ID,
+            date=date(2026, 5, 1),
+            start_hour=Decimal("9"),
+            end_hour=Decimal("24.01"),
         )
 
 
 def test_create_accepts_boundary_hours() -> None:
     """ScheduleBlockCreate must accept start_hour=0, end_hour=24."""
     b = ScheduleBlockCreate(
-        task_id=TASK_ID, date=date(2026, 5, 1),
-        start_hour=Decimal("0"), end_hour=Decimal("24"),
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("0"),
+        end_hour=Decimal("24"),
     )
     assert b.start_hour == Decimal("0")
     assert b.end_hour == Decimal("24")
@@ -125,8 +156,10 @@ def test_create_rejects_invalid_source() -> None:
     """ScheduleBlockCreate must reject invalid source values."""
     with pytest.raises(ValidationError):
         ScheduleBlockCreate(
-            task_id=TASK_ID, date=date(2026, 5, 1),
-            start_hour=Decimal("9"), end_hour=Decimal("10"),
+            task_id=TASK_ID,
+            date=date(2026, 5, 1),
+            start_hour=Decimal("9"),
+            end_hour=Decimal("10"),
             source="outlook",
         )
 
@@ -134,14 +167,18 @@ def test_create_rejects_invalid_source() -> None:
 def test_create_accepts_valid_sources() -> None:
     """ScheduleBlockCreate must accept both valid source values."""
     b1 = ScheduleBlockCreate(
-        task_id=TASK_ID, date=date(2026, 5, 1),
-        start_hour=Decimal("9"), end_hour=Decimal("10"),
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9"),
+        end_hour=Decimal("10"),
         source="manual",
     )
     assert b1.source == "manual"
     b2 = ScheduleBlockCreate(
-        task_id=TASK_ID, date=date(2026, 5, 1),
-        start_hour=Decimal("9"), end_hour=Decimal("10"),
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9"),
+        end_hour=Decimal("10"),
         source="google_calendar",
     )
     assert b2.source == "google_calendar"
@@ -150,8 +187,10 @@ def test_create_accepts_valid_sources() -> None:
 def test_create_accepts_decimal_hours() -> None:
     """ScheduleBlockCreate must accept fractional hours (e.g. 9.5 = 9:30)."""
     b = ScheduleBlockCreate(
-        task_id=TASK_ID, date=date(2026, 5, 1),
-        start_hour=Decimal("9.5"), end_hour=Decimal("10.75"),
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9.5"),
+        end_hour=Decimal("10.75"),
     )
     assert b.start_hour == Decimal("9.5")
     assert b.end_hour == Decimal("10.75")

--- a/backend/tests/unit/test_schedule_block_schema.py
+++ b/backend/tests/unit/test_schedule_block_schema.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.schedule_block import (
+    ScheduleBlockCreate,
+    ScheduleBlockResponse,
+    ScheduleBlockUpdate,
+)
+
+TASK_ID = uuid.UUID("00000000-0000-0000-0000-aaaaaaaaaaaa")
+
+# ---------------------------------------------------------------------------
+# ScheduleBlockCreate
+# ---------------------------------------------------------------------------
+
+
+def test_create_with_required_fields() -> None:
+    """ScheduleBlockCreate must accept all required fields."""
+    b = ScheduleBlockCreate(
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9.00"),
+        end_hour=Decimal("10.50"),
+    )
+    assert b.task_id == TASK_ID
+    assert b.date == date(2026, 5, 1)
+    assert b.start_hour == Decimal("9.00")
+    assert b.end_hour == Decimal("10.50")
+
+
+def test_create_defaults_source_to_manual() -> None:
+    """ScheduleBlockCreate.source must default to 'manual'."""
+    b = ScheduleBlockCreate(
+        task_id=TASK_ID, date=date(2026, 5, 1), start_hour=Decimal("9"), end_hour=Decimal("10"),
+    )
+    assert b.source == "manual"
+
+
+def test_create_rejects_missing_task_id() -> None:
+    """ScheduleBlockCreate without task_id must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockCreate(date=date(2026, 5, 1), start_hour=Decimal("9"), end_hour=Decimal("10"))  # type: ignore[call-arg]
+
+
+def test_create_rejects_missing_date() -> None:
+    """ScheduleBlockCreate without date must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockCreate(task_id=TASK_ID, start_hour=Decimal("9"), end_hour=Decimal("10"))  # type: ignore[call-arg]
+
+
+def test_create_rejects_missing_start_hour() -> None:
+    """ScheduleBlockCreate without start_hour must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockCreate(task_id=TASK_ID, date=date(2026, 5, 1), end_hour=Decimal("10"))  # type: ignore[call-arg]
+
+
+def test_create_rejects_missing_end_hour() -> None:
+    """ScheduleBlockCreate without end_hour must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockCreate(task_id=TASK_ID, date=date(2026, 5, 1), start_hour=Decimal("9"))  # type: ignore[call-arg]
+
+
+def test_create_rejects_start_equal_end() -> None:
+    """ScheduleBlockCreate must reject start_hour == end_hour."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockCreate(
+            task_id=TASK_ID, date=date(2026, 5, 1),
+            start_hour=Decimal("10"), end_hour=Decimal("10"),
+        )
+
+
+def test_create_rejects_start_gt_end() -> None:
+    """ScheduleBlockCreate must reject start_hour > end_hour."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockCreate(
+            task_id=TASK_ID, date=date(2026, 5, 1),
+            start_hour=Decimal("15"), end_hour=Decimal("10"),
+        )
+
+
+def test_create_rejects_negative_start_hour() -> None:
+    """ScheduleBlockCreate must reject negative start_hour."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockCreate(
+            task_id=TASK_ID, date=date(2026, 5, 1),
+            start_hour=Decimal("-1"), end_hour=Decimal("10"),
+        )
+
+
+def test_create_rejects_start_hour_above_24() -> None:
+    """ScheduleBlockCreate must reject start_hour > 24."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockCreate(
+            task_id=TASK_ID, date=date(2026, 5, 1),
+            start_hour=Decimal("24.01"), end_hour=Decimal("25"),
+        )
+
+
+def test_create_rejects_end_hour_above_24() -> None:
+    """ScheduleBlockCreate must reject end_hour > 24."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockCreate(
+            task_id=TASK_ID, date=date(2026, 5, 1),
+            start_hour=Decimal("9"), end_hour=Decimal("24.01"),
+        )
+
+
+def test_create_accepts_boundary_hours() -> None:
+    """ScheduleBlockCreate must accept start_hour=0, end_hour=24."""
+    b = ScheduleBlockCreate(
+        task_id=TASK_ID, date=date(2026, 5, 1),
+        start_hour=Decimal("0"), end_hour=Decimal("24"),
+    )
+    assert b.start_hour == Decimal("0")
+    assert b.end_hour == Decimal("24")
+
+
+def test_create_rejects_invalid_source() -> None:
+    """ScheduleBlockCreate must reject invalid source values."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockCreate(
+            task_id=TASK_ID, date=date(2026, 5, 1),
+            start_hour=Decimal("9"), end_hour=Decimal("10"),
+            source="outlook",
+        )
+
+
+def test_create_accepts_valid_sources() -> None:
+    """ScheduleBlockCreate must accept both valid source values."""
+    b1 = ScheduleBlockCreate(
+        task_id=TASK_ID, date=date(2026, 5, 1),
+        start_hour=Decimal("9"), end_hour=Decimal("10"),
+        source="manual",
+    )
+    assert b1.source == "manual"
+    b2 = ScheduleBlockCreate(
+        task_id=TASK_ID, date=date(2026, 5, 1),
+        start_hour=Decimal("9"), end_hour=Decimal("10"),
+        source="google_calendar",
+    )
+    assert b2.source == "google_calendar"
+
+
+def test_create_accepts_decimal_hours() -> None:
+    """ScheduleBlockCreate must accept fractional hours (e.g. 9.5 = 9:30)."""
+    b = ScheduleBlockCreate(
+        task_id=TASK_ID, date=date(2026, 5, 1),
+        start_hour=Decimal("9.5"), end_hour=Decimal("10.75"),
+    )
+    assert b.start_hour == Decimal("9.5")
+    assert b.end_hour == Decimal("10.75")
+
+
+# ---------------------------------------------------------------------------
+# ScheduleBlockUpdate
+# ---------------------------------------------------------------------------
+
+
+def test_update_all_fields_optional() -> None:
+    """ScheduleBlockUpdate must allow empty (no fields set)."""
+    u = ScheduleBlockUpdate()
+    assert u.date is None
+    assert u.start_hour is None
+    assert u.end_hour is None
+    assert u.source is None
+
+
+def test_update_rejects_start_gte_end_when_both_provided() -> None:
+    """ScheduleBlockUpdate must reject start_hour >= end_hour when both set."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockUpdate(start_hour=Decimal("10"), end_hour=Decimal("9"))
+
+
+def test_update_allows_partial_hour_update() -> None:
+    """ScheduleBlockUpdate must allow setting only one of start/end hour."""
+    u = ScheduleBlockUpdate(start_hour=Decimal("8"))
+    assert u.start_hour == Decimal("8")
+    assert u.end_hour is None
+
+
+def test_update_rejects_invalid_source() -> None:
+    """ScheduleBlockUpdate must reject invalid source values."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockUpdate(source="outlook")
+
+
+def test_update_rejects_out_of_range_hours() -> None:
+    """ScheduleBlockUpdate must reject hours outside 0-24 range."""
+    with pytest.raises(ValidationError):
+        ScheduleBlockUpdate(start_hour=Decimal("-1"))
+    with pytest.raises(ValidationError):
+        ScheduleBlockUpdate(end_hour=Decimal("24.01"))
+
+
+# ---------------------------------------------------------------------------
+# ScheduleBlockResponse
+# ---------------------------------------------------------------------------
+
+
+def test_response_from_attributes() -> None:
+    """ScheduleBlockResponse must support from_attributes (ORM mode)."""
+    assert ScheduleBlockResponse.model_config.get("from_attributes") is True
+
+
+def test_response_round_trip() -> None:
+    """ScheduleBlockResponse must serialize all fields."""
+    now = datetime.now(UTC)
+    bid = uuid.uuid4()
+    resp = ScheduleBlockResponse(
+        id=bid,
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9.00"),
+        end_hour=Decimal("10.50"),
+        source="manual",
+        created_at=now,
+    )
+    assert resp.id == bid
+    assert resp.task_id == TASK_ID
+    assert resp.source == "manual"

--- a/backend/tests/unit/test_schedule_block_service.py
+++ b/backend/tests/unit/test_schedule_block_service.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, UTC
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.schedule_block import ScheduleBlock, ScheduleBlockSource
+from app.schemas.schedule_block import ScheduleBlockCreate, ScheduleBlockUpdate
+from app.services.schedule_block_service import (
+    create_schedule_block,
+    delete_schedule_block,
+    get_schedule_block,
+    list_schedule_blocks,
+    update_schedule_block,
+)
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+OTHER_USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+PROJECT_ID = uuid.UUID("00000000-0000-0000-0000-aaaaaaaaaaaa")
+TASK_ID = uuid.UUID("00000000-0000-0000-0000-bbbbbbbbbbbb")
+BLOCK_ID = uuid.UUID("00000000-0000-0000-0000-cccccccccccc")
+
+
+def _make_fake_block(**overrides: object) -> MagicMock:
+    defaults = {
+        "id": BLOCK_ID,
+        "task_id": TASK_ID,
+        "date": date(2026, 5, 1),
+        "start_hour": Decimal("9.00"),
+        "end_hour": Decimal("10.00"),
+        "source": ScheduleBlockSource.MANUAL,
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    fake = MagicMock(spec=ScheduleBlock)
+    for k, v in defaults.items():
+        setattr(fake, k, v)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# _get_block_with_ownership
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_block_returns_block_for_owner() -> None:
+    """get_schedule_block must return block when user owns it."""
+    fake = _make_fake_block()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    result = await get_schedule_block(db=db, block_id=BLOCK_ID, user_id=USER_ID)
+
+    assert result == fake
+
+
+@pytest.mark.asyncio
+async def test_get_block_raises_404_when_not_found() -> None:
+    """get_schedule_block must raise 404 when block doesn't exist or user doesn't own it."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_schedule_block(db=db, block_id=BLOCK_ID, user_id=USER_ID)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Schedule block not found"
+
+
+@pytest.mark.asyncio
+async def test_get_block_query_joins_task_and_project() -> None:
+    """get_schedule_block query must JOIN tasks and projects for ownership."""
+    fake = _make_fake_block()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await get_schedule_block(db=db, block_id=BLOCK_ID, user_id=USER_ID)
+
+    executed_stmt = db.execute.call_args[0][0]
+    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "tasks" in compiled.lower()
+    assert "projects" in compiled.lower()
+    assert "JOIN" in compiled.upper()
+
+
+# ---------------------------------------------------------------------------
+# create_schedule_block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_block_returns_block() -> None:
+    """create_schedule_block must add, commit, refresh and return block."""
+    db = AsyncMock()
+    # Mock for task ownership check
+    mock_task_result = MagicMock()
+    mock_task_result.scalar_one_or_none.return_value = MagicMock()
+    # Mock for overlap check
+    mock_overlap_result = MagicMock()
+    mock_overlap_result.scalar_one_or_none.return_value = None
+    db.execute.side_effect = [mock_task_result, mock_overlap_result]
+
+    data = ScheduleBlockCreate(
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9"),
+        end_hour=Decimal("10"),
+    )
+    result = await create_schedule_block(db=db, user_id=USER_ID, data=data)
+
+    db.add.assert_called_once()
+    db.commit.assert_awaited_once()
+    db.refresh.assert_awaited_once()
+    assert isinstance(result, ScheduleBlock)
+
+
+@pytest.mark.asyncio
+async def test_create_block_raises_404_for_wrong_task_owner() -> None:
+    """create_schedule_block must raise 404 if task doesn't belong to user."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    data = ScheduleBlockCreate(
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9"),
+        end_hour=Decimal("10"),
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await create_schedule_block(db=db, user_id=USER_ID, data=data)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_block_raises_409_on_overlap() -> None:
+    """create_schedule_block must raise 409 when overlapping block exists."""
+    db = AsyncMock()
+    # Task ownership OK
+    mock_task_result = MagicMock()
+    mock_task_result.scalar_one_or_none.return_value = MagicMock()
+    # Overlap found
+    mock_overlap_result = MagicMock()
+    mock_overlap_result.scalar_one_or_none.return_value = _make_fake_block()
+    db.execute.side_effect = [mock_task_result, mock_overlap_result]
+
+    data = ScheduleBlockCreate(
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9"),
+        end_hour=Decimal("10"),
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await create_schedule_block(db=db, user_id=USER_ID, data=data)
+
+    assert exc_info.value.status_code == 409
+    assert "overlap" in exc_info.value.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# list_schedule_blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_blocks_returns_blocks_for_date() -> None:
+    """list_schedule_blocks must return blocks for the given date."""
+    fake1 = _make_fake_block()
+    fake2 = _make_fake_block()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [fake1, fake2]
+    db.execute.return_value = mock_result
+
+    result = await list_schedule_blocks(db=db, user_id=USER_ID, query_date=date(2026, 5, 1))
+
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_blocks_returns_empty_for_no_blocks() -> None:
+    """list_schedule_blocks must return empty list, not 404."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    result = await list_schedule_blocks(db=db, user_id=USER_ID, query_date=date(2026, 5, 1))
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_blocks_scopes_to_user() -> None:
+    """list_schedule_blocks query must filter by user ownership."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_schedule_blocks(db=db, user_id=USER_ID, query_date=date(2026, 5, 1))
+
+    executed_stmt = db.execute.call_args[0][0]
+    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "projects" in compiled.lower()
+    assert "JOIN" in compiled.upper()
+
+
+# ---------------------------------------------------------------------------
+# update_schedule_block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_block_applies_changes() -> None:
+    """update_schedule_block must apply provided fields."""
+    fake = _make_fake_block()
+    db = AsyncMock()
+    # Ownership query
+    mock_own_result = MagicMock()
+    mock_own_result.scalar_one_or_none.return_value = fake
+    # Overlap check
+    mock_overlap_result = MagicMock()
+    mock_overlap_result.scalar_one_or_none.return_value = None
+    db.execute.side_effect = [mock_own_result, mock_overlap_result]
+
+    data = ScheduleBlockUpdate(start_hour=Decimal("8"), end_hour=Decimal("11"))
+    result = await update_schedule_block(
+        db=db, block_id=BLOCK_ID, user_id=USER_ID, data=data,
+    )
+
+    assert result == fake
+    db.commit.assert_awaited_once()
+    db.refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_block_raises_404_when_not_found() -> None:
+    """update_schedule_block must raise 404 for missing/unauthorized block."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    data = ScheduleBlockUpdate(start_hour=Decimal("8"))
+    with pytest.raises(HTTPException) as exc_info:
+        await update_schedule_block(db=db, block_id=BLOCK_ID, user_id=USER_ID, data=data)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_block_raises_409_on_overlap() -> None:
+    """update_schedule_block must raise 409 when update causes overlap."""
+    fake = _make_fake_block()
+    db = AsyncMock()
+    mock_own_result = MagicMock()
+    mock_own_result.scalar_one_or_none.return_value = fake
+    # Overlap found (different block)
+    other_block = _make_fake_block(id=uuid.uuid4())
+    mock_overlap_result = MagicMock()
+    mock_overlap_result.scalar_one_or_none.return_value = other_block
+    db.execute.side_effect = [mock_own_result, mock_overlap_result]
+
+    data = ScheduleBlockUpdate(start_hour=Decimal("9"), end_hour=Decimal("10"))
+    with pytest.raises(HTTPException) as exc_info:
+        await update_schedule_block(db=db, block_id=BLOCK_ID, user_id=USER_ID, data=data)
+
+    assert exc_info.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# delete_schedule_block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_block_removes_block() -> None:
+    """delete_schedule_block must delete and commit."""
+    fake = _make_fake_block()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await delete_schedule_block(db=db, block_id=BLOCK_ID, user_id=USER_ID)
+
+    db.delete.assert_awaited_once_with(fake)
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_block_raises_404_when_not_found() -> None:
+    """delete_schedule_block must raise 404 for missing/unauthorized block."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await delete_schedule_block(db=db, block_id=BLOCK_ID, user_id=USER_ID)
+
+    assert exc_info.value.status_code == 404

--- a/backend/tests/unit/test_schedule_block_service.py
+++ b/backend/tests/unit/test_schedule_block_service.py
@@ -108,7 +108,7 @@ async def test_create_block_returns_block() -> None:
     mock_task_result.scalar_one_or_none.return_value = MagicMock()
     # Mock for overlap check
     mock_overlap_result = MagicMock()
-    mock_overlap_result.scalar_one_or_none.return_value = None
+    mock_overlap_result.scalars.return_value.first.return_value = None
     db.execute.side_effect = [mock_task_result, mock_overlap_result]
 
     data = ScheduleBlockCreate(
@@ -154,7 +154,7 @@ async def test_create_block_raises_409_on_overlap() -> None:
     mock_task_result.scalar_one_or_none.return_value = MagicMock()
     # Overlap found
     mock_overlap_result = MagicMock()
-    mock_overlap_result.scalar_one_or_none.return_value = _make_fake_block()
+    mock_overlap_result.scalars.return_value.first.return_value = _make_fake_block()
     db.execute.side_effect = [mock_task_result, mock_overlap_result]
 
     data = ScheduleBlockCreate(
@@ -246,7 +246,7 @@ async def test_update_block_applies_changes() -> None:
     mock_own_result.scalar_one_or_none.return_value = fake
     # Overlap check
     mock_overlap_result = MagicMock()
-    mock_overlap_result.scalar_one_or_none.return_value = None
+    mock_overlap_result.scalars.return_value.first.return_value = None
     db.execute.side_effect = [mock_own_result, mock_overlap_result]
 
     data = ScheduleBlockUpdate(start_hour=Decimal("8"), end_hour=Decimal("11"))
@@ -292,7 +292,7 @@ async def test_update_block_raises_409_on_overlap() -> None:
     # Overlap found (different block)
     other_block = _make_fake_block(id=uuid.uuid4())
     mock_overlap_result = MagicMock()
-    mock_overlap_result.scalar_one_or_none.return_value = other_block
+    mock_overlap_result.scalars.return_value.first.return_value = other_block
     db.execute.side_effect = [mock_own_result, mock_overlap_result]
 
     data = ScheduleBlockUpdate(start_hour=Decimal("9"), end_hour=Decimal("10"))
@@ -305,6 +305,31 @@ async def test_update_block_raises_409_on_overlap() -> None:
         )
 
     assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_update_block_rejects_partial_hour_inversion() -> None:
+    """update with only start_hour > existing end_hour must return 422."""
+    fake = _make_fake_block(
+        start_hour=Decimal("9"),
+        end_hour=Decimal("10"),
+    )
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    data = ScheduleBlockUpdate(start_hour=Decimal("15"))
+    with pytest.raises(HTTPException) as exc_info:
+        await update_schedule_block(
+            db=db,
+            block_id=BLOCK_ID,
+            user_id=USER_ID,
+            data=data,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "end_hour must be greater than start_hour" in exc_info.value.detail
 
 
 # ---------------------------------------------------------------------------
@@ -393,7 +418,7 @@ async def test_overlap_check_query_filters() -> None:
     mock_task_result = MagicMock()
     mock_task_result.scalar_one_or_none.return_value = MagicMock()
     mock_overlap_result = MagicMock()
-    mock_overlap_result.scalar_one_or_none.return_value = None
+    mock_overlap_result.scalars.return_value.first.return_value = None
     db.execute.side_effect = [mock_task_result, mock_overlap_result]
 
     data = ScheduleBlockCreate(
@@ -508,7 +533,7 @@ async def test_update_overlap_excludes_self() -> None:
     mock_own = MagicMock()
     mock_own.scalar_one_or_none.return_value = fake
     mock_overlap = MagicMock()
-    mock_overlap.scalar_one_or_none.return_value = None
+    mock_overlap.scalars.return_value.first.return_value = None
     db.execute.side_effect = [mock_own, mock_overlap]
 
     data = ScheduleBlockUpdate(

--- a/backend/tests/unit/test_schedule_block_service.py
+++ b/backend/tests/unit/test_schedule_block_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date, datetime, UTC
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
@@ -63,7 +63,7 @@ async def test_get_block_returns_block_for_owner() -> None:
 
 @pytest.mark.asyncio
 async def test_get_block_raises_404_when_not_found() -> None:
-    """get_schedule_block must raise 404 when block doesn't exist or user doesn't own it."""
+    """get_schedule_block must raise 404 when not found."""
     db = AsyncMock()
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = None
@@ -185,7 +185,11 @@ async def test_list_blocks_returns_blocks_for_date() -> None:
     mock_result.scalars.return_value.all.return_value = [fake1, fake2]
     db.execute.return_value = mock_result
 
-    result = await list_schedule_blocks(db=db, user_id=USER_ID, query_date=date(2026, 5, 1))
+    result = await list_schedule_blocks(
+        db=db,
+        user_id=USER_ID,
+        query_date=date(2026, 5, 1),
+    )
 
     assert len(result) == 2
 
@@ -198,7 +202,11 @@ async def test_list_blocks_returns_empty_for_no_blocks() -> None:
     mock_result.scalars.return_value.all.return_value = []
     db.execute.return_value = mock_result
 
-    result = await list_schedule_blocks(db=db, user_id=USER_ID, query_date=date(2026, 5, 1))
+    result = await list_schedule_blocks(
+        db=db,
+        user_id=USER_ID,
+        query_date=date(2026, 5, 1),
+    )
 
     assert result == []
 
@@ -211,7 +219,11 @@ async def test_list_blocks_scopes_to_user() -> None:
     mock_result.scalars.return_value.all.return_value = []
     db.execute.return_value = mock_result
 
-    await list_schedule_blocks(db=db, user_id=USER_ID, query_date=date(2026, 5, 1))
+    await list_schedule_blocks(
+        db=db,
+        user_id=USER_ID,
+        query_date=date(2026, 5, 1),
+    )
 
     executed_stmt = db.execute.call_args[0][0]
     compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
@@ -239,7 +251,10 @@ async def test_update_block_applies_changes() -> None:
 
     data = ScheduleBlockUpdate(start_hour=Decimal("8"), end_hour=Decimal("11"))
     result = await update_schedule_block(
-        db=db, block_id=BLOCK_ID, user_id=USER_ID, data=data,
+        db=db,
+        block_id=BLOCK_ID,
+        user_id=USER_ID,
+        data=data,
     )
 
     assert result == fake
@@ -257,7 +272,12 @@ async def test_update_block_raises_404_when_not_found() -> None:
 
     data = ScheduleBlockUpdate(start_hour=Decimal("8"))
     with pytest.raises(HTTPException) as exc_info:
-        await update_schedule_block(db=db, block_id=BLOCK_ID, user_id=USER_ID, data=data)
+        await update_schedule_block(
+            db=db,
+            block_id=BLOCK_ID,
+            user_id=USER_ID,
+            data=data,
+        )
 
     assert exc_info.value.status_code == 404
 
@@ -277,7 +297,12 @@ async def test_update_block_raises_409_on_overlap() -> None:
 
     data = ScheduleBlockUpdate(start_hour=Decimal("9"), end_hour=Decimal("10"))
     with pytest.raises(HTTPException) as exc_info:
-        await update_schedule_block(db=db, block_id=BLOCK_ID, user_id=USER_ID, data=data)
+        await update_schedule_block(
+            db=db,
+            block_id=BLOCK_ID,
+            user_id=USER_ID,
+            data=data,
+        )
 
     assert exc_info.value.status_code == 409
 

--- a/backend/tests/unit/test_schedule_block_service.py
+++ b/backend/tests/unit/test_schedule_block_service.py
@@ -339,3 +339,192 @@ async def test_delete_block_raises_404_when_not_found() -> None:
         await delete_schedule_block(db=db, block_id=BLOCK_ID, user_id=USER_ID)
 
     assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Schedule block not found"
+
+
+# ---------------------------------------------------------------------------
+# SQL WHERE clause verification (mutation killing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_block_query_where_clauses() -> None:
+    """Ownership query must filter by block_id AND user_id."""
+    fake = _make_fake_block()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await get_schedule_block(db=db, block_id=BLOCK_ID, user_id=USER_ID)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert BLOCK_ID.hex in compiled
+    assert USER_ID.hex in compiled
+
+
+@pytest.mark.asyncio
+async def test_list_blocks_query_where_clauses() -> None:
+    """List query must filter by user_id AND date."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_schedule_blocks(
+        db=db,
+        user_id=USER_ID,
+        query_date=date(2026, 5, 1),
+    )
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert USER_ID.hex in compiled
+    assert "2026-05-01" in compiled
+
+
+@pytest.mark.asyncio
+async def test_overlap_check_query_filters() -> None:
+    """Overlap check must filter by user, date, and time range."""
+    db = AsyncMock()
+    mock_task_result = MagicMock()
+    mock_task_result.scalar_one_or_none.return_value = MagicMock()
+    mock_overlap_result = MagicMock()
+    mock_overlap_result.scalar_one_or_none.return_value = None
+    db.execute.side_effect = [mock_task_result, mock_overlap_result]
+
+    data = ScheduleBlockCreate(
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9"),
+        end_hour=Decimal("10"),
+    )
+    await create_schedule_block(db=db, user_id=USER_ID, data=data)
+
+    overlap_compiled = str(
+        db.execute.call_args_list[1][0][0].compile(
+            compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert "2026-05-01" in overlap_compiled
+    assert USER_ID.hex in overlap_compiled
+
+
+@pytest.mark.asyncio
+async def test_create_block_verify_task_query_checks_user() -> None:
+    """Task ownership query must check user_id."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    data = ScheduleBlockCreate(
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9"),
+        end_hour=Decimal("10"),
+    )
+    with pytest.raises(HTTPException):
+        await create_schedule_block(db=db, user_id=USER_ID, data=data)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert TASK_ID.hex in compiled
+    assert USER_ID.hex in compiled
+
+
+@pytest.mark.asyncio
+async def test_create_block_detail_on_task_not_found() -> None:
+    """create_schedule_block must say 'Task not found'."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    data = ScheduleBlockCreate(
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9"),
+        end_hour=Decimal("10"),
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await create_schedule_block(db=db, user_id=USER_ID, data=data)
+
+    assert exc_info.value.detail == "Task not found"
+
+
+@pytest.mark.asyncio
+async def test_create_block_overlap_detail() -> None:
+    """create_schedule_block overlap detail message."""
+    db = AsyncMock()
+    mock_task = MagicMock()
+    mock_task.scalar_one_or_none.return_value = MagicMock()
+    mock_overlap = MagicMock()
+    mock_overlap.scalar_one_or_none.return_value = _make_fake_block()
+    db.execute.side_effect = [mock_task, mock_overlap]
+
+    data = ScheduleBlockCreate(
+        task_id=TASK_ID,
+        date=date(2026, 5, 1),
+        start_hour=Decimal("9"),
+        end_hour=Decimal("10"),
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await create_schedule_block(db=db, user_id=USER_ID, data=data)
+
+    assert exc_info.value.detail == ("Schedule block overlaps with an existing block")
+
+
+@pytest.mark.asyncio
+async def test_update_skips_overlap_for_non_time_changes() -> None:
+    """update should skip overlap check for non-time fields."""
+    fake = _make_fake_block()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    data = ScheduleBlockUpdate(source="google_calendar")
+    await update_schedule_block(
+        db=db,
+        block_id=BLOCK_ID,
+        user_id=USER_ID,
+        data=data,
+    )
+
+    # Only 1 DB call (ownership), no overlap check
+    assert db.execute.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_update_overlap_excludes_self() -> None:
+    """update overlap check must exclude the block being updated."""
+    fake = _make_fake_block()
+    db = AsyncMock()
+    mock_own = MagicMock()
+    mock_own.scalar_one_or_none.return_value = fake
+    mock_overlap = MagicMock()
+    mock_overlap.scalar_one_or_none.return_value = None
+    db.execute.side_effect = [mock_own, mock_overlap]
+
+    data = ScheduleBlockUpdate(
+        start_hour=Decimal("8"),
+        end_hour=Decimal("11"),
+    )
+    await update_schedule_block(
+        db=db,
+        block_id=BLOCK_ID,
+        user_id=USER_ID,
+        data=data,
+    )
+
+    overlap_compiled = str(
+        db.execute.call_args_list[1][0][0].compile(
+            compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert BLOCK_ID.hex in overlap_compiled


### PR DESCRIPTION
## Summary
- Add ScheduleBlock SQLAlchemy model with UUID PK, FK to tasks (CASCADE), `Numeric(4,2)` hours, source enum, check constraints (`end_hour > start_hour`, valid source), and composite index on (date, task_id)
- Add Pydantic v2 schemas with `@model_validator` for end > start, `Field(ge=0, le=24)` hour bounds, and source enum validation
- Add async service layer with 3-table ownership join (ScheduleBlock → Task → Project → User), overlap detection (409 Conflict), and partial-hour inversion guard (422)
- Add flat REST routes: `POST /schedule-blocks` (201), `GET /schedule-blocks?date=` (200), `GET /schedule-blocks/{id}` (200), `PUT /schedule-blocks/{id}` (200), `DELETE /schedule-blocks/{id}` (204) — all auth-gated
- Add Alembic migration `0005_add_schedule_blocks_table`
- 69 unit tests across model, schema, service, and route layers

## Test plan
- [x] `pytest -x -q` — 69 tests pass
- [x] `ruff check . && ruff format .` — no lint issues
- [x] PR review (`/review-pr-v2`) — APPROVE, zero findings

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)