### PR TITLE
Fix mypy attr-defined errors in TimeEntry model tests

### DIFF
--- a/backend/tests/unit/test_time_entry_model.py
+++ b/backend/tests/unit/test_time_entry_model.py
@@ -62,7 +62,7 @@ def test_time_entry_started_at_not_nullable() -> None:
 def test_time_entry_started_at_is_datetime_tz() -> None:
     """TimeEntry.started_at must be DateTime with timezone."""
     col = inspect(TimeEntry).columns["started_at"]
-    assert col.type.timezone is True
+    assert col.type.timezone is True  # type: ignore[attr-defined]
 
 
 def test_time_entry_ended_at_is_nullable() -> None:
@@ -74,7 +74,7 @@ def test_time_entry_ended_at_is_nullable() -> None:
 def test_time_entry_ended_at_is_datetime_tz() -> None:
     """TimeEntry.ended_at must be DateTime with timezone."""
     col = inspect(TimeEntry).columns["ended_at"]
-    assert col.type.timezone is True
+    assert col.type.timezone is True  # type: ignore[attr-defined]
 
 
 def test_time_entry_duration_seconds_is_nullable() -> None:


### PR DESCRIPTION
## Summary
- Add `# type: ignore[attr-defined]` to `col.type.timezone` assertions in `test_time_entry_model.py`
- Fixes CI Lint & Type-check failure from PR #46

## Test plan
- [x] `mypy tests/unit/test_time_entry_model.py` passes
- [x] All 14 model tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)