### PR TITLE
Fix mypy type ignore in analytics test helper

### DIFF
--- a/backend/tests/unit/test_analytics_service.py
+++ b/backend/tests/unit/test_analytics_service.py
@@ -218,7 +218,7 @@ def test_compute_status_tag_zero_zero() -> None:
 
 
 def _compile(stmt: object) -> str:
-    return str(stmt.compile(compile_kwargs={"literal_binds": True}))  # type: ignore[union-attr]
+    return str(stmt.compile(compile_kwargs={"literal_binds": True}))  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fix CI failure from PR #48: `type: ignore[union-attr]` → `type: ignore[attr-defined]` to match the actual mypy error code in `_compile` helper

## Test plan
- [ ] `mypy tests/unit/test_analytics_service.py` — passes with no errors
- [ ] All unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)