### PR TITLE
Implement TimeEntry model and CRUD API (#20)

### DIFF
--- a/backend/alembic/versions/0006_add_time_entries_table.py
+++ b/backend/alembic/versions/0006_add_time_entries_table.py
@@ -1,0 +1,46 @@
+"""add time_entries table
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-04-15
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0006"
+down_revision: str = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "time_entries",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "task_id",
+            sa.UUID(),
+            sa.ForeignKey("tasks.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("duration_seconds", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "idx_time_entry_task_started", "time_entries", ["task_id", "started_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_time_entry_task_started", table_name="time_entries")
+    op.drop_table("time_entries")

--- a/backend/alembic/versions/0006_add_time_entries_table.py
+++ b/backend/alembic/versions/0006_add_time_entries_table.py
@@ -34,7 +34,12 @@ def upgrade() -> None:
         sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("duration_seconds", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
     )
     op.create_index(
         "idx_time_entry_task_started", "time_entries", ["task_id", "started_at"]

--- a/backend/app/api/time_entries.py
+++ b/backend/app/api/time_entries.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.models.user import User
+from app.schemas.time_entry import TimeEntryResponse, TimeEntryStart
+from app.services.time_entry_service import (
+    delete_time_entry,
+    list_time_entries,
+    start_timer,
+    stop_timer,
+)
+
+router = APIRouter(prefix="/time-entries", tags=["time-entries"])
+
+
+@router.post(
+    "/start",
+    response_model=TimeEntryResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def start_timer_route(
+    body: TimeEntryStart,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> TimeEntryResponse:
+    """Start a new timer for a task."""
+    entry = await start_timer(db=db, user_id=current_user.id, data=body)
+    return TimeEntryResponse.model_validate(entry)
+
+
+@router.post("/{entry_id}/stop", response_model=TimeEntryResponse)
+async def stop_timer_route(
+    entry_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> TimeEntryResponse:
+    """Stop a running timer."""
+    entry = await stop_timer(db=db, entry_id=entry_id, user_id=current_user.id)
+    return TimeEntryResponse.model_validate(entry)
+
+
+@router.get("", response_model=list[TimeEntryResponse])
+async def list_time_entries_route(
+    task_id: uuid.UUID | None = Query(default=None),
+    date: date | None = Query(default=None),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[TimeEntryResponse]:
+    """List time entries with optional filters."""
+    entries = await list_time_entries(
+        db=db, user_id=current_user.id, task_id=task_id, query_date=date
+    )
+    return [TimeEntryResponse.model_validate(e) for e in entries]
+
+
+@router.delete(
+    "/{entry_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None
+)
+async def delete_time_entry_route(
+    entry_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Delete a time entry."""
+    await delete_time_entry(db=db, entry_id=entry_id, user_id=current_user.id)

--- a/backend/app/api/time_entries.py
+++ b/backend/app/api/time_entries.py
@@ -49,13 +49,13 @@ async def stop_timer_route(
 @router.get("", response_model=list[TimeEntryResponse])
 async def list_time_entries_route(
     task_id: uuid.UUID | None = Query(default=None),
-    date: date | None = Query(default=None),
+    entry_date: date | None = Query(default=None, alias="date"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[TimeEntryResponse]:
     """List time entries with optional filters."""
     entries = await list_time_entries(
-        db=db, user_id=current_user.id, task_id=task_id, query_date=date
+        db=db, user_id=current_user.id, task_id=task_id, query_date=entry_date
     )
     return [TimeEntryResponse.model_validate(e) for e in entries]
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from app.api.health import router as health_router
 from app.api.projects import router as projects_router
 from app.api.schedule_blocks import router as schedule_blocks_router
 from app.api.tasks import router as tasks_router
+from app.api.time_entries import router as time_entries_router
 from app.core.config import settings
 from app.core.database import dispose_engine, init_engine
 from app.core.redis import close_redis, init_redis
@@ -48,6 +49,7 @@ def create_app() -> FastAPI:
     app.include_router(projects_router)
     app.include_router(tasks_router)
     app.include_router(schedule_blocks_router)
+    app.include_router(time_entries_router)
 
     return app
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 from app.models.project import Project
 from app.models.schedule_block import ScheduleBlock
 from app.models.task import Task
+from app.models.time_entry import TimeEntry
 from app.models.user import User
 
-__all__ = ["Project", "ScheduleBlock", "Task", "User"]
+__all__ = ["Project", "ScheduleBlock", "Task", "TimeEntry", "User"]

--- a/backend/app/models/time_entry.py
+++ b/backend/app/models/time_entry.py
@@ -14,9 +14,7 @@ class TimeEntry(Base):
     """Time entry entity — see docs/DATA_MODEL.md for full specification."""
 
     __tablename__ = "time_entries"
-    __table_args__ = (
-        Index("idx_time_entry_task_started", "task_id", "started_at"),
-    )
+    __table_args__ = (Index("idx_time_entry_task_started", "task_id", "started_at"),)
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4

--- a/backend/app/models/time_entry.py
+++ b/backend/app/models/time_entry.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class TimeEntry(Base):
+    """Time entry entity — see docs/DATA_MODEL.md for full specification."""
+
+    __tablename__ = "time_entries"
+    __table_args__ = (
+        Index("idx_time_entry_task_started", "task_id", "started_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    task_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tasks.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    duration_seconds: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    def __repr__(self) -> str:
+        return f"<TimeEntry(id={self.id})>"

--- a/backend/app/schemas/time_entry.py
+++ b/backend/app/schemas/time_entry.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TimeEntryStart(BaseModel):
+    """Schema for starting a new timer."""
+
+    task_id: uuid.UUID
+    started_at: datetime | None = None
+
+
+class TimeEntryResponse(BaseModel):
+    """Public time entry representation."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    task_id: uuid.UUID
+    started_at: datetime
+    ended_at: datetime | None
+    duration_seconds: int | None
+    created_at: datetime

--- a/backend/app/services/ownership.py
+++ b/backend/app/services/ownership.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project import Project
+from app.models.task import Task
+
+
+async def verify_task_ownership(
+    db: AsyncSession,
+    task_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    """Verify that the task exists and belongs to the user via Project.
+
+    Returns 404 for missing task or ownership mismatch (prevents ID enumeration).
+    """
+    stmt = (
+        select(Task)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            Task.id == task_id,
+            Project.user_id == user_id,
+        )
+    )
+    result = await db.execute(stmt)
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found",
+        )

--- a/backend/app/services/schedule_block_service.py
+++ b/backend/app/services/schedule_block_service.py
@@ -11,6 +11,7 @@ from app.models.project import Project
 from app.models.schedule_block import ScheduleBlock
 from app.models.task import Task
 from app.schemas.schedule_block import ScheduleBlockCreate, ScheduleBlockUpdate
+from app.services.ownership import verify_task_ownership
 
 
 async def _get_block_with_ownership(
@@ -39,28 +40,6 @@ async def _get_block_with_ownership(
             detail="Schedule block not found",
         )
     return block
-
-
-async def _verify_task_ownership(
-    db: AsyncSession,
-    task_id: uuid.UUID,
-    user_id: uuid.UUID,
-) -> None:
-    """Verify that the task exists and belongs to the user via Project."""
-    stmt = (
-        select(Task)
-        .join(Project, Task.project_id == Project.id)
-        .where(
-            Task.id == task_id,
-            Project.user_id == user_id,
-        )
-    )
-    result = await db.execute(stmt)
-    if result.scalar_one_or_none() is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Task not found",
-        )
 
 
 async def _check_overlap(
@@ -99,7 +78,7 @@ async def create_schedule_block(
     data: ScheduleBlockCreate,
 ) -> ScheduleBlock:
     """Create a new schedule block, verifying task ownership and no overlap."""
-    await _verify_task_ownership(db, data.task_id, user_id)
+    await verify_task_ownership(db, data.task_id, user_id)
     await _check_overlap(db, user_id, data.date, data.start_hour, data.end_hour)
 
     block = ScheduleBlock(

--- a/backend/app/services/time_entry_service.py
+++ b/backend/app/services/time_entry_service.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime, timedelta
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project import Project
+from app.models.task import Task
+from app.models.time_entry import TimeEntry
+from app.schemas.time_entry import TimeEntryStart
+
+
+async def _verify_task_ownership(
+    db: AsyncSession,
+    task_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    """Verify that the task exists and belongs to the user via Project."""
+    stmt = (
+        select(Task)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            Task.id == task_id,
+            Project.user_id == user_id,
+        )
+    )
+    result = await db.execute(stmt)
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found",
+        )
+
+
+async def _check_no_active_timer(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> None:
+    """Raise 409 if the user already has an active (unstopped) timer."""
+    stmt = (
+        select(TimeEntry)
+        .join(Task, TimeEntry.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            Project.user_id == user_id,
+            TimeEntry.ended_at.is_(None),
+        )
+    )
+    result = await db.execute(stmt)
+    if result.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="User already has an active timer",
+        )
+
+
+async def _get_entry_with_ownership(
+    db: AsyncSession,
+    entry_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> TimeEntry:
+    """Fetch a time entry verifying the user owns it via Task -> Project."""
+    stmt = (
+        select(TimeEntry)
+        .join(Task, TimeEntry.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            TimeEntry.id == entry_id,
+            Project.user_id == user_id,
+        )
+    )
+    result = await db.execute(stmt)
+    entry = result.scalar_one_or_none()
+    if entry is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Time entry not found",
+        )
+    return entry
+
+
+async def start_timer(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    data: TimeEntryStart,
+) -> TimeEntry:
+    """Start a new timer, verifying task ownership and no active timer."""
+    await _verify_task_ownership(db, data.task_id, user_id)
+    await _check_no_active_timer(db, user_id)
+
+    entry = TimeEntry(
+        task_id=data.task_id,
+        started_at=data.started_at or datetime.now(UTC),
+    )
+    db.add(entry)
+    await db.commit()
+    await db.refresh(entry)
+    return entry
+
+
+async def stop_timer(
+    db: AsyncSession,
+    entry_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> TimeEntry:
+    """Stop a running timer, computing duration_seconds."""
+    entry = await _get_entry_with_ownership(db, entry_id, user_id)
+
+    if entry.ended_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Timer already stopped",
+        )
+
+    now = datetime.now(UTC)
+    entry.ended_at = now
+    entry.duration_seconds = int((now - entry.started_at).total_seconds())
+    await db.commit()
+    await db.refresh(entry)
+    return entry
+
+
+async def list_time_entries(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    task_id: uuid.UUID | None = None,
+    query_date: date | None = None,
+) -> list[TimeEntry]:
+    """List time entries for the user with optional filters."""
+    stmt = (
+        select(TimeEntry)
+        .join(Task, TimeEntry.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(Project.user_id == user_id)
+    )
+
+    if task_id is not None:
+        stmt = stmt.where(TimeEntry.task_id == task_id)
+
+    if query_date is not None:
+        day_start = datetime(
+            query_date.year, query_date.month, query_date.day, tzinfo=UTC
+        )
+        day_end = day_start + timedelta(days=1)
+        stmt = stmt.where(
+            TimeEntry.started_at >= day_start,
+            TimeEntry.started_at < day_end,
+        )
+
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def delete_time_entry(
+    db: AsyncSession,
+    entry_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    """Delete a time entry, enforcing ownership."""
+    entry = await _get_entry_with_ownership(db, entry_id, user_id)
+    await db.delete(entry)
+    await db.commit()

--- a/backend/app/services/time_entry_service.py
+++ b/backend/app/services/time_entry_service.py
@@ -11,35 +11,18 @@ from app.models.project import Project
 from app.models.task import Task
 from app.models.time_entry import TimeEntry
 from app.schemas.time_entry import TimeEntryStart
-
-
-async def _verify_task_ownership(
-    db: AsyncSession,
-    task_id: uuid.UUID,
-    user_id: uuid.UUID,
-) -> None:
-    """Verify that the task exists and belongs to the user via Project."""
-    stmt = (
-        select(Task)
-        .join(Project, Task.project_id == Project.id)
-        .where(
-            Task.id == task_id,
-            Project.user_id == user_id,
-        )
-    )
-    result = await db.execute(stmt)
-    if result.scalar_one_or_none() is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Task not found",
-        )
+from app.services.ownership import verify_task_ownership
 
 
 async def _check_no_active_timer(
     db: AsyncSession,
     user_id: uuid.UUID,
 ) -> None:
-    """Raise 409 if the user already has an active (unstopped) timer."""
+    """Raise 409 if the user already has an active (unstopped) timer.
+
+    Uses FOR UPDATE to prevent race conditions where two concurrent
+    requests could both pass the check and create duplicate active timers.
+    """
     stmt = (
         select(TimeEntry)
         .join(Task, TimeEntry.task_id == Task.id)
@@ -48,9 +31,10 @@ async def _check_no_active_timer(
             Project.user_id == user_id,
             TimeEntry.ended_at.is_(None),
         )
+        .with_for_update()
     )
     result = await db.execute(stmt)
-    if result.scalar_one_or_none() is not None:
+    if result.scalars().first() is not None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="User already has an active timer",
@@ -88,13 +72,11 @@ async def start_timer(
     data: TimeEntryStart,
 ) -> TimeEntry:
     """Start a new timer, verifying task ownership and no active timer."""
-    await _verify_task_ownership(db, data.task_id, user_id)
+    await verify_task_ownership(db, data.task_id, user_id)
     await _check_no_active_timer(db, user_id)
 
-    entry = TimeEntry(
-        task_id=data.task_id,
-        started_at=data.started_at or datetime.now(UTC),
-    )
+    started = data.started_at if data.started_at is not None else datetime.now(UTC)
+    entry = TimeEntry(task_id=data.task_id, started_at=started)
     db.add(entry)
     await db.commit()
     await db.refresh(entry)

--- a/backend/tests/unit/test_time_entry_model.py
+++ b/backend/tests/unit/test_time_entry_model.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import inspect
+
+from app.models.time_entry import TimeEntry
+
+
+def test_time_entry_table_name() -> None:
+    """TimeEntry.__tablename__ must be 'time_entries'."""
+    assert TimeEntry.__tablename__ == "time_entries"
+
+
+def test_time_entry_has_required_columns() -> None:
+    """TimeEntry must have all columns from DATA_MODEL.md."""
+    columns = {c.name for c in inspect(TimeEntry).columns}
+    expected = {
+        "id",
+        "task_id",
+        "started_at",
+        "ended_at",
+        "duration_seconds",
+        "created_at",
+    }
+    assert expected.issubset(columns), f"Missing columns: {expected - columns}"
+
+
+def test_time_entry_id_is_uuid() -> None:
+    """TimeEntry.id column type must be UUID."""
+    col = inspect(TimeEntry).columns["id"]
+    assert "UUID" in str(col.type).upper()
+
+
+def test_time_entry_task_id_is_foreign_key() -> None:
+    """TimeEntry.task_id must reference tasks.id."""
+    col = inspect(TimeEntry).columns["task_id"]
+    fk_targets = {fk.target_fullname for fk in col.foreign_keys}
+    assert "tasks.id" in fk_targets
+
+
+def test_time_entry_task_id_cascade_delete() -> None:
+    """TimeEntry.task_id FK must have ondelete CASCADE."""
+    col = inspect(TimeEntry).columns["task_id"]
+    for fk in col.foreign_keys:
+        if fk.target_fullname == "tasks.id":
+            assert fk.ondelete == "CASCADE"
+
+
+def test_time_entry_task_id_not_nullable() -> None:
+    """TimeEntry.task_id must be NOT NULL."""
+    col = inspect(TimeEntry).columns["task_id"]
+    assert col.nullable is False
+
+
+def test_time_entry_started_at_not_nullable() -> None:
+    """TimeEntry.started_at must be NOT NULL."""
+    col = inspect(TimeEntry).columns["started_at"]
+    assert col.nullable is False
+
+
+def test_time_entry_started_at_is_datetime_tz() -> None:
+    """TimeEntry.started_at must be DateTime with timezone."""
+    col = inspect(TimeEntry).columns["started_at"]
+    assert col.type.timezone is True
+
+
+def test_time_entry_ended_at_is_nullable() -> None:
+    """TimeEntry.ended_at must be nullable (active timer has no end)."""
+    col = inspect(TimeEntry).columns["ended_at"]
+    assert col.nullable is True
+
+
+def test_time_entry_ended_at_is_datetime_tz() -> None:
+    """TimeEntry.ended_at must be DateTime with timezone."""
+    col = inspect(TimeEntry).columns["ended_at"]
+    assert col.type.timezone is True
+
+
+def test_time_entry_duration_seconds_is_nullable() -> None:
+    """TimeEntry.duration_seconds must be nullable (computed on stop)."""
+    col = inspect(TimeEntry).columns["duration_seconds"]
+    assert col.nullable is True
+
+
+def test_time_entry_duration_seconds_is_integer() -> None:
+    """TimeEntry.duration_seconds column type must be INTEGER."""
+    col = inspect(TimeEntry).columns["duration_seconds"]
+    assert "INTEGER" in str(col.type).upper()
+
+
+def test_time_entry_has_task_started_index() -> None:
+    """TimeEntry must have an index on (task_id, started_at)."""
+    indexes = {idx.name for idx in inspect(TimeEntry).mapped_table.indexes}
+    assert "idx_time_entry_task_started" in indexes
+
+
+def test_time_entry_repr_contains_id() -> None:
+    """TimeEntry.__repr__ should include the entry id."""
+    entry_id = uuid.uuid4()
+    entry = TimeEntry(id=entry_id, task_id=uuid.uuid4())
+    assert str(entry_id) in repr(entry)

--- a/backend/tests/unit/test_time_entry_routes.py
+++ b/backend/tests/unit/test_time_entry_routes.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.main import app
+from app.models.time_entry import TimeEntry
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+TASK_ID = uuid.UUID("00000000-0000-0000-0000-bbbbbbbbbbbb")
+ENTRY_ID = uuid.UUID("00000000-0000-0000-0000-cccccccccccc")
+
+
+def _make_fake_user() -> MagicMock:
+    fake = MagicMock()
+    fake.id = USER_ID
+    fake.email = "test@example.com"
+    fake.name = "Test User"
+    return fake
+
+
+def _make_fake_entry(**overrides: object) -> MagicMock:
+    defaults: dict[str, object] = {
+        "id": ENTRY_ID,
+        "task_id": TASK_ID,
+        "started_at": datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
+        "ended_at": None,
+        "duration_seconds": None,
+        "created_at": datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    fake = MagicMock(spec=TimeEntry)
+    for k, v in defaults.items():
+        setattr(fake, k, v)
+    return fake
+
+
+@pytest.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+def _setup_overrides() -> None:
+    app.dependency_overrides[get_current_user] = _make_fake_user
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+
+
+def _clear_overrides() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /time-entries/start
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_timer_returns_201(client: AsyncClient) -> None:
+    """POST /time-entries/start with valid data must return 201."""
+    fake = _make_fake_entry()
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.time_entries.start_timer",
+            new_callable=AsyncMock,
+        ) as mock_start:
+            mock_start.return_value = fake
+            response = await client.post(
+                "/time-entries/start",
+                json={"task_id": str(TASK_ID)},
+            )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] == str(ENTRY_ID)
+
+
+@pytest.mark.asyncio
+async def test_start_timer_returns_401_without_auth(client: AsyncClient) -> None:
+    """POST /time-entries/start without auth must return 401."""
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.post(
+            "/time-entries/start",
+            json={"task_id": str(TASK_ID)},
+        )
+    finally:
+        _clear_overrides()
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /time-entries/{entry_id}/stop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_timer_returns_200(client: AsyncClient) -> None:
+    """POST /time-entries/{id}/stop must return 200."""
+    fake = _make_fake_entry(
+        ended_at=datetime(2026, 5, 1, 10, 0, tzinfo=UTC),
+        duration_seconds=3600,
+    )
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.time_entries.stop_timer",
+            new_callable=AsyncMock,
+        ) as mock_stop:
+            mock_stop.return_value = fake
+            response = await client.post(f"/time-entries/{ENTRY_ID}/stop")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /time-entries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_entries_returns_200(client: AsyncClient) -> None:
+    """GET /time-entries?task_id=... must return 200 with list."""
+    fake = _make_fake_entry()
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.time_entries.list_time_entries",
+            new_callable=AsyncMock,
+        ) as mock_list:
+            mock_list.return_value = [fake]
+            response = await client.get(
+                f"/time-entries?task_id={TASK_ID}"
+            )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_entries_accepts_date_filter(client: AsyncClient) -> None:
+    """GET /time-entries?date=2026-05-01 must return 200."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.time_entries.list_time_entries",
+            new_callable=AsyncMock,
+        ) as mock_list:
+            mock_list.return_value = []
+            response = await client.get("/time-entries?date=2026-05-01")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_list_entries_works_without_filters(client: AsyncClient) -> None:
+    """GET /time-entries without filters must return 200."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.time_entries.list_time_entries",
+            new_callable=AsyncMock,
+        ) as mock_list:
+            mock_list.return_value = []
+            response = await client.get("/time-entries")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# DELETE /time-entries/{entry_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_entry_returns_204(client: AsyncClient) -> None:
+    """DELETE /time-entries/{id} must return 204."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.time_entries.delete_time_entry",
+            new_callable=AsyncMock,
+        ) as mock_delete:
+            mock_delete.return_value = None
+            response = await client.delete(f"/time-entries/{ENTRY_ID}")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_entry_returns_401_without_auth(client: AsyncClient) -> None:
+    """DELETE /time-entries/{id} without auth must return 401."""
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.delete(f"/time-entries/{ENTRY_ID}")
+    finally:
+        _clear_overrides()
+    assert response.status_code == 401

--- a/backend/tests/unit/test_time_entry_routes.py
+++ b/backend/tests/unit/test_time_entry_routes.py
@@ -151,9 +151,7 @@ async def test_list_entries_returns_200(client: AsyncClient) -> None:
             new_callable=AsyncMock,
         ) as mock_list:
             mock_list.return_value = [fake]
-            response = await client.get(
-                f"/time-entries?task_id={TASK_ID}"
-            )
+            response = await client.get(f"/time-entries?task_id={TASK_ID}")
     finally:
         _clear_overrides()
 

--- a/backend/tests/unit/test_time_entry_schema.py
+++ b/backend/tests/unit/test_time_entry_schema.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.time_entry import TimeEntryResponse, TimeEntryStart
+
+TASK_ID = uuid.UUID("00000000-0000-0000-0000-aaaaaaaaaaaa")
+
+# ---------------------------------------------------------------------------
+# TimeEntryStart
+# ---------------------------------------------------------------------------
+
+
+def test_start_with_task_id_only() -> None:
+    """TimeEntryStart must accept task_id alone; started_at defaults to None."""
+    s = TimeEntryStart(task_id=TASK_ID)
+    assert s.task_id == TASK_ID
+    assert s.started_at is None
+
+
+def test_start_with_explicit_started_at() -> None:
+    """TimeEntryStart must accept an explicit started_at datetime."""
+    now = datetime.now(UTC)
+    s = TimeEntryStart(task_id=TASK_ID, started_at=now)
+    assert s.started_at == now
+
+
+def test_start_rejects_missing_task_id() -> None:
+    """TimeEntryStart without task_id must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        TimeEntryStart()  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# TimeEntryResponse
+# ---------------------------------------------------------------------------
+
+
+def test_response_from_attributes() -> None:
+    """TimeEntryResponse must support from_attributes (ORM mode)."""
+    assert TimeEntryResponse.model_config.get("from_attributes") is True
+
+
+def test_response_round_trip() -> None:
+    """TimeEntryResponse must serialize all fields."""
+    now = datetime.now(UTC)
+    entry_id = uuid.uuid4()
+    resp = TimeEntryResponse(
+        id=entry_id,
+        task_id=TASK_ID,
+        started_at=now,
+        ended_at=now,
+        duration_seconds=3600,
+        created_at=now,
+    )
+    assert resp.id == entry_id
+    assert resp.task_id == TASK_ID
+    assert resp.duration_seconds == 3600
+
+
+def test_response_allows_null_ended_at() -> None:
+    """TimeEntryResponse must allow ended_at=None (active timer)."""
+    now = datetime.now(UTC)
+    resp = TimeEntryResponse(
+        id=uuid.uuid4(),
+        task_id=TASK_ID,
+        started_at=now,
+        ended_at=None,
+        duration_seconds=None,
+        created_at=now,
+    )
+    assert resp.ended_at is None
+
+
+def test_response_allows_null_duration() -> None:
+    """TimeEntryResponse must allow duration_seconds=None (active timer)."""
+    now = datetime.now(UTC)
+    resp = TimeEntryResponse(
+        id=uuid.uuid4(),
+        task_id=TASK_ID,
+        started_at=now,
+        ended_at=None,
+        duration_seconds=None,
+        created_at=now,
+    )
+    assert resp.duration_seconds is None

--- a/backend/tests/unit/test_time_entry_service.py
+++ b/backend/tests/unit/test_time_entry_service.py
@@ -51,7 +51,7 @@ async def test_start_timer_returns_time_entry() -> None:
     mock_task_result.scalar_one_or_none.return_value = MagicMock()
     # Mock for active timer check
     mock_active_result = MagicMock()
-    mock_active_result.scalar_one_or_none.return_value = None
+    mock_active_result.scalars.return_value.first.return_value = None
     db.execute.side_effect = [mock_task_result, mock_active_result]
 
     data = TimeEntryStart(task_id=TASK_ID)
@@ -87,7 +87,7 @@ async def test_start_timer_raises_409_when_active_timer_exists() -> None:
     mock_task_result.scalar_one_or_none.return_value = MagicMock()
     # Active timer found
     mock_active_result = MagicMock()
-    mock_active_result.scalar_one_or_none.return_value = _make_fake_entry()
+    mock_active_result.scalars.return_value.first.return_value = _make_fake_entry()
     db.execute.side_effect = [mock_task_result, mock_active_result]
 
     data = TimeEntryStart(task_id=TASK_ID)
@@ -105,7 +105,7 @@ async def test_start_timer_query_checks_user_for_active() -> None:
     mock_task_result = MagicMock()
     mock_task_result.scalar_one_or_none.return_value = MagicMock()
     mock_active_result = MagicMock()
-    mock_active_result.scalar_one_or_none.return_value = None
+    mock_active_result.scalars.return_value.first.return_value = None
     db.execute.side_effect = [mock_task_result, mock_active_result]
 
     data = TimeEntryStart(task_id=TASK_ID)
@@ -126,7 +126,7 @@ async def test_start_timer_uses_provided_started_at() -> None:
     mock_task_result = MagicMock()
     mock_task_result.scalar_one_or_none.return_value = MagicMock()
     mock_active_result = MagicMock()
-    mock_active_result.scalar_one_or_none.return_value = None
+    mock_active_result.scalars.return_value.first.return_value = None
     db.execute.side_effect = [mock_task_result, mock_active_result]
 
     custom_time = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
@@ -158,7 +158,7 @@ async def test_start_timer_detail_on_active_timer() -> None:
     mock_task_result = MagicMock()
     mock_task_result.scalar_one_or_none.return_value = MagicMock()
     mock_active_result = MagicMock()
-    mock_active_result.scalar_one_or_none.return_value = _make_fake_entry()
+    mock_active_result.scalars.return_value.first.return_value = _make_fake_entry()
     db.execute.side_effect = [mock_task_result, mock_active_result]
 
     data = TimeEntryStart(task_id=TASK_ID)
@@ -412,7 +412,7 @@ async def test_active_timer_check_query_filters() -> None:
     mock_task_result = MagicMock()
     mock_task_result.scalar_one_or_none.return_value = MagicMock()
     mock_active_result = MagicMock()
-    mock_active_result.scalar_one_or_none.return_value = None
+    mock_active_result.scalars.return_value.first.return_value = None
     db.execute.side_effect = [mock_task_result, mock_active_result]
 
     data = TimeEntryStart(task_id=TASK_ID)
@@ -522,7 +522,7 @@ async def test_start_timer_active_detail_message_exact() -> None:
     mock_task_result = MagicMock()
     mock_task_result.scalar_one_or_none.return_value = MagicMock()
     mock_active_result = MagicMock()
-    mock_active_result.scalar_one_or_none.return_value = _make_fake_entry()
+    mock_active_result.scalars.return_value.first.return_value = _make_fake_entry()
     db.execute.side_effect = [mock_task_result, mock_active_result]
 
     data = TimeEntryStart(task_id=TASK_ID)
@@ -559,7 +559,7 @@ async def test_active_timer_check_join_uses_equality() -> None:
     mock_task_result = MagicMock()
     mock_task_result.scalar_one_or_none.return_value = MagicMock()
     mock_active_result = MagicMock()
-    mock_active_result.scalar_one_or_none.return_value = None
+    mock_active_result.scalars.return_value.first.return_value = None
     db.execute.side_effect = [mock_task_result, mock_active_result]
 
     data = TimeEntryStart(task_id=TASK_ID)

--- a/backend/tests/unit/test_time_entry_service.py
+++ b/backend/tests/unit/test_time_entry_service.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.time_entry import TimeEntry
+from app.schemas.time_entry import TimeEntryStart
+from app.services.time_entry_service import (
+    delete_time_entry,
+    list_time_entries,
+    start_timer,
+    stop_timer,
+)
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+TASK_ID = uuid.UUID("00000000-0000-0000-0000-bbbbbbbbbbbb")
+ENTRY_ID = uuid.UUID("00000000-0000-0000-0000-cccccccccccc")
+
+
+def _make_fake_entry(**overrides: object) -> MagicMock:
+    defaults: dict[str, object] = {
+        "id": ENTRY_ID,
+        "task_id": TASK_ID,
+        "started_at": datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
+        "ended_at": None,
+        "duration_seconds": None,
+        "created_at": datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    fake = MagicMock(spec=TimeEntry)
+    for k, v in defaults.items():
+        setattr(fake, k, v)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# start_timer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_timer_returns_time_entry() -> None:
+    """start_timer must add, commit, refresh and return TimeEntry."""
+    db = AsyncMock()
+    # Mock for task ownership check
+    mock_task_result = MagicMock()
+    mock_task_result.scalar_one_or_none.return_value = MagicMock()
+    # Mock for active timer check
+    mock_active_result = MagicMock()
+    mock_active_result.scalar_one_or_none.return_value = None
+    db.execute.side_effect = [mock_task_result, mock_active_result]
+
+    data = TimeEntryStart(task_id=TASK_ID)
+    result = await start_timer(db=db, user_id=USER_ID, data=data)
+
+    db.add.assert_called_once()
+    db.commit.assert_awaited_once()
+    db.refresh.assert_awaited_once()
+    assert isinstance(result, TimeEntry)
+
+
+@pytest.mark.asyncio
+async def test_start_timer_raises_404_for_wrong_task_owner() -> None:
+    """start_timer must raise 404 if task doesn't belong to user."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    data = TimeEntryStart(task_id=TASK_ID)
+    with pytest.raises(HTTPException) as exc_info:
+        await start_timer(db=db, user_id=USER_ID, data=data)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_start_timer_raises_409_when_active_timer_exists() -> None:
+    """start_timer must raise 409 when user already has an active timer."""
+    db = AsyncMock()
+    # Task ownership OK
+    mock_task_result = MagicMock()
+    mock_task_result.scalar_one_or_none.return_value = MagicMock()
+    # Active timer found
+    mock_active_result = MagicMock()
+    mock_active_result.scalar_one_or_none.return_value = _make_fake_entry()
+    db.execute.side_effect = [mock_task_result, mock_active_result]
+
+    data = TimeEntryStart(task_id=TASK_ID)
+    with pytest.raises(HTTPException) as exc_info:
+        await start_timer(db=db, user_id=USER_ID, data=data)
+
+    assert exc_info.value.status_code == 409
+    assert "active timer" in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_start_timer_query_checks_user_for_active() -> None:
+    """Active timer check must JOIN through Task/Project and filter user_id."""
+    db = AsyncMock()
+    mock_task_result = MagicMock()
+    mock_task_result.scalar_one_or_none.return_value = MagicMock()
+    mock_active_result = MagicMock()
+    mock_active_result.scalar_one_or_none.return_value = None
+    db.execute.side_effect = [mock_task_result, mock_active_result]
+
+    data = TimeEntryStart(task_id=TASK_ID)
+    await start_timer(db=db, user_id=USER_ID, data=data)
+
+    # The second execute call is the active timer check
+    active_stmt = db.execute.call_args_list[1][0][0]
+    compiled = str(active_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "tasks" in compiled.lower()
+    assert "projects" in compiled.lower()
+    assert USER_ID.hex in compiled
+
+
+@pytest.mark.asyncio
+async def test_start_timer_uses_provided_started_at() -> None:
+    """start_timer must use the provided started_at datetime."""
+    db = AsyncMock()
+    mock_task_result = MagicMock()
+    mock_task_result.scalar_one_or_none.return_value = MagicMock()
+    mock_active_result = MagicMock()
+    mock_active_result.scalar_one_or_none.return_value = None
+    db.execute.side_effect = [mock_task_result, mock_active_result]
+
+    custom_time = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+    data = TimeEntryStart(task_id=TASK_ID, started_at=custom_time)
+    result = await start_timer(db=db, user_id=USER_ID, data=data)
+
+    assert result.started_at == custom_time
+
+
+@pytest.mark.asyncio
+async def test_start_timer_detail_on_task_not_found() -> None:
+    """start_timer must say 'Task not found'."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    data = TimeEntryStart(task_id=TASK_ID)
+    with pytest.raises(HTTPException) as exc_info:
+        await start_timer(db=db, user_id=USER_ID, data=data)
+
+    assert exc_info.value.detail == "Task not found"
+
+
+@pytest.mark.asyncio
+async def test_start_timer_detail_on_active_timer() -> None:
+    """start_timer must mention 'active timer' in 409 detail."""
+    db = AsyncMock()
+    mock_task_result = MagicMock()
+    mock_task_result.scalar_one_or_none.return_value = MagicMock()
+    mock_active_result = MagicMock()
+    mock_active_result.scalar_one_or_none.return_value = _make_fake_entry()
+    db.execute.side_effect = [mock_task_result, mock_active_result]
+
+    data = TimeEntryStart(task_id=TASK_ID)
+    with pytest.raises(HTTPException) as exc_info:
+        await start_timer(db=db, user_id=USER_ID, data=data)
+
+    assert "active timer" in exc_info.value.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# stop_timer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_timer_sets_ended_at_and_duration() -> None:
+    """stop_timer must set ended_at and compute duration_seconds."""
+    fake = _make_fake_entry(
+        started_at=datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
+        ended_at=None,
+    )
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    result = await stop_timer(db=db, entry_id=ENTRY_ID, user_id=USER_ID)
+
+    assert result.ended_at is not None
+    assert result.duration_seconds is not None
+    assert result.duration_seconds > 0
+    db.commit.assert_awaited_once()
+    db.refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_timer_raises_404_when_not_found() -> None:
+    """stop_timer must raise 404 when entry not found."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await stop_timer(db=db, entry_id=ENTRY_ID, user_id=USER_ID)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_stop_timer_raises_409_when_already_stopped() -> None:
+    """stop_timer must raise 409 when timer already has ended_at."""
+    fake = _make_fake_entry(
+        ended_at=datetime(2026, 5, 1, 10, 0, tzinfo=UTC),
+        duration_seconds=3600,
+    )
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await stop_timer(db=db, entry_id=ENTRY_ID, user_id=USER_ID)
+
+    assert exc_info.value.status_code == 409
+    assert "already stopped" in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_stop_timer_query_joins_for_ownership() -> None:
+    """stop_timer query must JOIN tasks and projects for ownership."""
+    fake = _make_fake_entry()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await stop_timer(db=db, entry_id=ENTRY_ID, user_id=USER_ID)
+
+    executed_stmt = db.execute.call_args[0][0]
+    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "tasks" in compiled.lower()
+    assert "projects" in compiled.lower()
+    assert "JOIN" in compiled.upper()
+
+
+@pytest.mark.asyncio
+async def test_stop_timer_computes_duration_correctly() -> None:
+    """stop_timer must compute duration as (ended_at - started_at) seconds."""
+    started = datetime(2026, 5, 1, 9, 0, tzinfo=UTC)
+    fake = _make_fake_entry(started_at=started, ended_at=None)
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    result = await stop_timer(db=db, entry_id=ENTRY_ID, user_id=USER_ID)
+
+    # Duration should be the difference between now and started_at
+    assert isinstance(result.duration_seconds, int)
+    assert result.duration_seconds >= 0
+
+
+# ---------------------------------------------------------------------------
+# list_time_entries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_entries_returns_list() -> None:
+    """list_time_entries must return a list of entries."""
+    fake1 = _make_fake_entry()
+    fake2 = _make_fake_entry()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [fake1, fake2]
+    db.execute.return_value = mock_result
+
+    result = await list_time_entries(db=db, user_id=USER_ID)
+
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_entries_returns_empty() -> None:
+    """list_time_entries must return empty list, not 404."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    result = await list_time_entries(db=db, user_id=USER_ID)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_entries_filters_by_task_id() -> None:
+    """list_time_entries query must filter by task_id when provided."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_time_entries(db=db, user_id=USER_ID, task_id=TASK_ID)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert TASK_ID.hex in compiled
+
+
+@pytest.mark.asyncio
+async def test_list_entries_filters_by_date() -> None:
+    """list_time_entries query must filter by date range on started_at."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_time_entries(
+        db=db, user_id=USER_ID, query_date=date(2026, 5, 1)
+    )
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert "2026-05-01" in compiled
+
+
+@pytest.mark.asyncio
+async def test_list_entries_scopes_to_user() -> None:
+    """list_time_entries query must JOIN through Task/Project for user scope."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_time_entries(db=db, user_id=USER_ID)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert "projects" in compiled.lower()
+    assert "JOIN" in compiled.upper()
+    assert USER_ID.hex in compiled
+
+
+# ---------------------------------------------------------------------------
+# delete_time_entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_entry_removes_and_commits() -> None:
+    """delete_time_entry must delete and commit."""
+    fake = _make_fake_entry()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await delete_time_entry(db=db, entry_id=ENTRY_ID, user_id=USER_ID)
+
+    db.delete.assert_awaited_once_with(fake)
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_entry_raises_404_when_not_found() -> None:
+    """delete_time_entry must raise 404 for missing/unauthorized entry."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await delete_time_entry(db=db, entry_id=ENTRY_ID, user_id=USER_ID)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Time entry not found"

--- a/backend/tests/unit/test_time_entry_service.py
+++ b/backend/tests/unit/test_time_entry_service.py
@@ -176,10 +176,8 @@ async def test_start_timer_detail_on_active_timer() -> None:
 @pytest.mark.asyncio
 async def test_stop_timer_sets_ended_at_and_duration() -> None:
     """stop_timer must set ended_at and compute duration_seconds."""
-    fake = _make_fake_entry(
-        started_at=datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
-        ended_at=None,
-    )
+    started = datetime.now(UTC) - timedelta(hours=1)
+    fake = _make_fake_entry(started_at=started, ended_at=None)
     db = AsyncMock()
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = fake
@@ -248,7 +246,7 @@ async def test_stop_timer_query_joins_for_ownership() -> None:
 @pytest.mark.asyncio
 async def test_stop_timer_computes_duration_correctly() -> None:
     """stop_timer must compute duration as (ended_at - started_at) seconds."""
-    started = datetime(2026, 5, 1, 9, 0, tzinfo=UTC)
+    started = datetime.now(UTC) - timedelta(seconds=120)
     fake = _make_fake_entry(started_at=started, ended_at=None)
     db = AsyncMock()
     mock_result = MagicMock()
@@ -257,9 +255,9 @@ async def test_stop_timer_computes_duration_correctly() -> None:
 
     result = await stop_timer(db=db, entry_id=ENTRY_ID, user_id=USER_ID)
 
-    # Duration should be the difference between now and started_at
     assert isinstance(result.duration_seconds, int)
-    assert result.duration_seconds >= 0
+    # Should be approximately 120 seconds (within 5s tolerance)
+    assert 115 <= result.duration_seconds <= 125
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_time_entry_service.py
+++ b/backend/tests/unit/test_time_entry_service.py
@@ -317,9 +317,7 @@ async def test_list_entries_filters_by_date() -> None:
     mock_result.scalars.return_value.all.return_value = []
     db.execute.return_value = mock_result
 
-    await list_time_entries(
-        db=db, user_id=USER_ID, query_date=date(2026, 5, 1)
-    )
+    await list_time_entries(db=db, user_id=USER_ID, query_date=date(2026, 5, 1))
 
     compiled = str(
         db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
@@ -378,3 +376,284 @@ async def test_delete_entry_raises_404_when_not_found() -> None:
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Time entry not found"
+
+
+# ---------------------------------------------------------------------------
+# SQL WHERE clause verification (mutation killing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_timer_verify_task_query_checks_user() -> None:
+    """Task ownership query must check task_id AND user_id."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    data = TimeEntryStart(task_id=TASK_ID)
+    with pytest.raises(HTTPException):
+        await start_timer(db=db, user_id=USER_ID, data=data)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert TASK_ID.hex in compiled
+    assert USER_ID.hex in compiled
+    # Verify JOIN condition uses equality (not !=)
+    assert "tasks" in compiled.lower()
+    assert "projects" in compiled.lower()
+
+
+@pytest.mark.asyncio
+async def test_active_timer_check_query_filters() -> None:
+    """Active timer check must filter by user and ended_at IS NULL."""
+    db = AsyncMock()
+    mock_task_result = MagicMock()
+    mock_task_result.scalar_one_or_none.return_value = MagicMock()
+    mock_active_result = MagicMock()
+    mock_active_result.scalar_one_or_none.return_value = None
+    db.execute.side_effect = [mock_task_result, mock_active_result]
+
+    data = TimeEntryStart(task_id=TASK_ID)
+    await start_timer(db=db, user_id=USER_ID, data=data)
+
+    active_compiled = str(
+        db.execute.call_args_list[1][0][0].compile(
+            compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert USER_ID.hex in active_compiled
+    assert "NULL" in active_compiled.upper()
+
+
+@pytest.mark.asyncio
+async def test_get_entry_query_where_clauses() -> None:
+    """Ownership query must filter by entry_id AND user_id."""
+    fake = _make_fake_entry()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await stop_timer(db=db, entry_id=ENTRY_ID, user_id=USER_ID)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert ENTRY_ID.hex in compiled
+    assert USER_ID.hex in compiled
+
+
+@pytest.mark.asyncio
+async def test_list_entries_query_where_clauses() -> None:
+    """List query must filter by user_id."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_time_entries(db=db, user_id=USER_ID)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert USER_ID.hex in compiled
+
+
+@pytest.mark.asyncio
+async def test_list_entries_task_filter_where_clause() -> None:
+    """List query with task_id must include task_id in WHERE."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_time_entries(db=db, user_id=USER_ID, task_id=TASK_ID)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert TASK_ID.hex in compiled
+    # Verify the task_id filter uses equality
+    assert "time_entries.task_id" in compiled.lower() or TASK_ID.hex in compiled
+
+
+@pytest.mark.asyncio
+async def test_list_entries_date_filter_uses_day_boundaries() -> None:
+    """Date filter must use >= day_start AND < day_end (next day)."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_time_entries(db=db, user_id=USER_ID, query_date=date(2026, 5, 1))
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    # Must contain both day boundaries
+    assert "2026-05-01" in compiled
+    assert "2026-05-02" in compiled
+
+
+@pytest.mark.asyncio
+async def test_stop_timer_detail_message_exact() -> None:
+    """stop_timer 409 detail must be exactly 'Timer already stopped'."""
+    fake = _make_fake_entry(
+        ended_at=datetime(2026, 5, 1, 10, 0, tzinfo=UTC),
+        duration_seconds=3600,
+    )
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await stop_timer(db=db, entry_id=ENTRY_ID, user_id=USER_ID)
+
+    assert exc_info.value.detail == "Timer already stopped"
+
+
+@pytest.mark.asyncio
+async def test_start_timer_active_detail_message_exact() -> None:
+    """start_timer 409 detail must be exactly 'User already has an active timer'."""
+    db = AsyncMock()
+    mock_task_result = MagicMock()
+    mock_task_result.scalar_one_or_none.return_value = MagicMock()
+    mock_active_result = MagicMock()
+    mock_active_result.scalar_one_or_none.return_value = _make_fake_entry()
+    db.execute.side_effect = [mock_task_result, mock_active_result]
+
+    data = TimeEntryStart(task_id=TASK_ID)
+    with pytest.raises(HTTPException) as exc_info:
+        await start_timer(db=db, user_id=USER_ID, data=data)
+
+    assert exc_info.value.detail == "User already has an active timer"
+
+
+@pytest.mark.asyncio
+async def test_verify_task_ownership_join_uses_equality() -> None:
+    """Task ownership JOIN must use = (not !=) for project_id = id."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+
+    data = TimeEntryStart(task_id=TASK_ID)
+    with pytest.raises(HTTPException):
+        await start_timer(db=db, user_id=USER_ID, data=data)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    # JOIN should use = not !=
+    assert "!=" not in compiled
+    assert "tasks.project_id = projects.id" in compiled.lower()
+
+
+@pytest.mark.asyncio
+async def test_active_timer_check_join_uses_equality() -> None:
+    """Active timer check JOINs must use = (not !=)."""
+    db = AsyncMock()
+    mock_task_result = MagicMock()
+    mock_task_result.scalar_one_or_none.return_value = MagicMock()
+    mock_active_result = MagicMock()
+    mock_active_result.scalar_one_or_none.return_value = None
+    db.execute.side_effect = [mock_task_result, mock_active_result]
+
+    data = TimeEntryStart(task_id=TASK_ID)
+    await start_timer(db=db, user_id=USER_ID, data=data)
+
+    active_compiled = str(
+        db.execute.call_args_list[1][0][0].compile(
+            compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert "!=" not in active_compiled
+    assert "time_entries.task_id = tasks.id" in active_compiled.lower()
+    assert "tasks.project_id = projects.id" in active_compiled.lower()
+
+
+@pytest.mark.asyncio
+async def test_get_entry_join_uses_equality() -> None:
+    """Entry ownership JOINs must use = (not !=)."""
+    fake = _make_fake_entry()
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake
+    db.execute.return_value = mock_result
+
+    await stop_timer(db=db, entry_id=ENTRY_ID, user_id=USER_ID)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert "!=" not in compiled
+    assert "time_entries.task_id = tasks.id" in compiled.lower()
+    assert "tasks.project_id = projects.id" in compiled.lower()
+
+
+@pytest.mark.asyncio
+async def test_list_entries_join_uses_equality() -> None:
+    """List entries JOINs must use = (not !=)."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_time_entries(db=db, user_id=USER_ID)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert "!=" not in compiled
+    assert "time_entries.task_id = tasks.id" in compiled.lower()
+    assert "tasks.project_id = projects.id" in compiled.lower()
+
+
+@pytest.mark.asyncio
+async def test_list_entries_date_filter_operators() -> None:
+    """Date filter must use >= for day_start and < for day_end."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_time_entries(db=db, user_id=USER_ID, query_date=date(2026, 5, 1))
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    # Must use >= for start and < (strict) for day_end
+    assert ">=" in compiled
+    assert "2026-05-02" in compiled
+    # Must use strict < for day_end, not <=
+    day_end_idx = compiled.index("2026-05-02")
+    # Extract the operator before the day_end value (skip quote/space)
+    before_day_end = compiled[:day_end_idx].rstrip().rstrip("'").rstrip()
+    tail = before_day_end[-5:]
+    assert before_day_end.endswith("<"), f"Expected '<', got: ...{tail}"
+    assert not before_day_end.endswith("<="), "Must use strict < not <="
+
+
+@pytest.mark.asyncio
+async def test_list_entries_task_filter_uses_equality() -> None:
+    """Task filter WHERE must use = (not !=)."""
+    db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    db.execute.return_value = mock_result
+
+    await list_time_entries(db=db, user_id=USER_ID, task_id=TASK_ID)
+
+    compiled = str(
+        db.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True})
+    )
+    # The task_id filter should NOT use !=
+    # Check that around the task_id hex there's = not !=
+    task_hex = TASK_ID.hex
+    idx = compiled.index(task_hex)
+    before = compiled[:idx]
+    # Should end with "= '" (equality), not "!= '"
+    assert "!=" not in before[before.rfind("task_id") :]


### PR DESCRIPTION
## Summary
- Add `TimeEntry` model with UUID PK, FK→Task (CASCADE), `started_at`/`ended_at`/`duration_seconds` columns, and composite index
- Implement start/stop timer endpoints (`POST /time-entries/start`, `POST /time-entries/{id}/stop`) with auto-computed `duration_seconds`
- Add list (`GET /time-entries?task_id=&date=`) and delete (`DELETE /time-entries/{id}`) endpoints
- Enforce one-active-timer-per-user constraint with `FOR UPDATE` lock to prevent race conditions
- Extract shared `verify_task_ownership` helper to `services/ownership.py` (used by both ScheduleBlock and TimeEntry)
- Alembic migration `0006` with `server_default=func.now()` on `created_at`

## Test plan
- [x] 14 model tests — columns, FK, index, repr
- [x] 7 schema tests — TimeEntryStart, TimeEntryResponse validation
- [x] 33 service tests — start/stop/list/delete logic, ownership, SQL WHERE clause verification
- [x] 8 route tests — status codes, auth enforcement
- [x] 360 total tests pass (0 failures)
- [x] 100% mutation score on `time_entry_service.py` (49/49 killed)
- [x] Lint clean (`ruff check . && ruff format .`)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)