### PR TITLE
[#25] Set up Grafana dashboards and AI metrics scaffolding

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,3 +24,4 @@ GITHUB_REDIRECT_URI=http://localhost:5060/auth/github/callback
 
 # Monitoring (optional — leave blank to disable Sentry)
 SENTRY_DSN=
+PROMETHEUS_ENABLED=true

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
 
     # Monitoring (optional — silently disabled when absent)
     SENTRY_DSN: str | None = None
+    PROMETHEUS_ENABLED: bool = True
 
 
 settings = Settings()

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
-from prometheus_client import Counter, Histogram
+from prometheus_client import CollectorRegistry, Counter, Histogram
 from prometheus_fastapi_instrumentator import Instrumentator
 
 # AI Agent metric placeholders — scaffolding for the future agent pipeline
@@ -26,8 +26,22 @@ judge_score: Histogram = Histogram(
 )
 
 
-def configure_metrics(app: FastAPI, *, enabled: bool = True) -> None:
-    """Instrument the app with Prometheus metrics; silently skip when disabled."""
+def configure_metrics(
+    app: FastAPI,
+    *,
+    enabled: bool = True,
+    registry: CollectorRegistry | None = None,
+) -> None:
+    """Instrument the app with Prometheus metrics; silently skip when disabled.
+
+    Args:
+        app: The FastAPI application to instrument.
+        enabled: When False, no instrumentation is applied (useful for testing
+            or environments that use a different scraping stack).
+        registry: Optional CollectorRegistry; defaults to the global REGISTRY.
+            Pass a fresh CollectorRegistry() in tests to avoid duplicate-metric
+            errors if multiple Instrumentator instances are created in one process.
+    """
     if not enabled:
         return
-    Instrumentator().instrument(app).expose(app, endpoint="/metrics")
+    Instrumentator(registry=registry).instrument(app).expose(app, endpoint="/metrics")

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from prometheus_fastapi_instrumentator import Instrumentator
+
+
+def configure_metrics(app: FastAPI, *, enabled: bool = True) -> None:
+    """Instrument the app with Prometheus metrics; silently skip when disabled."""
+    if not enabled:
+        return
+    Instrumentator().instrument(app).expose(app, endpoint="/metrics")

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -1,7 +1,29 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+from prometheus_client import Counter, Histogram
 from prometheus_fastapi_instrumentator import Instrumentator
+
+# AI Agent metric placeholders — scaffolding for the future agent pipeline
+agent_latency_seconds: Histogram = Histogram(
+    "agent_latency_seconds",
+    "Time spent in an AI agent call",
+    labelnames=["agent_name"],
+    buckets=(0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)
+
+token_cost_total: Counter = Counter(
+    "token_cost_total",
+    "Cumulative token cost across all AI agent calls",
+    labelnames=["agent_name", "model"],
+)
+
+judge_score: Histogram = Histogram(
+    "judge_score",
+    "Score assigned by the judge agent",
+    labelnames=["agent_name"],
+    buckets=(10, 20, 30, 40, 50, 60, 70, 80, 90, 100),
+)
 
 
 def configure_metrics(app: FastAPI, *, enabled: bool = True) -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.api.tasks import router as tasks_router
 from app.api.time_entries import router as time_entries_router
 from app.core.config import settings
 from app.core.database import dispose_engine, init_engine
+from app.core.metrics import configure_metrics
 from app.core.redis import close_redis, init_redis
 from app.core.sentry import SentryBreadcrumbMiddleware, configure_sentry
 
@@ -44,6 +45,7 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
+    configure_metrics(app, enabled=settings.PROMETHEUS_ENABLED)
     app.add_middleware(SentryBreadcrumbMiddleware)  # type: ignore[arg-type]
 
     app.include_router(health_router)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "httpx>=0.27.0",
     "sentry-sdk[fastapi]>=2.0.0",
     "redis>=5.0.0",
+    "prometheus-fastapi-instrumentator>=7.0.0",
+    "prometheus-client>=0.20.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -53,7 +53,7 @@ ignore_missing_imports = true
 exclude = ["mutants/"]
 
 [tool.mutmut]
-paths_to_mutate = "app/core/database.py:app/core/redis.py:app/core/sentry.py:app/api/health.py"
+paths_to_mutate = "app/core/database.py:app/core/redis.py:app/core/sentry.py:app/core/metrics.py:app/api/health.py"
 runner = "python -m pytest tests/unit/ tests/test_health.py -x -q --tb=no"
 
 [tool.pytest.ini_options]

--- a/backend/tests/unit/test_metrics.py
+++ b/backend/tests/unit/test_metrics.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from prometheus_client import Counter, Histogram
+from prometheus_client import CollectorRegistry, Counter, Histogram
 
 from app.core.metrics import (
     agent_latency_seconds,
@@ -40,7 +40,9 @@ def test_configure_metrics_disabled_skips_instrumentation() -> None:
 async def test_metrics_endpoint_returns_200() -> None:
     """A real app with metrics enabled must expose GET /metrics returning 200."""
     app = FastAPI()
-    configure_metrics(app, enabled=True)
+    # Use an isolated registry so this test never clashes with other real
+    # Instrumentator instances created in the same pytest process.
+    configure_metrics(app, enabled=True, registry=CollectorRegistry())
 
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
@@ -88,7 +90,12 @@ def test_token_cost_has_agent_name_and_model_labels() -> None:
 
 
 async def test_ai_metrics_appear_in_metrics_output() -> None:
-    """After observing values, metric names must appear in GET /metrics output."""
+    """After observing values, metric names must appear in GET /metrics output.
+
+    Uses the global default registry (no custom registry arg) so that the
+    module-level AI metric singletons — which self-register on import — are
+    included in the /metrics response alongside the instrumentator's HTTP metrics.
+    """
     app = FastAPI()
     configure_metrics(app, enabled=True)
 

--- a/backend/tests/unit/test_metrics.py
+++ b/backend/tests/unit/test_metrics.py
@@ -6,7 +6,9 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from app.core.metrics import configure_metrics
+from prometheus_client import Counter, Histogram
+
+from app.core.metrics import agent_latency_seconds, configure_metrics, judge_score, token_cost_total
 
 
 def test_configure_metrics_enabled_instruments_app() -> None:
@@ -53,3 +55,44 @@ async def test_metrics_endpoint_absent_when_disabled() -> None:
         response = await client.get("/metrics")
 
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2: AI metric placeholder tests
+# ---------------------------------------------------------------------------
+
+
+def test_ai_metrics_registered_as_correct_types() -> None:
+    """The AI metric singletons must be the correct prometheus_client types."""
+    assert isinstance(agent_latency_seconds, Histogram)
+    assert isinstance(token_cost_total, Counter)
+    assert isinstance(judge_score, Histogram)
+
+
+def test_agent_latency_has_agent_name_label() -> None:
+    """agent_latency_seconds must carry the 'agent_name' label."""
+    assert "agent_name" in agent_latency_seconds._labelnames  # type: ignore[attr-defined]
+
+
+def test_token_cost_has_agent_name_and_model_labels() -> None:
+    """token_cost_total must carry 'agent_name' and 'model' labels."""
+    assert "agent_name" in token_cost_total._labelnames  # type: ignore[attr-defined]
+    assert "model" in token_cost_total._labelnames  # type: ignore[attr-defined]
+
+
+async def test_ai_metrics_appear_in_metrics_output() -> None:
+    """After observing values, metric names must appear in GET /metrics output."""
+    app = FastAPI()
+    configure_metrics(app, enabled=True)
+
+    agent_latency_seconds.labels(agent_name="test_agent").observe(0.5)
+    token_cost_total.labels(agent_name="test_agent", model="gpt-4").inc(10)
+    judge_score.labels(agent_name="test_agent").observe(85)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/metrics")
+
+    body = response.text
+    assert "agent_latency_seconds" in body
+    assert "token_cost_total" in body
+    assert "judge_score" in body

--- a/backend/tests/unit/test_metrics.py
+++ b/backend/tests/unit/test_metrics.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-
 from prometheus_client import Counter, Histogram
 
-from app.core.metrics import agent_latency_seconds, configure_metrics, judge_score, token_cost_total
+from app.core.metrics import (
+    agent_latency_seconds,
+    configure_metrics,
+    judge_score,
+    token_cost_total,
+)
 
 
 def test_configure_metrics_enabled_instruments_app() -> None:
@@ -39,7 +42,9 @@ async def test_metrics_endpoint_returns_200() -> None:
     app = FastAPI()
     configure_metrics(app, enabled=True)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
         response = await client.get("/metrics")
 
     assert response.status_code == 200
@@ -51,7 +56,9 @@ async def test_metrics_endpoint_absent_when_disabled() -> None:
     app = FastAPI()
     configure_metrics(app, enabled=False)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
         response = await client.get("/metrics")
 
     assert response.status_code == 404
@@ -71,13 +78,13 @@ def test_ai_metrics_registered_as_correct_types() -> None:
 
 def test_agent_latency_has_agent_name_label() -> None:
     """agent_latency_seconds must carry the 'agent_name' label."""
-    assert "agent_name" in agent_latency_seconds._labelnames  # type: ignore[attr-defined]
+    assert "agent_name" in agent_latency_seconds._labelnames
 
 
 def test_token_cost_has_agent_name_and_model_labels() -> None:
     """token_cost_total must carry 'agent_name' and 'model' labels."""
-    assert "agent_name" in token_cost_total._labelnames  # type: ignore[attr-defined]
-    assert "model" in token_cost_total._labelnames  # type: ignore[attr-defined]
+    assert "agent_name" in token_cost_total._labelnames
+    assert "model" in token_cost_total._labelnames
 
 
 async def test_ai_metrics_appear_in_metrics_output() -> None:
@@ -89,7 +96,9 @@ async def test_ai_metrics_appear_in_metrics_output() -> None:
     token_cost_total.labels(agent_name="test_agent", model="gpt-4").inc(10)
     judge_score.labels(agent_name="test_agent").observe(85)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
         response = await client.get("/metrics")
 
     body = response.text

--- a/backend/tests/unit/test_metrics.py
+++ b/backend/tests/unit/test_metrics.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.metrics import configure_metrics
+
+
+def test_configure_metrics_enabled_instruments_app() -> None:
+    """When enabled, Instrumentator must be instantiated, instrumented, and exposed."""
+    app = FastAPI()
+    with patch("app.core.metrics.Instrumentator") as mock_cls:
+        mock_instance = MagicMock()
+        mock_cls.return_value = mock_instance
+        mock_instance.instrument.return_value = mock_instance
+
+        configure_metrics(app, enabled=True)
+
+        mock_cls.assert_called_once()
+        mock_instance.instrument.assert_called_once_with(app)
+        mock_instance.expose.assert_called_once()
+
+
+def test_configure_metrics_disabled_skips_instrumentation() -> None:
+    """When disabled, Instrumentator must NOT be instantiated."""
+    app = FastAPI()
+    with patch("app.core.metrics.Instrumentator") as mock_cls:
+        configure_metrics(app, enabled=False)
+        mock_cls.assert_not_called()
+
+
+async def test_metrics_endpoint_returns_200() -> None:
+    """A real app with metrics enabled must expose GET /metrics returning 200."""
+    app = FastAPI()
+    configure_metrics(app, enabled=True)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/metrics")
+
+    assert response.status_code == 200
+    assert "text/plain" in response.headers["content-type"]
+
+
+async def test_metrics_endpoint_absent_when_disabled() -> None:
+    """A real app with metrics disabled must NOT have GET /metrics (returns 404)."""
+    app = FastAPI()
+    configure_metrics(app, enabled=False)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/metrics")
+
+    assert response.status_code == 404

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,31 @@ services:
       timeout: 5s
       retries: 5
 
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+
 volumes:
   postgres_data:
   redis_data:
+  grafana_data:

--- a/docker/grafana/dashboards/flowday.json
+++ b/docker/grafana/dashboards/flowday.json
@@ -1,0 +1,97 @@
+{
+  "uid": "flowday-overview",
+  "title": "FlowDay Overview",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Error Rate (5xx)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m]))",
+          "legendFormat": "error rate"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Active Users (placeholder)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Placeholder — replace with real user session metric when available.",
+      "targets": [
+        {
+          "expr": "sum(http_requests_total)",
+          "legendFormat": "total requests (proxy for activity)"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Agent Latency p95 by Agent",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(agent_latency_seconds_bucket[5m])) by (le, agent_name))",
+          "legendFormat": "{{ agent_name }} p95"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Token Cost Rate by Agent",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(token_cost_total[5m])) by (agent_name, model)",
+          "legendFormat": "{{ agent_name }} / {{ model }}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Judge Score Distribution (p50)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(judge_score_bucket[5m])) by (le, agent_name))",
+          "legendFormat": "{{ agent_name }} median score"
+        }
+      ]
+    }
+  ]
+}

--- a/docker/grafana/provisioning/dashboards/dashboard.yml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: FlowDay
+    orgId: 1
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,6 +1,7 @@
 apiVersion: 1
 datasources:
   - name: Prometheus
+    uid: prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "flowday-backend"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["host.docker.internal:5060"]

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,78 @@
+# FlowDay Monitoring
+
+## Overview
+
+FlowDay exposes a Prometheus-compatible `/metrics` endpoint and ships Grafana dashboards for observability. The stack includes:
+
+- **Prometheus** — scrapes `/metrics` from the backend every 15 s
+- **Grafana** — auto-provisions the Prometheus datasource and the FlowDay dashboard at startup
+- **Custom AI metrics** — placeholder Histogram/Counter collectors for the agent pipeline (recorded in `backend/app/core/metrics.py`)
+
+## Local Setup
+
+1. Start the full stack (includes Prometheus + Grafana):
+   ```bash
+   docker compose -f docker/docker-compose.yml up -d
+   ```
+
+2. Start the backend:
+   ```bash
+   cd backend
+   uvicorn app.main:app --reload --port 5060
+   ```
+
+3. Access:
+   | Service    | URL                        | Default credentials |
+   |------------|---------------------------|---------------------|
+   | Grafana    | http://localhost:3001      | admin / admin       |
+   | Prometheus | http://localhost:9090      | —                   |
+   | Metrics    | http://localhost:5060/metrics | —                |
+
+4. The **FlowDay Overview** dashboard is auto-provisioned — open Grafana, navigate to Dashboards → FlowDay Overview.
+
+## Disabling Prometheus
+
+Set `PROMETHEUS_ENABLED=false` in `.env` to disable the `/metrics` endpoint (e.g., in production environments where a different scraper is used).
+
+## Available Metrics
+
+### HTTP metrics (auto-instrumented)
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `http_request_duration_seconds` | Histogram | Request latency by method, path, status |
+| `http_requests_total` | Counter | Total requests by method, path, status |
+
+### AI agent metrics (placeholders)
+
+These are defined in `backend/app/core/metrics.py`. Agent code will call them when the agent pipeline is implemented.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `agent_latency_seconds` | Histogram | `agent_name` | Time spent in an AI agent call |
+| `token_cost_total` | Counter | `agent_name`, `model` | Cumulative token cost |
+| `judge_score` | Histogram | `agent_name` | Judge agent score (0–100) |
+
+## Dashboard Panels
+
+| Panel | PromQL summary |
+|-------|---------------|
+| Request Latency (p50/p95/p99) | `histogram_quantile` on `http_request_duration_seconds_bucket` |
+| Error Rate (5xx) | ratio of 5xx to total requests |
+| Active Users | placeholder using total request count |
+| Agent Latency p95 | `histogram_quantile` on `agent_latency_seconds_bucket` |
+| Token Cost Rate | `rate(token_cost_total)` by agent + model |
+| Judge Score Distribution | `histogram_quantile` on `judge_score_bucket` |
+
+## Adding New Metrics
+
+1. Define a module-level singleton in `backend/app/core/metrics.py`:
+   ```python
+   my_metric: Counter = Counter("my_metric_total", "Description", labelnames=["label"])
+   ```
+2. Call it from service or agent code:
+   ```python
+   from app.core.metrics import my_metric
+   my_metric.labels(label="value").inc()
+   ```
+3. The metric will automatically appear at `/metrics` and in Grafana.

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -34,6 +34,10 @@ FlowDay exposes a Prometheus-compatible `/metrics` endpoint and ships Grafana da
 
 Set `PROMETHEUS_ENABLED=false` in `.env` to disable the `/metrics` endpoint (e.g., in production environments where a different scraper is used).
 
+## Security Note
+
+The `/metrics` endpoint is **unauthenticated by design** — Prometheus scrapers require direct access without tokens. In production, restrict access at the reverse proxy or network level (e.g., allow only the Prometheus server's IP, or bind the metrics port to an internal interface). Do not expose port 5060 directly to the public internet without such controls.
+
 ## Available Metrics
 
 ### HTTP metrics (auto-instrumented)


### PR DESCRIPTION
## Summary

- Adds Prometheus `/metrics` endpoint via `prometheus-fastapi-instrumentator`, toggleable with `PROMETHEUS_ENABLED` setting
- Registers three AI metric placeholder collectors (`agent_latency_seconds`, `token_cost_total`, `judge_score`) with labels ready for the future agent pipeline
- Adds Docker Compose services for Prometheus (`:9090`) and Grafana (`:3001`) with auto-provisioned datasource and 6-panel FlowDay dashboard
- Documents local setup, metric catalog, and security guidance in `docs/MONITORING.md`

Closes #25

## Test plan

- [x] `pytest tests/unit/test_metrics.py` — 8 tests pass
- [x] `ruff check . && ruff format .` — clean
- [x] `mypy .` — clean
- [x] Grafana datasource UID matches dashboard panel references (`uid: prometheus`)
- [x] Registry isolation: endpoint existence test uses `CollectorRegistry()`, AI metrics test uses global registry
- [ ] Manual: `docker compose -f docker/docker-compose.yml up -d` → Grafana at http://localhost:3001 shows FlowDay Overview dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)