### PR TITLE
feat(#22): add weekly aggregation and stats endpoint

### DIFF
--- a/backend/app/api/analytics.py
+++ b/backend/app/api/analytics.py
@@ -8,8 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.core.deps import get_current_user
 from app.models.user import User
-from app.schemas.analytics import PlannedVsActualResponse
-from app.services.analytics_service import get_planned_vs_actual
+from app.schemas.analytics import PlannedVsActualResponse, WeeklyStatsResponse
+from app.services.analytics_service import get_planned_vs_actual, get_weekly_stats
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
 
@@ -23,4 +23,16 @@ async def planned_vs_actual_route(
     """Return planned-vs-actual comparison for a single day."""
     return await get_planned_vs_actual(
         db=db, user_id=current_user.id, query_date=query_date
+    )
+
+
+@router.get("/weekly-stats", response_model=WeeklyStatsResponse)
+async def weekly_stats_route(
+    week_start: date = Query(..., alias="week_start"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WeeklyStatsResponse:
+    """Return per-project weekly stats for the week containing week_start."""
+    return await get_weekly_stats(
+        db=db, user_id=current_user.id, week_start=week_start
     )

--- a/backend/app/api/analytics.py
+++ b/backend/app/api/analytics.py
@@ -33,6 +33,4 @@ async def weekly_stats_route(
     db: AsyncSession = Depends(get_db),
 ) -> WeeklyStatsResponse:
     """Return per-project weekly stats for the week containing week_start."""
-    return await get_weekly_stats(
-        db=db, user_id=current_user.id, week_start=week_start
-    )
+    return await get_weekly_stats(db=db, user_id=current_user.id, week_start=week_start)

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -43,3 +43,31 @@ class PlannedVsActualResponse(BaseModel):
     date: date
     tasks: list[TaskComparison]
     summary: PlannedVsActualSummary
+
+
+class ProjectWeeklyStats(BaseModel):
+    """Per-project breakdown for the week."""
+
+    project_id: uuid.UUID
+    project_name: str
+    project_color: str
+    planned_hours: float
+    actual_hours: float
+    accuracy_pct: float
+
+
+class WeeklyStatsSummary(BaseModel):
+    """Aggregate totals across all projects for the week."""
+
+    total_planned_hours: float
+    total_actual_hours: float
+    average_accuracy_pct: float
+
+
+class WeeklyStatsResponse(BaseModel):
+    """Full response for the weekly-stats endpoint."""
+
+    week_start: date
+    week_end: date
+    projects: list[ProjectWeeklyStats]
+    summary: WeeklyStatsSummary

--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -8,6 +8,16 @@ def align_to_monday(d: date) -> date:
     """Return the Monday of the week containing *d*."""
     return d - timedelta(days=d.weekday())
 
+
+def compute_accuracy_pct(planned: float, actual: float) -> float:
+    """Return estimation accuracy as a percentage.
+
+    Returns 0.0 when planned == 0 to avoid division by zero.
+    """
+    if planned == 0:
+        return 0.0
+    return (actual / planned) * 100
+
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -3,6 +3,23 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, date, datetime, timedelta
 
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project import Project
+from app.models.schedule_block import ScheduleBlock
+from app.models.task import Task
+from app.models.time_entry import TimeEntry
+from app.schemas.analytics import (
+    PlannedVsActualResponse,
+    PlannedVsActualSummary,
+    ProjectWeeklyStats,
+    StatusTag,
+    TaskComparison,
+    WeeklyStatsResponse,
+    WeeklyStatsSummary,
+)
+
 
 def align_to_monday(d: date) -> date:
     """Return the Monday of the week containing *d*."""
@@ -17,23 +34,6 @@ def compute_accuracy_pct(planned: float, actual: float) -> float:
     if planned == 0:
         return 0.0
     return (actual / planned) * 100
-
-from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.models.project import Project
-from app.models.schedule_block import ScheduleBlock
-from app.models.task import Task
-from app.models.time_entry import TimeEntry
-from app.schemas.analytics import (
-    PlannedVsActualResponse,
-    PlannedVsActualSummary,
-    ProjectWeeklyStats,
-    StatusTag,
-    TaskComparison,
-    WeeklyStatsSummary,
-    WeeklyStatsResponse,
-)
 
 
 def compute_status_tag(planned_hours: float, actual_hours: float) -> StatusTag:
@@ -143,7 +143,7 @@ async def get_weekly_stats(
     user_id: uuid.UUID,
     week_start: date,
 ) -> WeeklyStatsResponse:
-    """Return per-project planned vs actual hours for the week containing *week_start*."""
+    """Return per-project planned vs actual hours for the week containing week_start."""
     monday = align_to_monday(week_start)
     next_monday = monday + timedelta(days=7)
     sunday = monday + timedelta(days=6)
@@ -195,12 +195,10 @@ async def get_weekly_stats(
 
     # Merge in Python
     planned_map: dict[uuid.UUID, tuple[str, str, float]] = {
-        row.id: (row.name, row.color, float(row.planned_hours))
-        for row in planned_rows
+        row.id: (row.name, row.color, float(row.planned_hours)) for row in planned_rows
     }
     actual_map: dict[uuid.UUID, tuple[str, str, float]] = {
-        row.id: (row.name, row.color, float(row.actual_hours))
-        for row in actual_rows
+        row.id: (row.name, row.color, float(row.actual_hours)) for row in actual_rows
     }
 
     all_project_ids = set(planned_map) | set(actual_map)

--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, date, datetime, timedelta
 
+
+def align_to_monday(d: date) -> date:
+    """Return the Monday of the week containing *d*."""
+    return d - timedelta(days=d.weekday())
+
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -28,8 +28,11 @@ from app.models.time_entry import TimeEntry
 from app.schemas.analytics import (
     PlannedVsActualResponse,
     PlannedVsActualSummary,
+    ProjectWeeklyStats,
     StatusTag,
     TaskComparison,
+    WeeklyStatsSummary,
+    WeeklyStatsResponse,
 )
 
 
@@ -131,5 +134,110 @@ async def get_planned_vs_actual(
     return PlannedVsActualResponse(
         date=query_date,
         tasks=comparisons,
+        summary=summary,
+    )
+
+
+async def get_weekly_stats(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    week_start: date,
+) -> WeeklyStatsResponse:
+    """Return per-project planned vs actual hours for the week containing *week_start*."""
+    monday = align_to_monday(week_start)
+    next_monday = monday + timedelta(days=7)
+    sunday = monday + timedelta(days=6)
+
+    # Query 1: planned hours per project from schedule blocks
+    planned_stmt = (
+        select(
+            Project.id,
+            Project.name,
+            Project.color,
+            func.sum(ScheduleBlock.end_hour - ScheduleBlock.start_hour).label(
+                "planned_hours"
+            ),
+        )
+        .join(Task, ScheduleBlock.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            ScheduleBlock.date >= monday,
+            ScheduleBlock.date < next_monday,
+            Project.user_id == user_id,
+        )
+        .group_by(Project.id, Project.name, Project.color)
+    )
+    planned_result = await db.execute(planned_stmt)
+    planned_rows = planned_result.all()
+
+    # Query 2: actual hours per project from completed time entries
+    week_start_dt = datetime.combine(monday, datetime.min.time(), tzinfo=UTC)
+    week_end_dt = datetime.combine(next_monday, datetime.min.time(), tzinfo=UTC)
+    actual_stmt = (
+        select(
+            Project.id,
+            Project.name,
+            Project.color,
+            (func.sum(TimeEntry.duration_seconds) / 3600.0).label("actual_hours"),
+        )
+        .join(Task, TimeEntry.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            TimeEntry.started_at >= week_start_dt,
+            TimeEntry.started_at < week_end_dt,
+            TimeEntry.duration_seconds.isnot(None),
+            Project.user_id == user_id,
+        )
+        .group_by(Project.id, Project.name, Project.color)
+    )
+    actual_result = await db.execute(actual_stmt)
+    actual_rows = actual_result.all()
+
+    # Merge in Python
+    planned_map: dict[uuid.UUID, tuple[str, str, float]] = {
+        row.id: (row.name, row.color, float(row.planned_hours))
+        for row in planned_rows
+    }
+    actual_map: dict[uuid.UUID, tuple[str, str, float]] = {
+        row.id: (row.name, row.color, float(row.actual_hours))
+        for row in actual_rows
+    }
+
+    all_project_ids = set(planned_map) | set(actual_map)
+    projects: list[ProjectWeeklyStats] = []
+    for pid in sorted(all_project_ids):
+        name = planned_map[pid][0] if pid in planned_map else actual_map[pid][0]
+        color = planned_map[pid][1] if pid in planned_map else actual_map[pid][1]
+        planned_h = planned_map[pid][2] if pid in planned_map else 0.0
+        actual_h = actual_map[pid][2] if pid in actual_map else 0.0
+        projects.append(
+            ProjectWeeklyStats(
+                project_id=pid,
+                project_name=name,
+                project_color=color,
+                planned_hours=planned_h,
+                actual_hours=actual_h,
+                accuracy_pct=compute_accuracy_pct(planned_h, actual_h),
+            )
+        )
+
+    # Average accuracy — only projects where planned > 0
+    projects_with_plan = [p for p in projects if p.planned_hours > 0]
+    average_accuracy = (
+        sum(p.accuracy_pct for p in projects_with_plan) / len(projects_with_plan)
+        if projects_with_plan
+        else 0.0
+    )
+
+    summary = WeeklyStatsSummary(
+        total_planned_hours=sum(p.planned_hours for p in projects),
+        total_actual_hours=sum(p.actual_hours for p in projects),
+        average_accuracy_pct=average_accuracy,
+    )
+
+    return WeeklyStatsResponse(
+        week_start=monday,
+        week_end=sunday,
+        projects=projects,
         summary=summary,
     )

--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -31,7 +31,7 @@ def compute_accuracy_pct(planned: float, actual: float) -> float:
 
     Returns 0.0 when planned == 0 to avoid division by zero.
     """
-    if planned == 0:
+    if planned <= 0:
         return 0.0
     return (actual / planned) * 100
 

--- a/backend/tests/unit/test_weekly_stats_routes.py
+++ b/backend/tests/unit/test_weekly_stats_routes.py
@@ -13,8 +13,8 @@ from app.core.deps import get_current_user
 from app.main import app
 from app.schemas.analytics import (
     ProjectWeeklyStats,
-    WeeklyStatsSummary,
     WeeklyStatsResponse,
+    WeeklyStatsSummary,
 )
 
 USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")

--- a/backend/tests/unit/test_weekly_stats_routes.py
+++ b/backend/tests/unit/test_weekly_stats_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
-from datetime import date
+from datetime import date, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,7 +21,6 @@ USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 PROJ_X = uuid.UUID("00000000-0000-0000-0000-000000001001")
 
 WEEK_MONDAY = date(2026, 4, 13)
-WEEK_SUNDAY = date(2026, 4, 19)
 
 
 def _make_fake_user() -> MagicMock:
@@ -35,7 +34,7 @@ def _make_fake_user() -> MagicMock:
 def _make_weekly_response(week_start: date = WEEK_MONDAY) -> WeeklyStatsResponse:
     return WeeklyStatsResponse(
         week_start=week_start,
-        week_end=WEEK_SUNDAY,
+        week_end=week_start + timedelta(days=6),
         projects=[
             ProjectWeeklyStats(
                 project_id=PROJ_X,

--- a/backend/tests/unit/test_weekly_stats_routes.py
+++ b/backend/tests/unit/test_weekly_stats_routes.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.main import app
+from app.schemas.analytics import (
+    ProjectWeeklyStats,
+    WeeklyStatsSummary,
+    WeeklyStatsResponse,
+)
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+PROJ_X = uuid.UUID("00000000-0000-0000-0000-000000001001")
+
+WEEK_MONDAY = date(2026, 4, 13)
+WEEK_SUNDAY = date(2026, 4, 19)
+
+
+def _make_fake_user() -> MagicMock:
+    fake = MagicMock()
+    fake.id = USER_ID
+    fake.email = "test@example.com"
+    fake.name = "Test User"
+    return fake
+
+
+def _make_weekly_response(week_start: date = WEEK_MONDAY) -> WeeklyStatsResponse:
+    return WeeklyStatsResponse(
+        week_start=week_start,
+        week_end=WEEK_SUNDAY,
+        projects=[
+            ProjectWeeklyStats(
+                project_id=PROJ_X,
+                project_name="Project X",
+                project_color="#ff0000",
+                planned_hours=4.0,
+                actual_hours=3.0,
+                accuracy_pct=75.0,
+            )
+        ],
+        summary=WeeklyStatsSummary(
+            total_planned_hours=4.0,
+            total_actual_hours=3.0,
+            average_accuracy_pct=75.0,
+        ),
+    )
+
+
+@pytest.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+def _setup_overrides() -> None:
+    app.dependency_overrides[get_current_user] = _make_fake_user
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+
+
+def _clear_overrides() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /analytics/weekly-stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_weekly_stats_returns_200(client: AsyncClient) -> None:
+    """GET /analytics/weekly-stats with valid week_start returns 200."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.analytics.get_weekly_stats",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = _make_weekly_response()
+            response = await client.get(
+                "/analytics/weekly-stats", params={"week_start": "2026-04-13"}
+            )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["week_start"] == "2026-04-13"
+    assert data["week_end"] == "2026-04-19"
+    assert len(data["projects"]) == 1
+    assert data["projects"][0]["accuracy_pct"] == pytest.approx(75.0)
+
+
+@pytest.mark.asyncio
+async def test_weekly_stats_returns_401_without_auth(client: AsyncClient) -> None:
+    """GET /analytics/weekly-stats without auth returns 401."""
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.get(
+            "/analytics/weekly-stats", params={"week_start": "2026-04-13"}
+        )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_weekly_stats_requires_week_start_param(client: AsyncClient) -> None:
+    """GET /analytics/weekly-stats without week_start returns 422."""
+    _setup_overrides()
+    try:
+        response = await client.get("/analytics/weekly-stats")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_weekly_stats_rejects_invalid_date(client: AsyncClient) -> None:
+    """GET /analytics/weekly-stats with invalid date returns 422."""
+    _setup_overrides()
+    try:
+        response = await client.get(
+            "/analytics/weekly-stats", params={"week_start": "not-a-date"}
+        )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_weekly_stats_passes_params_to_service(client: AsyncClient) -> None:
+    """Service is called with parsed week_start and correct user_id."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.analytics.get_weekly_stats",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = _make_weekly_response()
+            await client.get(
+                "/analytics/weekly-stats", params={"week_start": "2026-04-13"}
+            )
+            mock_svc.assert_called_once()
+            call_kwargs = mock_svc.call_args.kwargs
+            assert call_kwargs["week_start"] == date(2026, 4, 13)
+            assert call_kwargs["user_id"] == USER_ID
+    finally:
+        _clear_overrides()
+
+
+@pytest.mark.asyncio
+async def test_weekly_stats_response_schema(client: AsyncClient) -> None:
+    """Response JSON has the expected top-level and summary keys."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.analytics.get_weekly_stats",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = _make_weekly_response()
+            response = await client.get(
+                "/analytics/weekly-stats", params={"week_start": "2026-04-13"}
+            )
+    finally:
+        _clear_overrides()
+
+    data = response.json()
+    assert set(data.keys()) == {"week_start", "week_end", "projects", "summary"}
+    assert set(data["summary"].keys()) == {
+        "total_planned_hours",
+        "total_actual_hours",
+        "average_accuracy_pct",
+    }
+    proj = data["projects"][0]
+    assert set(proj.keys()) == {
+        "project_id",
+        "project_name",
+        "project_color",
+        "planned_hours",
+        "actual_hours",
+        "accuracy_pct",
+    }

--- a/backend/tests/unit/test_weekly_stats_service.py
+++ b/backend/tests/unit/test_weekly_stats_service.py
@@ -170,3 +170,67 @@ async def test_get_weekly_stats_auto_aligns_to_monday() -> None:
     resp = await get_weekly_stats(db, USER_ID, wednesday)
 
     assert resp.week_start == WEEK_MONDAY  # aligned to Monday
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — SQL query inspection
+# ---------------------------------------------------------------------------
+
+
+def _compile(stmt: object) -> str:
+    return str(stmt.compile(compile_kwargs={"literal_binds": True}))  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_weekly_planned_query_joins_and_filters() -> None:
+    """Planned query must JOIN ScheduleBlock→Task→Project, group by project, filter by week range + user_id."""
+    db = _mock_weekly_db([], [])
+    await get_weekly_stats(db, USER_ID, WEEK_MONDAY)
+
+    planned_stmt = db.execute.call_args_list[0][0][0]
+    compiled = _compile(planned_stmt)
+
+    assert "schedule_blocks.task_id = tasks.id" in compiled.lower()
+    assert "tasks.project_id = projects.id" in compiled.lower()
+    assert "2026-04-13" in compiled   # week_start
+    assert "2026-04-20" in compiled   # next_monday
+    assert USER_ID.hex in compiled
+    assert " - " in compiled          # end_hour - start_hour
+
+
+@pytest.mark.asyncio
+async def test_weekly_actual_query_joins_and_filters() -> None:
+    """Actual query must JOIN TimeEntry→Task→Project, filter by datetime range + user_id, divide by 3600."""
+    db = _mock_weekly_db([], [])
+    await get_weekly_stats(db, USER_ID, WEEK_MONDAY)
+
+    actual_stmt = db.execute.call_args_list[1][0][0]
+    compiled = _compile(actual_stmt)
+
+    assert "time_entries.task_id = tasks.id" in compiled.lower()
+    assert "tasks.project_id = projects.id" in compiled.lower()
+    assert "2026-04-13" in compiled   # week_start_dt date part
+    assert "2026-04-20" in compiled   # week_end_dt date part
+    assert USER_ID.hex in compiled
+    assert "3600" in compiled
+    assert ">=" in compiled
+    assert "< '2026-04-20" in compiled
+
+
+@pytest.mark.asyncio
+async def test_weekly_date_range_spans_seven_days() -> None:
+    """Both queries must reference exactly the Monday and the following Monday."""
+    db = _mock_weekly_db([], [])
+    await get_weekly_stats(db, USER_ID, WEEK_MONDAY)
+
+    planned_stmt = db.execute.call_args_list[0][0][0]
+    actual_stmt = db.execute.call_args_list[1][0][0]
+
+    planned_compiled = _compile(planned_stmt)
+    actual_compiled = _compile(actual_stmt)
+
+    # Monday 2026-04-13 and next Monday 2026-04-20 must both appear
+    assert "2026-04-13" in planned_compiled
+    assert "2026-04-20" in planned_compiled
+    assert "2026-04-13" in actual_compiled
+    assert "2026-04-20" in actual_compiled

--- a/backend/tests/unit/test_weekly_stats_service.py
+++ b/backend/tests/unit/test_weekly_stats_service.py
@@ -4,7 +4,7 @@ from datetime import date
 
 import pytest
 
-from app.services.analytics_service import align_to_monday
+from app.services.analytics_service import align_to_monday, compute_accuracy_pct
 
 
 # ---------------------------------------------------------------------------
@@ -22,3 +22,24 @@ def test_align_to_monday_from_wednesday() -> None:
 
 def test_align_to_monday_from_sunday() -> None:
     assert align_to_monday(date(2026, 4, 19)) == date(2026, 4, 13)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — compute_accuracy_pct
+# ---------------------------------------------------------------------------
+
+
+def test_accuracy_pct_normal_case() -> None:
+    assert compute_accuracy_pct(2.0, 1.5) == 75.0
+
+
+def test_accuracy_pct_zero_planned() -> None:
+    assert compute_accuracy_pct(0.0, 1.5) == 0.0
+
+
+def test_accuracy_pct_over_100_percent() -> None:
+    assert compute_accuracy_pct(2.0, 4.0) == 200.0
+
+
+def test_accuracy_pct_exact_match() -> None:
+    assert compute_accuracy_pct(3.0, 3.0) == 100.0

--- a/backend/tests/unit/test_weekly_stats_service.py
+++ b/backend/tests/unit/test_weekly_stats_service.py
@@ -6,6 +6,8 @@ from datetime import date
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from app.services.analytics_service import (
     align_to_monday,
@@ -49,6 +51,29 @@ def test_accuracy_pct_over_100_percent() -> None:
 
 def test_accuracy_pct_exact_match() -> None:
     assert compute_accuracy_pct(3.0, 3.0) == 100.0
+
+
+# ---------------------------------------------------------------------------
+# compute_accuracy_pct — property-based tests
+# ---------------------------------------------------------------------------
+
+
+@given(
+    planned=st.floats(min_value=0.01, max_value=1000.0),
+    actual=st.floats(min_value=0.0, max_value=1000.0),
+)
+def test_accuracy_pct_positive_planned_returns_ratio(
+    planned: float, actual: float
+) -> None:
+    """When planned > 0, result equals (actual / planned) * 100."""
+    result = compute_accuracy_pct(planned, actual)
+    assert result == pytest.approx((actual / planned) * 100, rel=1e-6)
+
+
+@given(actual=st.floats(min_value=0.0, max_value=1000.0))
+def test_accuracy_pct_zero_planned_always_zero(actual: float) -> None:
+    """When planned == 0, result is always 0.0 regardless of actual."""
+    assert compute_accuracy_pct(0.0, actual) == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_weekly_stats_service.py
+++ b/backend/tests/unit/test_weekly_stats_service.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import uuid
+from collections import namedtuple
 from datetime import date
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from app.services.analytics_service import align_to_monday, compute_accuracy_pct
+from app.services.analytics_service import (
+    align_to_monday,
+    compute_accuracy_pct,
+    get_weekly_stats,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -43,3 +50,123 @@ def test_accuracy_pct_over_100_percent() -> None:
 
 def test_accuracy_pct_exact_match() -> None:
     assert compute_accuracy_pct(3.0, 3.0) == 100.0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — get_weekly_stats (mocked DB)
+# ---------------------------------------------------------------------------
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+PROJ_X = uuid.UUID("00000000-0000-0000-0000-000000001001")
+PROJ_Y = uuid.UUID("00000000-0000-0000-0000-000000001002")
+
+PlannedProjectRow = namedtuple(
+    "PlannedProjectRow", ["id", "name", "color", "planned_hours"]
+)
+ActualProjectRow = namedtuple(
+    "ActualProjectRow", ["id", "name", "color", "actual_hours"]
+)
+
+WEEK_MONDAY = date(2026, 4, 13)  # known Monday
+
+
+def _mock_weekly_db(
+    planned_rows: list[PlannedProjectRow],
+    actual_rows: list[ActualProjectRow],
+) -> AsyncMock:
+    db = AsyncMock()
+    planned_result = MagicMock()
+    planned_result.all.return_value = planned_rows
+    actual_result = MagicMock()
+    actual_result.all.return_value = actual_rows
+    db.execute.side_effect = [planned_result, actual_result]
+    return db
+
+
+@pytest.mark.asyncio
+async def test_get_weekly_stats_mixed_projects() -> None:
+    """Two projects: one with planned+actual, one with only planned."""
+    db = _mock_weekly_db(
+        planned_rows=[
+            PlannedProjectRow(PROJ_X, "Project X", "#ff0000", 4.0),
+            PlannedProjectRow(PROJ_Y, "Project Y", "#00ff00", 2.0),
+        ],
+        actual_rows=[
+            ActualProjectRow(PROJ_X, "Project X", "#ff0000", 3.0),
+        ],
+    )
+    resp = await get_weekly_stats(db, USER_ID, WEEK_MONDAY)
+
+    assert resp.week_start == WEEK_MONDAY
+    assert resp.week_end == date(2026, 4, 19)
+
+    by_id = {p.project_id: p for p in resp.projects}
+    assert by_id[PROJ_X].planned_hours == pytest.approx(4.0)
+    assert by_id[PROJ_X].actual_hours == pytest.approx(3.0)
+    assert by_id[PROJ_X].accuracy_pct == pytest.approx(75.0)
+
+    assert by_id[PROJ_Y].planned_hours == pytest.approx(2.0)
+    assert by_id[PROJ_Y].actual_hours == pytest.approx(0.0)
+    assert by_id[PROJ_Y].accuracy_pct == pytest.approx(0.0)
+
+    assert resp.summary.total_planned_hours == pytest.approx(6.0)
+    assert resp.summary.total_actual_hours == pytest.approx(3.0)
+    # Both projects have planned > 0: mean of [75.0, 0.0] = 37.5
+    assert resp.summary.average_accuracy_pct == pytest.approx(37.5)
+
+
+@pytest.mark.asyncio
+async def test_get_weekly_stats_empty_week() -> None:
+    """No data at all → empty projects list, zero summary."""
+    db = _mock_weekly_db([], [])
+    resp = await get_weekly_stats(db, USER_ID, WEEK_MONDAY)
+
+    assert resp.projects == []
+    assert resp.summary.total_planned_hours == 0.0
+    assert resp.summary.total_actual_hours == 0.0
+    assert resp.summary.average_accuracy_pct == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_weekly_stats_only_actual() -> None:
+    """Unplanned work: actual but no schedule blocks."""
+    db = _mock_weekly_db(
+        planned_rows=[],
+        actual_rows=[ActualProjectRow(PROJ_X, "Project X", "#ff0000", 2.0)],
+    )
+    resp = await get_weekly_stats(db, USER_ID, WEEK_MONDAY)
+
+    assert len(resp.projects) == 1
+    proj = resp.projects[0]
+    assert proj.planned_hours == pytest.approx(0.0)
+    assert proj.actual_hours == pytest.approx(2.0)
+    assert proj.accuracy_pct == pytest.approx(0.0)
+    # No projects with planned > 0 → average is 0.0
+    assert resp.summary.average_accuracy_pct == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_get_weekly_stats_only_planned() -> None:
+    """Planned but no actuals → accuracy 0%."""
+    db = _mock_weekly_db(
+        planned_rows=[PlannedProjectRow(PROJ_X, "Project X", "#ff0000", 3.0)],
+        actual_rows=[],
+    )
+    resp = await get_weekly_stats(db, USER_ID, WEEK_MONDAY)
+
+    assert len(resp.projects) == 1
+    proj = resp.projects[0]
+    assert proj.planned_hours == pytest.approx(3.0)
+    assert proj.actual_hours == pytest.approx(0.0)
+    assert proj.accuracy_pct == pytest.approx(0.0)
+    assert resp.summary.average_accuracy_pct == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_get_weekly_stats_auto_aligns_to_monday() -> None:
+    """Passing a Wednesday still returns a response with week_start on Monday."""
+    db = _mock_weekly_db([], [])
+    wednesday = date(2026, 4, 15)
+    resp = await get_weekly_stats(db, USER_ID, wednesday)
+
+    assert resp.week_start == WEEK_MONDAY  # aligned to Monday

--- a/backend/tests/unit/test_weekly_stats_service.py
+++ b/backend/tests/unit/test_weekly_stats_service.py
@@ -13,7 +13,6 @@ from app.services.analytics_service import (
     get_weekly_stats,
 )
 
-
 # ---------------------------------------------------------------------------
 # Cycle 1 — align_to_monday
 # ---------------------------------------------------------------------------
@@ -183,7 +182,7 @@ def _compile(stmt: object) -> str:
 
 @pytest.mark.asyncio
 async def test_weekly_planned_query_joins_and_filters() -> None:
-    """Planned query must JOIN ScheduleBlock→Task→Project, group by project, filter by week range + user_id."""
+    """Planned query must JOIN ScheduleBlock→Task→Project, group by project."""
     db = _mock_weekly_db([], [])
     await get_weekly_stats(db, USER_ID, WEEK_MONDAY)
 
@@ -192,15 +191,15 @@ async def test_weekly_planned_query_joins_and_filters() -> None:
 
     assert "schedule_blocks.task_id = tasks.id" in compiled.lower()
     assert "tasks.project_id = projects.id" in compiled.lower()
-    assert "2026-04-13" in compiled   # week_start
-    assert "2026-04-20" in compiled   # next_monday
+    assert "2026-04-13" in compiled  # week_start
+    assert "2026-04-20" in compiled  # next_monday
     assert USER_ID.hex in compiled
-    assert " - " in compiled          # end_hour - start_hour
+    assert " - " in compiled  # end_hour - start_hour
 
 
 @pytest.mark.asyncio
 async def test_weekly_actual_query_joins_and_filters() -> None:
-    """Actual query must JOIN TimeEntry→Task→Project, filter by datetime range + user_id, divide by 3600."""
+    """Actual query must JOIN TimeEntry→Task→Project, filter by datetime range."""
     db = _mock_weekly_db([], [])
     await get_weekly_stats(db, USER_ID, WEEK_MONDAY)
 
@@ -209,8 +208,8 @@ async def test_weekly_actual_query_joins_and_filters() -> None:
 
     assert "time_entries.task_id = tasks.id" in compiled.lower()
     assert "tasks.project_id = projects.id" in compiled.lower()
-    assert "2026-04-13" in compiled   # week_start_dt date part
-    assert "2026-04-20" in compiled   # week_end_dt date part
+    assert "2026-04-13" in compiled  # week_start_dt date part
+    assert "2026-04-20" in compiled  # week_end_dt date part
     assert USER_ID.hex in compiled
     assert "3600" in compiled
     assert ">=" in compiled

--- a/backend/tests/unit/test_weekly_stats_service.py
+++ b/backend/tests/unit/test_weekly_stats_service.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.analytics_service import align_to_monday
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — align_to_monday
+# ---------------------------------------------------------------------------
+
+
+def test_align_to_monday_already_monday() -> None:
+    assert align_to_monday(date(2026, 4, 13)) == date(2026, 4, 13)
+
+
+def test_align_to_monday_from_wednesday() -> None:
+    assert align_to_monday(date(2026, 4, 15)) == date(2026, 4, 13)
+
+
+def test_align_to_monday_from_sunday() -> None:
+    assert align_to_monday(date(2026, 4, 19)) == date(2026, 4, 13)


### PR DESCRIPTION
## Summary
- Adds `GET /analytics/weekly-stats?week_start=YYYY-MM-DD` — per-project weekly breakdown of planned vs actual hours
- Auto-aligns any input date to the Monday of that week
- Returns `planned_hours`, `actual_hours`, `accuracy_pct` per project plus overall totals, suitable for bar chart rendering

## Implementation
- **Schemas** (`schemas/analytics.py`): `ProjectWeeklyStats`, `WeeklyStatsSummary`, `WeeklyStatsResponse`
- **Service** (`services/analytics_service.py`): `align_to_monday`, `compute_accuracy_pct`, `get_weekly_stats` — two SQL queries (ScheduleBlock + TimeEntry) grouped by Project, merged in Python
- **Route** (`api/analytics.py`): thin handler delegating to service, protected by `get_current_user`

## Test plan
- [x] Unit tests for pure functions (`align_to_monday`, `compute_accuracy_pct`) including Hypothesis property-based tests
- [x] Mocked DB tests for `get_weekly_stats` (mixed, empty, only-planned, only-actual, auto-align)
- [x] SQL query inspection tests (JOINs, date range, user_id filter, operators)
- [x] Route tests (200, 401, 422 missing param, 422 invalid date, arg forwarding, schema shape)
- [x] 383 unit tests passing, `ruff` clean, `mypy` clean

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)