### PR TITLE
[#23] Implement ExternalSync model and base sync framework

### DIFF
--- a/backend/alembic/versions/0007_add_external_syncs_table.py
+++ b/backend/alembic/versions/0007_add_external_syncs_table.py
@@ -1,0 +1,74 @@
+"""add external_syncs table
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-04-17
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0007"
+down_revision: str = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "external_syncs",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id"),
+            nullable=False,
+        ),
+        sa.Column("provider", sa.String(20), nullable=False),
+        sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "sync_config_json",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default="active",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "provider IN ('google_calendar', 'github')",
+            name="ck_external_syncs_provider",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'paused', 'error')",
+            name="ck_external_syncs_status",
+        ),
+    )
+    op.create_index(
+        "idx_external_sync_user_provider",
+        "external_syncs",
+        ["user_id", "provider"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_external_sync_user_provider", table_name="external_syncs")
+    op.drop_table("external_syncs")

--- a/backend/app/api/sync.py
+++ b/backend/app/api/sync.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
 from app.core.deps import get_current_user
+from app.models.external_sync import SyncProvider
 from app.models.user import User
 from app.schemas.sync import SyncStatusResponse
 from app.services.sync_service import get_sync_status, trigger_sync
@@ -24,7 +25,7 @@ async def get_sync_status_route(
 
 @router.post("/{provider}/trigger", response_model=SyncStatusResponse)
 async def trigger_sync_route(
-    provider: str,
+    provider: SyncProvider,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> SyncStatusResponse:

--- a/backend/app/api/sync.py
+++ b/backend/app/api/sync.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.models.user import User
+from app.schemas.sync import SyncStatusResponse
+from app.services.sync_service import get_sync_status, trigger_sync
+
+router = APIRouter(prefix="/sync", tags=["sync"])
+
+
+@router.get("/status", response_model=list[SyncStatusResponse])
+async def get_sync_status_route(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[SyncStatusResponse]:
+    """Return all sync connections for the current user."""
+    records = await get_sync_status(db=db, user_id=current_user.id)
+    return [SyncStatusResponse.model_validate(r) for r in records]
+
+
+@router.post("/{provider}/trigger", response_model=SyncStatusResponse)
+async def trigger_sync_route(
+    provider: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SyncStatusResponse:
+    """Manually trigger a sync for the given provider."""
+    record = await trigger_sync(db=db, user_id=current_user.id, provider=provider)
+    return SyncStatusResponse.model_validate(record)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from app.api.auth import router as auth_router
 from app.api.health import router as health_router
 from app.api.projects import router as projects_router
 from app.api.schedule_blocks import router as schedule_blocks_router
+from app.api.sync import router as sync_router
 from app.api.tasks import router as tasks_router
 from app.api.time_entries import router as time_entries_router
 from app.core.config import settings
@@ -51,6 +52,7 @@ def create_app() -> FastAPI:
     app.include_router(projects_router)
     app.include_router(tasks_router)
     app.include_router(schedule_blocks_router)
+    app.include_router(sync_router)
     app.include_router(time_entries_router)
 
     return app

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,8 @@
+from app.models.external_sync import ExternalSync
 from app.models.project import Project
 from app.models.schedule_block import ScheduleBlock
 from app.models.task import Task
 from app.models.time_entry import TimeEntry
 from app.models.user import User
 
-__all__ = ["Project", "ScheduleBlock", "Task", "TimeEntry", "User"]
+__all__ = ["ExternalSync", "Project", "ScheduleBlock", "Task", "TimeEntry", "User"]

--- a/backend/app/models/external_sync.py
+++ b/backend/app/models/external_sync.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class SyncProvider(enum.StrEnum):
+    """Supported external sync providers."""
+
+    GOOGLE_CALENDAR = "google_calendar"
+    GITHUB = "github"
+
+
+class SyncStatus(enum.StrEnum):
+    """Sync connection lifecycle status."""
+
+    ACTIVE = "active"
+    PAUSED = "paused"
+    ERROR = "error"
+
+
+class ExternalSync(Base):
+    """ExternalSync entity -- see docs/DATA_MODEL.md for full specification."""
+
+    __tablename__ = "external_syncs"
+    __table_args__ = (
+        CheckConstraint(
+            "provider IN ('google_calendar', 'github')",
+            name="ck_external_syncs_provider",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'paused', 'error')",
+            name="ck_external_syncs_status",
+        ),
+        Index("idx_external_sync_user_provider", "user_id", "provider", unique=True),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False
+    )
+    provider: Mapped[str] = mapped_column(String(20), nullable=False)
+    last_synced_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    sync_config_json: Mapped[dict] = mapped_column(  # type: ignore[type-arg]
+        JSONB, nullable=False, server_default=text("'{}'")
+    )
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=SyncStatus.ACTIVE
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
+
+    def __repr__(self) -> str:
+        return f"<ExternalSync(id={self.id}, provider={self.provider})>"

--- a/backend/app/schemas/sync.py
+++ b/backend/app/schemas/sync.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SyncStatusResponse(BaseModel):
+    """Response schema for an ExternalSync record."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    provider: str
+    status: str
+    last_synced_at: datetime | None
+    sync_config_json: dict  # type: ignore[type-arg]
+    created_at: datetime

--- a/backend/app/services/sync_provider.py
+++ b/backend/app/services/sync_provider.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import abc
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.external_sync import ExternalSync
+
+
+class BaseSyncProvider(abc.ABC):
+    """Abstract base class for external sync providers."""
+
+    @abc.abstractmethod
+    async def sync(self, db: AsyncSession, sync_record: ExternalSync) -> None:
+        """Execute sync for the given ExternalSync record."""
+        ...
+
+
+class ProviderRegistry:
+    """Registry mapping provider names to BaseSyncProvider subclasses."""
+
+    def __init__(self) -> None:
+        self._providers: dict[str, type[BaseSyncProvider]] = {}
+
+    def register(
+        self, provider_name: str, provider_class: type[BaseSyncProvider]
+    ) -> None:
+        """Register a provider class under the given name."""
+        self._providers[provider_name] = provider_class
+
+    def get(self, provider_name: str) -> type[BaseSyncProvider] | None:
+        """Return the provider class for the given name, or None."""
+        return self._providers.get(provider_name)
+
+    def list_providers(self) -> list[str]:
+        """Return all registered provider names."""
+        return list(self._providers.keys())
+
+
+# Module-level singleton used by the sync service
+provider_registry = ProviderRegistry()

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import UTC, datetime
 
@@ -9,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.external_sync import ExternalSync, SyncStatus
 from app.services.sync_provider import provider_registry
+
+logger = logging.getLogger(__name__)
 
 
 async def get_sync_status(
@@ -51,7 +54,10 @@ async def trigger_sync(
         await provider_instance.sync(db, sync_record)
         sync_record.last_synced_at = datetime.now(UTC)
         sync_record.status = SyncStatus.ACTIVE
+    except HTTPException:
+        raise
     except Exception:
+        logger.exception("sync failed for provider %s (user %s)", provider, user_id)
         sync_record.status = SyncStatus.ERROR
 
     await db.commit()

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.external_sync import ExternalSync, SyncStatus
+from app.services.sync_provider import provider_registry
+
+
+async def get_sync_status(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> list[ExternalSync]:
+    """Return all ExternalSync records for the given user."""
+    stmt = select(ExternalSync).where(ExternalSync.user_id == user_id)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def trigger_sync(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    provider: str,
+) -> ExternalSync:
+    """Trigger a sync for the given provider and user.
+
+    Raises HTTP 404 if no ExternalSync record exists.
+    Raises HTTP 501 if the provider is not registered.
+    On provider error, sets status to 'error' and commits.
+    """
+    stmt = select(ExternalSync).where(
+        ExternalSync.user_id == user_id,
+        ExternalSync.provider == provider,
+    )
+    result = await db.execute(stmt)
+    sync_record = result.scalar_one_or_none()
+
+    if sync_record is None:
+        raise HTTPException(status_code=404, detail="Sync connection not found")
+
+    provider_cls = provider_registry.get(provider)
+    if provider_cls is None:
+        raise HTTPException(status_code=501, detail="Provider not implemented")
+
+    try:
+        provider_instance = provider_cls()
+        await provider_instance.sync(db, sync_record)
+        sync_record.last_synced_at = datetime.now(UTC)
+        sync_record.status = SyncStatus.ACTIVE
+    except Exception:
+        sync_record.status = SyncStatus.ERROR
+
+    await db.commit()
+    await db.refresh(sync_record)
+    return sync_record

--- a/backend/tests/unit/test_external_sync_model.py
+++ b/backend/tests/unit/test_external_sync_model.py
@@ -54,7 +54,10 @@ def test_external_sync_provider_not_nullable() -> None:
 
 def test_external_sync_provider_is_string_20() -> None:
     """ExternalSync.provider must be String(20)."""
+    from sqlalchemy import String as SAString
+
     col = inspect(ExternalSync).columns["provider"]
+    assert isinstance(col.type, SAString)
     assert col.type.length == 20
 
 
@@ -66,7 +69,10 @@ def test_external_sync_last_synced_at_nullable() -> None:
 
 def test_external_sync_last_synced_at_is_datetime_tz() -> None:
     """ExternalSync.last_synced_at must be timezone-aware."""
+    from sqlalchemy import DateTime as SADateTime
+
     col = inspect(ExternalSync).columns["last_synced_at"]
+    assert isinstance(col.type, SADateTime)
     assert col.type.timezone is True
 
 
@@ -103,7 +109,10 @@ def test_external_sync_created_at_not_nullable() -> None:
 
 def test_external_sync_created_at_is_datetime_tz() -> None:
     """ExternalSync.created_at must be timezone-aware."""
+    from sqlalchemy import DateTime as SADateTime
+
     col = inspect(ExternalSync).columns["created_at"]
+    assert isinstance(col.type, SADateTime)
     assert col.type.timezone is True
 
 

--- a/backend/tests/unit/test_external_sync_model.py
+++ b/backend/tests/unit/test_external_sync_model.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import inspect
+
+from app.models.external_sync import ExternalSync, SyncProvider, SyncStatus
+
+
+def test_external_sync_table_name() -> None:
+    """ExternalSync.__tablename__ must be 'external_syncs'."""
+    assert ExternalSync.__tablename__ == "external_syncs"
+
+
+def test_external_sync_has_required_columns() -> None:
+    """ExternalSync model must have all columns defined in DATA_MODEL.md."""
+    columns = {c.name for c in inspect(ExternalSync).columns}
+    expected = {
+        "id",
+        "user_id",
+        "provider",
+        "last_synced_at",
+        "sync_config_json",
+        "status",
+        "created_at",
+    }
+    assert expected.issubset(columns), f"Missing columns: {expected - columns}"
+
+
+def test_external_sync_id_is_uuid() -> None:
+    """ExternalSync.id column type must be UUID."""
+    col = inspect(ExternalSync).columns["id"]
+    assert "UUID" in str(col.type).upper()
+
+
+def test_external_sync_user_id_is_foreign_key() -> None:
+    """ExternalSync.user_id must reference users.id."""
+    col = inspect(ExternalSync).columns["user_id"]
+    fk_targets = {fk.target_fullname for fk in col.foreign_keys}
+    assert "users.id" in fk_targets
+
+
+def test_external_sync_user_id_not_nullable() -> None:
+    """ExternalSync.user_id must be NOT NULL."""
+    col = inspect(ExternalSync).columns["user_id"]
+    assert col.nullable is False
+
+
+def test_external_sync_provider_not_nullable() -> None:
+    """ExternalSync.provider must be NOT NULL."""
+    col = inspect(ExternalSync).columns["provider"]
+    assert col.nullable is False
+
+
+def test_external_sync_provider_is_string_20() -> None:
+    """ExternalSync.provider must be String(20)."""
+    col = inspect(ExternalSync).columns["provider"]
+    assert col.type.length == 20
+
+
+def test_external_sync_last_synced_at_nullable() -> None:
+    """ExternalSync.last_synced_at must be NULLABLE."""
+    col = inspect(ExternalSync).columns["last_synced_at"]
+    assert col.nullable is True
+
+
+def test_external_sync_last_synced_at_is_datetime_tz() -> None:
+    """ExternalSync.last_synced_at must be timezone-aware."""
+    col = inspect(ExternalSync).columns["last_synced_at"]
+    assert col.type.timezone is True
+
+
+def test_external_sync_status_not_nullable() -> None:
+    """ExternalSync.status must be NOT NULL."""
+    col = inspect(ExternalSync).columns["status"]
+    assert col.nullable is False
+
+
+def test_external_sync_status_has_default_active() -> None:
+    """ExternalSync.status must default to SyncStatus.ACTIVE."""
+    col = inspect(ExternalSync).columns["status"]
+    assert col.default is not None
+    assert col.default.arg == SyncStatus.ACTIVE  # type: ignore[attr-defined]
+
+
+def test_external_sync_sync_config_json_type() -> None:
+    """ExternalSync.sync_config_json must be JSONB."""
+    col = inspect(ExternalSync).columns["sync_config_json"]
+    assert "JSONB" in str(col.type).upper()
+
+
+def test_external_sync_sync_config_json_not_nullable() -> None:
+    """ExternalSync.sync_config_json must be NOT NULL."""
+    col = inspect(ExternalSync).columns["sync_config_json"]
+    assert col.nullable is False
+
+
+def test_external_sync_created_at_not_nullable() -> None:
+    """ExternalSync.created_at must be NOT NULL."""
+    col = inspect(ExternalSync).columns["created_at"]
+    assert col.nullable is False
+
+
+def test_external_sync_created_at_is_datetime_tz() -> None:
+    """ExternalSync.created_at must be timezone-aware."""
+    col = inspect(ExternalSync).columns["created_at"]
+    assert col.type.timezone is True
+
+
+def test_external_sync_has_provider_check_constraint() -> None:
+    """ExternalSync must have a CHECK constraint on provider column."""
+    constraints = {c.name for c in ExternalSync.__table__.constraints}  # type: ignore[attr-defined]
+    assert "ck_external_syncs_provider" in constraints
+
+
+def test_external_sync_has_status_check_constraint() -> None:
+    """ExternalSync must have a CHECK constraint on status column."""
+    constraints = {c.name for c in ExternalSync.__table__.constraints}  # type: ignore[attr-defined]
+    assert "ck_external_syncs_status" in constraints
+
+
+def test_external_sync_has_unique_user_provider_index() -> None:
+    """ExternalSync must have a unique index on (user_id, provider)."""
+    indexes = {idx.name: idx for idx in ExternalSync.__table__.indexes}  # type: ignore[attr-defined]
+    assert "idx_external_sync_user_provider" in indexes
+    assert indexes["idx_external_sync_user_provider"].unique is True
+
+
+def test_sync_provider_enum_values() -> None:
+    """SyncProvider enum must have google_calendar and github values."""
+    assert SyncProvider.GOOGLE_CALENDAR.value == "google_calendar"
+    assert SyncProvider.GITHUB.value == "github"
+
+
+def test_sync_status_enum_values() -> None:
+    """SyncStatus enum must have active, paused, and error values."""
+    assert SyncStatus.ACTIVE.value == "active"
+    assert SyncStatus.PAUSED.value == "paused"
+    assert SyncStatus.ERROR.value == "error"
+
+
+def test_external_sync_repr_contains_id() -> None:
+    """ExternalSync.__repr__ should include the id for debugging."""
+    sync_id = uuid.uuid4()
+    obj = ExternalSync(
+        id=sync_id,
+        user_id=uuid.uuid4(),
+        provider=SyncProvider.GITHUB,
+    )
+    assert str(sync_id) in repr(obj)

--- a/backend/tests/unit/test_sync_provider.py
+++ b/backend/tests/unit/test_sync_provider.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.sync_provider import BaseSyncProvider, ProviderRegistry
+
+
+class _FakeProvider(BaseSyncProvider):
+    async def sync(self, db, sync_record) -> None:  # type: ignore[override]
+        pass
+
+
+class _AnotherProvider(BaseSyncProvider):
+    async def sync(self, db, sync_record) -> None:  # type: ignore[override]
+        pass
+
+
+def test_base_sync_provider_is_abstract() -> None:
+    """BaseSyncProvider cannot be instantiated directly."""
+    with pytest.raises(TypeError):
+        BaseSyncProvider()  # type: ignore[abstract]
+
+
+def test_base_sync_provider_sync_is_abstract_method() -> None:
+    """BaseSyncProvider.sync must be declared as an abstract method."""
+    assert getattr(BaseSyncProvider.sync, "__isabstractmethod__", False) is True
+
+
+def test_concrete_provider_can_be_instantiated() -> None:
+    """A concrete subclass implementing sync() can be instantiated."""
+    provider = _FakeProvider()
+    assert isinstance(provider, BaseSyncProvider)
+
+
+def test_provider_registry_register_and_get() -> None:
+    """Registered provider can be retrieved by name."""
+    registry = ProviderRegistry()
+    registry.register("github", _FakeProvider)
+    assert registry.get("github") is _FakeProvider
+
+
+def test_provider_registry_get_unknown_returns_none() -> None:
+    """Getting an unregistered provider name returns None."""
+    registry = ProviderRegistry()
+    assert registry.get("nonexistent") is None
+
+
+def test_provider_registry_register_overwrites() -> None:
+    """Re-registering a name overwrites the previous class."""
+    registry = ProviderRegistry()
+    registry.register("github", _FakeProvider)
+    registry.register("github", _AnotherProvider)
+    assert registry.get("github") is _AnotherProvider
+
+
+def test_provider_registry_list_providers() -> None:
+    """list_providers() returns all registered provider names."""
+    registry = ProviderRegistry()
+    registry.register("github", _FakeProvider)
+    registry.register("google_calendar", _AnotherProvider)
+    assert set(registry.list_providers()) == {"github", "google_calendar"}

--- a/backend/tests/unit/test_sync_provider.py
+++ b/backend/tests/unit/test_sync_provider.py
@@ -6,12 +6,12 @@ from app.services.sync_provider import BaseSyncProvider, ProviderRegistry
 
 
 class _FakeProvider(BaseSyncProvider):
-    async def sync(self, db, sync_record) -> None:  # type: ignore[override]
+    async def sync(self, db: object, sync_record: object) -> None:
         pass
 
 
 class _AnotherProvider(BaseSyncProvider):
-    async def sync(self, db, sync_record) -> None:  # type: ignore[override]
+    async def sync(self, db: object, sync_record: object) -> None:
         pass
 
 

--- a/backend/tests/unit/test_sync_routes.py
+++ b/backend/tests/unit/test_sync_routes.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.main import app
+from app.schemas.sync import SyncStatusResponse
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+SYNC_ID = uuid.UUID("00000000-0000-0000-0000-aaaaaaaaaaaa")
+
+
+def _make_fake_user() -> MagicMock:
+    fake = MagicMock()
+    fake.id = USER_ID
+    fake.email = "test@example.com"
+    fake.name = "Test User"
+    return fake
+
+
+def _make_sync_response(provider: str = "github") -> SyncStatusResponse:
+    return SyncStatusResponse(
+        id=SYNC_ID,
+        provider=provider,
+        status="active",
+        last_synced_at=None,
+        sync_config_json={},
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+def _setup_overrides() -> None:
+    app.dependency_overrides[get_current_user] = _make_fake_user
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+
+
+def _clear_overrides() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /sync/status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_sync_status_returns_200(client: AsyncClient) -> None:
+    """GET /sync/status returns 200 with list of sync connections."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.sync.get_sync_status",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = [_make_sync_response()]
+            response = await client.get("/sync/status")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["provider"] == "github"
+
+
+@pytest.mark.asyncio
+async def test_get_sync_status_returns_401_without_auth(client: AsyncClient) -> None:
+    """GET /sync/status without auth returns 401."""
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.get("/sync/status")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_sync_status_returns_empty_list(client: AsyncClient) -> None:
+    """GET /sync/status returns 200 with empty list when no connections."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.sync.get_sync_status",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = []
+            response = await client.get("/sync/status")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+# ---------------------------------------------------------------------------
+# POST /sync/{provider}/trigger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_returns_200(client: AsyncClient) -> None:
+    """POST /sync/github/trigger returns 200 with updated sync record."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.sync.trigger_sync",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = _make_sync_response("github")
+            response = await client.post("/sync/github/trigger")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    assert response.json()["provider"] == "github"
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_returns_401_without_auth(client: AsyncClient) -> None:
+    """POST /sync/github/trigger without auth returns 401."""
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.post("/sync/github/trigger")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_returns_404_no_sync_record(client: AsyncClient) -> None:
+    """POST /sync/github/trigger returns 404 when no sync record found."""
+    from fastapi import HTTPException
+
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.sync.trigger_sync",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.side_effect = HTTPException(
+                status_code=404, detail="Sync connection not found"
+            )
+            response = await client.post("/sync/github/trigger")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_returns_501_unknown_provider(client: AsyncClient) -> None:
+    """POST /sync/github/trigger returns 501 when provider not implemented."""
+    from fastapi import HTTPException
+
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.sync.trigger_sync",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.side_effect = HTTPException(
+                status_code=501, detail="Provider not implemented"
+            )
+            response = await client.post("/sync/github/trigger")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 501
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_passes_provider_to_service(client: AsyncClient) -> None:
+    """POST /sync/{provider}/trigger passes provider string to service."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.sync.trigger_sync",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = _make_sync_response("google_calendar")
+            await client.post("/sync/google_calendar/trigger")
+            mock_svc.assert_called_once()
+            call_kwargs = mock_svc.call_args.kwargs
+            assert call_kwargs["provider"] == "google_calendar"
+            assert call_kwargs["user_id"] == USER_ID
+    finally:
+        _clear_overrides()

--- a/backend/tests/unit/test_sync_routes.py
+++ b/backend/tests/unit/test_sync_routes.py
@@ -86,6 +86,7 @@ async def test_get_sync_status_returns_200(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_get_sync_status_returns_401_without_auth(client: AsyncClient) -> None:
     """GET /sync/status without auth returns 401."""
+
     async def override_db() -> AsyncMock:  # type: ignore[misc]
         yield AsyncMock()
 
@@ -142,6 +143,7 @@ async def test_trigger_sync_returns_200(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_trigger_sync_returns_401_without_auth(client: AsyncClient) -> None:
     """POST /sync/github/trigger without auth returns 401."""
+
     async def override_db() -> AsyncMock:  # type: ignore[misc]
         yield AsyncMock()
 
@@ -213,3 +215,15 @@ async def test_trigger_sync_passes_provider_to_service(client: AsyncClient) -> N
             assert call_kwargs["user_id"] == USER_ID
     finally:
         _clear_overrides()
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_rejects_invalid_provider(client: AsyncClient) -> None:
+    """POST /sync/invalid_provider/trigger returns 422 (FastAPI enum validation)."""
+    _setup_overrides()
+    try:
+        response = await client.post("/sync/invalid_provider/trigger")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 422

--- a/backend/tests/unit/test_sync_schema.py
+++ b/backend/tests/unit/test_sync_schema.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.sync import SyncStatusResponse
+
+
+def test_sync_status_response_from_attributes() -> None:
+    """SyncStatusResponse must have from_attributes=True for ORM conversion."""
+    assert SyncStatusResponse.model_config.get("from_attributes") is True
+
+
+def test_sync_status_response_round_trip() -> None:
+    """SyncStatusResponse instantiates correctly with all fields."""
+    sync_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    resp = SyncStatusResponse(
+        id=sync_id,
+        provider="github",
+        status="active",
+        last_synced_at=now,
+        sync_config_json={},
+        created_at=now,
+    )
+    assert resp.id == sync_id
+    assert resp.provider == "github"
+    assert resp.status == "active"
+    assert resp.last_synced_at == now
+    assert resp.sync_config_json == {}
+    assert resp.created_at == now
+
+
+def test_sync_status_response_allows_null_last_synced_at() -> None:
+    """SyncStatusResponse must accept last_synced_at=None."""
+    now = datetime.now(UTC)
+    resp = SyncStatusResponse(
+        id=uuid.uuid4(),
+        provider="google_calendar",
+        status="active",
+        last_synced_at=None,
+        sync_config_json={},
+        created_at=now,
+    )
+    assert resp.last_synced_at is None
+
+
+def test_sync_status_response_rejects_missing_required_fields() -> None:
+    """SyncStatusResponse raises ValidationError when required fields are missing."""
+    with pytest.raises(ValidationError):
+        SyncStatusResponse(provider="github")  # type: ignore[call-arg]

--- a/backend/tests/unit/test_sync_service.py
+++ b/backend/tests/unit/test_sync_service.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.sync_service import get_sync_status, trigger_sync
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+SYNC_ID = uuid.UUID("00000000-0000-0000-0000-aaaaaaaaaaaa")
+
+
+def _make_fake_sync(
+    provider: str = "github", status: str = "active"
+) -> MagicMock:
+    fake = MagicMock()
+    fake.id = SYNC_ID
+    fake.user_id = USER_ID
+    fake.provider = provider
+    fake.status = status
+    fake.last_synced_at = None
+    fake.sync_config_json = {}
+    return fake
+
+
+def _mock_db_returning(rows: list) -> AsyncMock:
+    db = AsyncMock()
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = rows
+    result.scalars.return_value = scalars
+    db.execute.return_value = result
+    return db
+
+
+# ---------------------------------------------------------------------------
+# get_sync_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_sync_status_returns_list() -> None:
+    """get_sync_status returns all ExternalSync records for the user."""
+    records = [_make_fake_sync("github"), _make_fake_sync("google_calendar")]
+    db = _mock_db_returning(records)
+    result = await get_sync_status(db, USER_ID)
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_sync_status_returns_empty() -> None:
+    """get_sync_status returns an empty list when user has no sync connections."""
+    db = _mock_db_returning([])
+    result = await get_sync_status(db, USER_ID)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_sync_status_filters_by_user_id() -> None:
+    """get_sync_status query must filter by user_id."""
+    db = _mock_db_returning([])
+    await get_sync_status(db, USER_ID)
+    stmt = db.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert USER_ID.hex in compiled
+
+
+# ---------------------------------------------------------------------------
+# trigger_sync
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_raises_404_when_no_record() -> None:
+    """trigger_sync raises HTTP 404 when no ExternalSync record exists."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    db.execute.return_value = result
+
+    with pytest.raises(HTTPException) as exc_info:
+        await trigger_sync(db, USER_ID, "github")
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_raises_501_when_provider_not_registered() -> None:
+    """trigger_sync raises HTTP 501 when provider is not in registry."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = _make_fake_sync("github")
+    db.execute.return_value = result
+
+    with patch("app.services.sync_service.provider_registry") as mock_registry:
+        mock_registry.get.return_value = None
+        with pytest.raises(HTTPException) as exc_info:
+            await trigger_sync(db, USER_ID, "github")
+    assert exc_info.value.status_code == 501
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_calls_provider_sync() -> None:
+    """trigger_sync calls the registered provider's sync() method."""
+    fake_record = _make_fake_sync("github")
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = fake_record
+    db.execute.return_value = result
+
+    mock_provider_instance = AsyncMock()
+    mock_provider_cls = MagicMock(return_value=mock_provider_instance)
+
+    with patch("app.services.sync_service.provider_registry") as mock_registry:
+        mock_registry.get.return_value = mock_provider_cls
+        await trigger_sync(db, USER_ID, "github")
+
+    mock_provider_instance.sync.assert_called_once_with(db, fake_record)
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_updates_last_synced_at() -> None:
+    """trigger_sync sets last_synced_at and commits on success."""
+    fake_record = _make_fake_sync("github")
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = fake_record
+    db.execute.return_value = result
+
+    mock_provider_instance = AsyncMock()
+    mock_provider_cls = MagicMock(return_value=mock_provider_instance)
+
+    with patch("app.services.sync_service.provider_registry") as mock_registry:
+        mock_registry.get.return_value = mock_provider_cls
+        await trigger_sync(db, USER_ID, "github")
+
+    assert fake_record.last_synced_at is not None
+    assert fake_record.status == "active"
+    db.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_sets_error_on_failure() -> None:
+    """trigger_sync sets status to 'error' and commits when provider raises."""
+    fake_record = _make_fake_sync("github")
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = fake_record
+    db.execute.return_value = result
+
+    mock_provider_instance = AsyncMock()
+    mock_provider_instance.sync.side_effect = RuntimeError("sync failed")
+    mock_provider_cls = MagicMock(return_value=mock_provider_instance)
+
+    with patch("app.services.sync_service.provider_registry") as mock_registry:
+        mock_registry.get.return_value = mock_provider_cls
+        await trigger_sync(db, USER_ID, "github")
+
+    assert fake_record.status == "error"
+    db.commit.assert_called_once()

--- a/backend/tests/unit/test_sync_service.py
+++ b/backend/tests/unit/test_sync_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,9 +12,7 @@ USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 SYNC_ID = uuid.UUID("00000000-0000-0000-0000-aaaaaaaaaaaa")
 
 
-def _make_fake_sync(
-    provider: str = "github", status: str = "active"
-) -> MagicMock:
+def _make_fake_sync(provider: str = "github", status: str = "active") -> MagicMock:
     fake = MagicMock()
     fake.id = SYNC_ID
     fake.user_id = USER_ID
@@ -26,7 +23,7 @@ def _make_fake_sync(
     return fake
 
 
-def _mock_db_returning(rows: list) -> AsyncMock:
+def _mock_db_returning(rows: list[MagicMock]) -> AsyncMock:
     db = AsyncMock()
     result = MagicMock()
     scalars = MagicMock()

--- a/backend/tests/unit/test_sync_service.py
+++ b/backend/tests/unit/test_sync_service.py
@@ -157,3 +157,27 @@ async def test_trigger_sync_sets_error_on_failure() -> None:
 
     assert fake_record.status == "error"
     db.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_reraises_http_exception() -> None:
+    """trigger_sync does not swallow HTTPException raised by the provider."""
+    fake_record = _make_fake_sync("github")
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = fake_record
+    db.execute.return_value = result
+
+    mock_provider_instance = AsyncMock()
+    mock_provider_instance.sync.side_effect = HTTPException(
+        status_code=401, detail="OAuth token expired"
+    )
+    mock_provider_cls = MagicMock(return_value=mock_provider_instance)
+
+    with patch("app.services.sync_service.provider_registry") as mock_registry:
+        mock_registry.get.return_value = mock_provider_cls
+        with pytest.raises(HTTPException) as exc_info:
+            await trigger_sync(db, USER_ID, "github")
+
+    assert exc_info.value.status_code == 401
+    assert fake_record.status != "error"


### PR DESCRIPTION
## Summary
- Adds `ExternalSync` SQLAlchemy model with `SyncProvider`/`SyncStatus` enums, Alembic migration `0007`, unique index on `(user_id, provider)`
- Implements `BaseSyncProvider` ABC + `ProviderRegistry` singleton for registering/looking up sync provider classes
- Adds `GET /sync/status` and `POST /sync/{provider}/trigger` endpoints with auth, 404/501/422 error handling, and failure logging

## Test plan
- [ ] `pytest tests/unit/test_external_sync_model.py` — 21 model inspection tests pass
- [ ] `pytest tests/unit/test_sync_provider.py` — 7 provider/registry tests pass
- [ ] `pytest tests/unit/test_sync_schema.py` — 4 schema tests pass
- [ ] `pytest tests/unit/test_sync_routes.py` — 9 route tests pass (200, 401, 404, 501, 422, arg forwarding)
- [ ] `pytest tests/unit/test_sync_service.py` — 9 service tests pass (calls provider, updates timestamps, re-raises HTTPException)
- [ ] `ruff check . && ruff format .` — clean
- [ ] `mypy .` — clean (95 source files)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)