### PR TITLE
fix: exclude zero-duration time entries from analytics actual hours

### DIFF
--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -89,7 +89,7 @@ async def get_planned_vs_actual(
         .where(
             TimeEntry.started_at >= day_start,
             TimeEntry.started_at < day_end,
-            TimeEntry.duration_seconds.isnot(None),
+            TimeEntry.duration_seconds > 0,
             Project.user_id == user_id,
         )
         .group_by(TimeEntry.task_id, Task.title)
@@ -185,7 +185,7 @@ async def get_weekly_stats(
         .where(
             TimeEntry.started_at >= week_start_dt,
             TimeEntry.started_at < week_end_dt,
-            TimeEntry.duration_seconds.isnot(None),
+            TimeEntry.duration_seconds > 0,
             Project.user_id == user_id,
         )
         .group_by(Project.id, Project.name, Project.color)


### PR DESCRIPTION
## Summary

- Fixes `test_planned_vs_actual_unplanned_work` CI failure introduced in #52
- When a timer is started and stopped within the same second (common in CI fast execution), `duration_seconds = 0`
- The previous filter `isnot(None)` passed these through, giving `actual_hours = 0.0`, so `compute_status_tag(0, 0)` returned `SKIPPED` instead of `UNPLANNED`
- Fix: change both time entry queries in `analytics_service.py` from `duration_seconds.isnot(None)` to `duration_seconds > 0`

## Test plan

- [x] `test_planned_vs_actual_unplanned_work` — now passes locally and in CI
- [x] All other analytics integration tests unaffected
- [x] `ruff check .` and `mypy .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)