### PR TITLE
Implement Google Calendar OAuth integration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,7 @@ SECRET_KEY=change-me-in-production
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:5060/auth/google/callback
+GOOGLE_CALENDAR_REDIRECT_URI=http://localhost:5060/sync/google-calendar/callback
 
 # OAuth — GitHub (optional — leave blank to disable)
 GITHUB_CLIENT_ID=

--- a/backend/app/api/sync.py
+++ b/backend/app/api/sync.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
 from app.core.deps import get_current_user
 from app.models.external_sync import SyncProvider
 from app.models.user import User
-from app.schemas.sync import SyncStatusResponse
+from app.schemas.sync import GoogleCalendarAuthResponse, SyncStatusResponse
+from app.services.google_calendar import (
+    build_authorization_url,
+    exchange_code_for_tokens,
+    get_or_create_google_calendar_sync,
+    store_tokens_in_sync_record,
+)
 from app.services.sync_service import get_sync_status, trigger_sync
 
 router = APIRouter(prefix="/sync", tags=["sync"])
@@ -32,3 +38,29 @@ async def trigger_sync_route(
     """Manually trigger a sync for the given provider."""
     record = await trigger_sync(db=db, user_id=current_user.id, provider=provider)
     return SyncStatusResponse.model_validate(record)
+
+
+@router.get("/google-calendar/auth", response_model=GoogleCalendarAuthResponse)
+async def google_calendar_auth_route(
+    current_user: User = Depends(get_current_user),
+) -> GoogleCalendarAuthResponse:
+    """Initiate Google Calendar OAuth consent flow."""
+    url = build_authorization_url(str(current_user.id))
+    return GoogleCalendarAuthResponse(authorization_url=url)
+
+
+@router.get("/google-calendar/callback", response_model=SyncStatusResponse)
+async def google_calendar_callback_route(
+    code: str,
+    state: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SyncStatusResponse:
+    """Handle Google Calendar OAuth callback, store tokens, and return sync record."""
+    if state != str(current_user.id):
+        raise HTTPException(status_code=400, detail="Invalid OAuth state parameter")
+
+    token_data = await exchange_code_for_tokens(code)
+    sync_record = await get_or_create_google_calendar_sync(db, current_user.id)
+    await store_tokens_in_sync_record(db, sync_record, token_data)
+    return SyncStatusResponse.model_validate(sync_record)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -29,6 +29,11 @@ class Settings(BaseSettings):
     # override via .env in browser-testing scenarios
     GOOGLE_REDIRECT_URI: str = "http://localhost:5060/auth/google/callback"
 
+    # OAuth — Google Calendar (separate scope from login OAuth)
+    GOOGLE_CALENDAR_REDIRECT_URI: str = (
+        "http://localhost:5060/sync/google-calendar/callback"
+    )
+
     # OAuth — GitHub
     GITHUB_CLIENT_ID: str | None = None
     GITHUB_CLIENT_SECRET: str | None = None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,8 +5,6 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-import app.services.google_calendar_provider  # noqa: F401 — registers Google Calendar provider
-
 from app.api.analytics import router as analytics_router
 from app.api.auth import router as auth_router
 from app.api.health import router as health_router
@@ -20,6 +18,7 @@ from app.core.database import dispose_engine, init_engine
 from app.core.metrics import configure_metrics
 from app.core.redis import close_redis, init_redis
 from app.core.sentry import SentryBreadcrumbMiddleware, configure_sentry
+from app.services import google_calendar_provider as _gcal_provider  # noqa: F401
 
 
 @asynccontextmanager

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+import app.services.google_calendar_provider  # noqa: F401 — registers Google Calendar provider
+
 from app.api.analytics import router as analytics_router
 from app.api.auth import router as auth_router
 from app.api.health import router as health_router

--- a/backend/app/schemas/sync.py
+++ b/backend/app/schemas/sync.py
@@ -7,6 +7,12 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict
 
 
+class GoogleCalendarAuthResponse(BaseModel):
+    """Response for the Google Calendar OAuth initiation endpoint."""
+
+    authorization_url: str
+
+
 class SyncStatusResponse(BaseModel):
     """Response schema for an ExternalSync record."""
 

--- a/backend/app/services/google_calendar.py
+++ b/backend/app/services/google_calendar.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.security import decrypt_oauth_token, encrypt_oauth_token
+from app.models.external_sync import ExternalSync
+
+GOOGLE_CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
+GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+GOOGLE_CALENDAR_EVENTS_URL = (
+    "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+)
+
+
+def build_authorization_url(user_id: str) -> str:
+    """Build the Google OAuth consent URL for calendar access."""
+    params = {
+        "client_id": settings.GOOGLE_CLIENT_ID or "",
+        "redirect_uri": settings.GOOGLE_CALENDAR_REDIRECT_URI,
+        "response_type": "code",
+        "scope": GOOGLE_CALENDAR_SCOPE,
+        "access_type": "offline",
+        "prompt": "consent",
+        "state": user_id,
+    }
+    return f"{GOOGLE_AUTH_URL}?{urlencode(params)}"
+
+
+async def exchange_code_for_tokens(code: str) -> dict[str, Any]:
+    """Exchange an authorization code for access and refresh tokens."""
+    payload = {
+        "code": code,
+        "client_id": settings.GOOGLE_CLIENT_ID or "",
+        "client_secret": settings.GOOGLE_CLIENT_SECRET or "",
+        "redirect_uri": settings.GOOGLE_CALENDAR_REDIRECT_URI,
+        "grant_type": "authorization_code",
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(GOOGLE_TOKEN_URL, data=payload)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=401, detail="Failed to exchange Google auth code")
+    return resp.json()
+
+
+async def store_tokens_in_sync_record(
+    db: AsyncSession,
+    sync_record: ExternalSync,
+    token_data: dict[str, Any],
+) -> None:
+    """Encrypt and persist access/refresh tokens in sync_config_json."""
+    expires_in: int = token_data.get("expires_in", 3600)
+    expiry = (datetime.now(UTC) + timedelta(seconds=expires_in)).isoformat()
+
+    current_config: dict[str, Any] = dict(sync_record.sync_config_json or {})
+    current_config["encrypted_access_token"] = encrypt_oauth_token(
+        token_data["access_token"]
+    )
+    if "refresh_token" in token_data:
+        current_config["encrypted_refresh_token"] = encrypt_oauth_token(
+            token_data["refresh_token"]
+        )
+    current_config["token_expiry"] = expiry
+
+    sync_record.sync_config_json = current_config
+    await db.commit()
+    await db.refresh(sync_record)
+
+
+async def refresh_access_token(encrypted_refresh_token: str) -> dict[str, Any]:
+    """Use a stored refresh token to get a new access token from Google."""
+    refresh_token = decrypt_oauth_token(encrypted_refresh_token)
+    payload = {
+        "client_id": settings.GOOGLE_CLIENT_ID or "",
+        "client_secret": settings.GOOGLE_CLIENT_SECRET or "",
+        "refresh_token": refresh_token,
+        "grant_type": "refresh_token",
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(GOOGLE_TOKEN_URL, data=payload)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=401, detail="Failed to refresh Google token")
+    return resp.json()
+
+
+async def fetch_calendar_events(
+    access_token: str,
+    time_min: str,
+    time_max: str,
+) -> list[dict[str, Any]]:
+    """Fetch all calendar events in [time_min, time_max] from the primary calendar."""
+    headers = {"Authorization": f"Bearer {access_token}"}
+    params: dict[str, Any] = {
+        "timeMin": time_min,
+        "timeMax": time_max,
+        "singleEvents": "true",
+        "orderBy": "startTime",
+    }
+    events: list[dict[str, Any]] = []
+    async with httpx.AsyncClient() as client:
+        while True:
+            resp = await client.get(
+                GOOGLE_CALENDAR_EVENTS_URL, headers=headers, params=params
+            )
+            if resp.status_code != 200:
+                raise HTTPException(
+                    status_code=502, detail="Failed to fetch Google Calendar events"
+                )
+            data = resp.json()
+            events.extend(data.get("items", []))
+            next_page = data.get("nextPageToken")
+            if not next_page:
+                break
+            params["pageToken"] = next_page
+    return events
+
+
+async def get_valid_access_token(
+    db: AsyncSession,
+    sync_record: ExternalSync,
+) -> str:
+    """Return a valid access token, refreshing if expired."""
+    config: dict[str, Any] = sync_record.sync_config_json or {}
+    expiry_str: str | None = config.get("token_expiry")
+    encrypted_access: str | None = config.get("encrypted_access_token")
+    encrypted_refresh: str | None = config.get("encrypted_refresh_token")
+
+    if not encrypted_access or not encrypted_refresh:
+        raise HTTPException(
+            status_code=401, detail="Google Calendar not connected — please re-authorize"
+        )
+
+    # Check if still valid (with 60 s buffer)
+    if expiry_str:
+        expiry = datetime.fromisoformat(expiry_str)
+        if datetime.now(UTC) < expiry - timedelta(seconds=60):
+            return decrypt_oauth_token(encrypted_access)
+
+    # Refresh
+    token_data = await refresh_access_token(encrypted_refresh)
+    await store_tokens_in_sync_record(db, sync_record, token_data)
+    return token_data["access_token"]
+
+
+async def get_or_create_google_calendar_sync(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> ExternalSync:
+    """Upsert an ExternalSync record for google_calendar for the given user."""
+    from sqlalchemy import select
+
+    from app.models.external_sync import ExternalSync as ES
+
+    result = await db.execute(
+        select(ES).where(
+            ES.user_id == user_id,
+            ES.provider == "google_calendar",
+        )
+    )
+    record = result.scalar_one_or_none()
+    if record is None:
+        record = ES(
+            user_id=user_id,
+            provider="google_calendar",
+            status="active",
+            sync_config_json={},
+        )
+        db.add(record)
+        await db.flush()
+    return record

--- a/backend/app/services/google_calendar.py
+++ b/backend/app/services/google_calendar.py
@@ -35,20 +35,45 @@ def build_authorization_url(user_id: str) -> str:
     return f"{GOOGLE_AUTH_URL}?{urlencode(params)}"
 
 
-async def exchange_code_for_tokens(code: str) -> dict[str, Any]:
-    """Exchange an authorization code for access and refresh tokens."""
-    payload = {
-        "code": code,
-        "client_id": settings.GOOGLE_CLIENT_ID or "",
-        "client_secret": settings.GOOGLE_CLIENT_SECRET or "",
-        "redirect_uri": settings.GOOGLE_CALENDAR_REDIRECT_URI,
-        "grant_type": "authorization_code",
-    }
+async def _post_to_token_endpoint(payload: dict[str, str]) -> dict[str, Any]:
+    """POST form data to the Google token endpoint and return the JSON response."""
     async with httpx.AsyncClient() as client:
         resp = await client.post(GOOGLE_TOKEN_URL, data=payload)
     if resp.status_code != 200:
-        raise HTTPException(status_code=401, detail="Failed to exchange Google auth code")
+        raise HTTPException(status_code=401, detail="Google token endpoint request failed")
     return resp.json()
+
+
+async def exchange_code_for_tokens(code: str) -> dict[str, Any]:
+    """Exchange an authorization code for access and refresh tokens."""
+    token_data = await _post_to_token_endpoint(
+        {
+            "code": code,
+            "client_id": settings.GOOGLE_CLIENT_ID or "",
+            "client_secret": settings.GOOGLE_CLIENT_SECRET or "",
+            "redirect_uri": settings.GOOGLE_CALENDAR_REDIRECT_URI,
+            "grant_type": "authorization_code",
+        }
+    )
+    if "access_token" not in token_data:
+        raise HTTPException(status_code=401, detail="Failed to exchange Google auth code")
+    return token_data
+
+
+async def refresh_access_token(encrypted_refresh_token: str) -> dict[str, Any]:
+    """Use a stored refresh token to get a new access token from Google."""
+    refresh_token = decrypt_oauth_token(encrypted_refresh_token)
+    token_data = await _post_to_token_endpoint(
+        {
+            "client_id": settings.GOOGLE_CLIENT_ID or "",
+            "client_secret": settings.GOOGLE_CLIENT_SECRET or "",
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+        }
+    )
+    if "access_token" not in token_data:
+        raise HTTPException(status_code=401, detail="Failed to refresh Google token")
+    return token_data
 
 
 async def store_tokens_in_sync_record(
@@ -73,22 +98,6 @@ async def store_tokens_in_sync_record(
     sync_record.sync_config_json = current_config
     await db.commit()
     await db.refresh(sync_record)
-
-
-async def refresh_access_token(encrypted_refresh_token: str) -> dict[str, Any]:
-    """Use a stored refresh token to get a new access token from Google."""
-    refresh_token = decrypt_oauth_token(encrypted_refresh_token)
-    payload = {
-        "client_id": settings.GOOGLE_CLIENT_ID or "",
-        "client_secret": settings.GOOGLE_CLIENT_SECRET or "",
-        "refresh_token": refresh_token,
-        "grant_type": "refresh_token",
-    }
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(GOOGLE_TOKEN_URL, data=payload)
-    if resp.status_code != 200:
-        raise HTTPException(status_code=401, detail="Failed to refresh Google token")
-    return resp.json()
 
 
 async def fetch_calendar_events(
@@ -127,7 +136,7 @@ async def get_valid_access_token(
     db: AsyncSession,
     sync_record: ExternalSync,
 ) -> str:
-    """Return a valid access token, refreshing if expired."""
+    """Return a valid access token, refreshing from Google if expired."""
     config: dict[str, Any] = sync_record.sync_config_json or {}
     expiry_str: str | None = config.get("token_expiry")
     encrypted_access: str | None = config.get("encrypted_access_token")
@@ -135,16 +144,17 @@ async def get_valid_access_token(
 
     if not encrypted_access or not encrypted_refresh:
         raise HTTPException(
-            status_code=401, detail="Google Calendar not connected — please re-authorize"
+            status_code=401,
+            detail="Google Calendar not connected — please re-authorize",
         )
 
-    # Check if still valid (with 60 s buffer)
+    # Return cached token if still valid (with 60 s buffer)
     if expiry_str:
         expiry = datetime.fromisoformat(expiry_str)
         if datetime.now(UTC) < expiry - timedelta(seconds=60):
             return decrypt_oauth_token(encrypted_access)
 
-    # Refresh
+    # Token expired — refresh it
     token_data = await refresh_access_token(encrypted_refresh)
     await store_tokens_in_sync_record(db, sync_record, token_data)
     return token_data["access_token"]
@@ -157,17 +167,15 @@ async def get_or_create_google_calendar_sync(
     """Upsert an ExternalSync record for google_calendar for the given user."""
     from sqlalchemy import select
 
-    from app.models.external_sync import ExternalSync as ES
-
     result = await db.execute(
-        select(ES).where(
-            ES.user_id == user_id,
-            ES.provider == "google_calendar",
+        select(ExternalSync).where(
+            ExternalSync.user_id == user_id,
+            ExternalSync.provider == "google_calendar",
         )
     )
     record = result.scalar_one_or_none()
     if record is None:
-        record = ES(
+        record = ExternalSync(
             user_id=user_id,
             provider="google_calendar",
             status="active",

--- a/backend/app/services/google_calendar.py
+++ b/backend/app/services/google_calendar.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlencode
 
 import httpx
@@ -40,8 +40,10 @@ async def _post_to_token_endpoint(payload: dict[str, str]) -> dict[str, Any]:
     async with httpx.AsyncClient() as client:
         resp = await client.post(GOOGLE_TOKEN_URL, data=payload)
     if resp.status_code != 200:
-        raise HTTPException(status_code=401, detail="Google token endpoint request failed")
-    return resp.json()
+        raise HTTPException(
+            status_code=401, detail="Google token endpoint request failed"
+        )
+    return cast(dict[str, Any], resp.json())
 
 
 async def exchange_code_for_tokens(code: str) -> dict[str, Any]:
@@ -56,7 +58,9 @@ async def exchange_code_for_tokens(code: str) -> dict[str, Any]:
         }
     )
     if "access_token" not in token_data:
-        raise HTTPException(status_code=401, detail="Failed to exchange Google auth code")
+        raise HTTPException(
+            status_code=401, detail="Failed to exchange Google auth code"
+        )
     return token_data
 
 
@@ -157,7 +161,7 @@ async def get_valid_access_token(
     # Token expired — refresh it
     token_data = await refresh_access_token(encrypted_refresh)
     await store_tokens_in_sync_record(db, sync_record, token_data)
-    return token_data["access_token"]
+    return str(token_data["access_token"])
 
 
 async def get_or_create_google_calendar_sync(

--- a/backend/app/services/google_calendar_provider.py
+++ b/backend/app/services/google_calendar_provider.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
@@ -20,7 +20,7 @@ _SYNC_DAYS_AHEAD = 7
 
 
 class GoogleCalendarSyncProvider(BaseSyncProvider):
-    """Syncs Google Calendar events as ScheduleBlock rows with source=google_calendar."""
+    """Syncs Google Calendar events as ScheduleBlock rows (source=google_calendar)."""
 
     async def sync(self, db: AsyncSession, sync_record: ExternalSync) -> None:
         """Fetch calendar events and upsert them as schedule blocks."""
@@ -28,9 +28,11 @@ class GoogleCalendarSyncProvider(BaseSyncProvider):
 
         now = datetime.now(UTC)
         time_min = now.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
-        time_max = (now + timedelta(days=_SYNC_DAYS_AHEAD)).replace(
-            hour=23, minute=59, second=59, microsecond=0
-        ).isoformat()
+        time_max = (
+            (now + timedelta(days=_SYNC_DAYS_AHEAD))
+            .replace(hour=23, minute=59, second=59, microsecond=0)
+            .isoformat()
+        )
 
         events = await fetch_calendar_events(access_token, time_min, time_max)
 
@@ -97,7 +99,9 @@ async def _delete_existing_blocks(
     """Delete google_calendar ScheduleBlocks for a user within the date range."""
     # ScheduleBlock → Task → Project (user_id)
     task_ids_result = await db.execute(
-        select(Task.id).join(Project, Task.project_id == Project.id).where(
+        select(Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
             Project.user_id == user_id,
             Project.name == _SENTINEL_PROJECT_NAME,
         )
@@ -119,7 +123,7 @@ async def _delete_existing_blocks(
 def _event_to_block_data(
     event: dict[str, Any],
 ) -> dict[str, Any] | None:
-    """Convert a Google Calendar event dict to block fields, or None for all-day events."""
+    """Convert a Google Calendar event to block fields, or None for all-day events."""
     start_obj = event.get("start", {})
     end_obj = event.get("end", {})
 
@@ -132,7 +136,7 @@ def _event_to_block_data(
     start_dt = datetime.fromisoformat(start_dt_str)
     end_dt = datetime.fromisoformat(end_dt_str)
 
-    event_date = start_dt.astimezone(timezone.utc).date()
+    event_date = start_dt.astimezone(UTC).date()
     start_hour = Decimal(str(round(start_dt.hour + start_dt.minute / 60, 2)))
     end_hour = Decimal(str(round(end_dt.hour + end_dt.minute / 60, 2)))
 

--- a/backend/app/services/google_calendar_provider.py
+++ b/backend/app/services/google_calendar_provider.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.external_sync import ExternalSync
+from app.models.project import Project
+from app.models.schedule_block import ScheduleBlock, ScheduleBlockSource
+from app.models.task import Task
+from app.services.google_calendar import fetch_calendar_events, get_valid_access_token
+from app.services.sync_provider import BaseSyncProvider, provider_registry
+
+_SENTINEL_PROJECT_NAME = "Google Calendar"
+_SENTINEL_PROJECT_COLOR = "#4285F4"
+_SYNC_DAYS_AHEAD = 7
+
+
+class GoogleCalendarSyncProvider(BaseSyncProvider):
+    """Syncs Google Calendar events as ScheduleBlock rows with source=google_calendar."""
+
+    async def sync(self, db: AsyncSession, sync_record: ExternalSync) -> None:
+        """Fetch calendar events and upsert them as schedule blocks."""
+        access_token = await get_valid_access_token(db, sync_record)
+
+        now = datetime.now(UTC)
+        time_min = now.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
+        time_max = (now + timedelta(days=_SYNC_DAYS_AHEAD)).replace(
+            hour=23, minute=59, second=59, microsecond=0
+        ).isoformat()
+
+        events = await fetch_calendar_events(access_token, time_min, time_max)
+
+        project = await _get_or_create_sentinel_project(db, sync_record.user_id)
+
+        # Delete existing google_calendar blocks for user in the date range
+        sync_start = now.date()
+        sync_end = (now + timedelta(days=_SYNC_DAYS_AHEAD)).date()
+        await _delete_existing_blocks(db, sync_record.user_id, sync_start, sync_end)
+
+        for event in events:
+            block_data = _event_to_block_data(event)
+            if block_data is None:
+                continue  # skip all-day events
+            task = Task(
+                project_id=project.id,
+                title=event.get("summary") or "Google Calendar Event",
+                description=event.get("id"),
+            )
+            db.add(task)
+            await db.flush()
+
+            block = ScheduleBlock(
+                task_id=task.id,
+                date=block_data["date"],
+                start_hour=block_data["start_hour"],
+                end_hour=block_data["end_hour"],
+                source=ScheduleBlockSource.GOOGLE_CALENDAR,
+            )
+            db.add(block)
+
+        await db.flush()
+
+
+async def _get_or_create_sentinel_project(
+    db: AsyncSession,
+    user_id: Any,
+) -> Project:
+    """Return the user's Google Calendar sentinel project, creating it if needed."""
+    result = await db.execute(
+        select(Project).where(
+            Project.user_id == user_id,
+            Project.name == _SENTINEL_PROJECT_NAME,
+        )
+    )
+    project = result.scalar_one_or_none()
+    if project is None:
+        project = Project(
+            user_id=user_id,
+            name=_SENTINEL_PROJECT_NAME,
+            color=_SENTINEL_PROJECT_COLOR,
+        )
+        db.add(project)
+        await db.flush()
+    return project
+
+
+async def _delete_existing_blocks(
+    db: AsyncSession,
+    user_id: Any,
+    start: date,
+    end: date,
+) -> None:
+    """Delete google_calendar ScheduleBlocks for a user within the date range."""
+    # ScheduleBlock → Task → Project (user_id)
+    task_ids_result = await db.execute(
+        select(Task.id).join(Project, Task.project_id == Project.id).where(
+            Project.user_id == user_id,
+            Project.name == _SENTINEL_PROJECT_NAME,
+        )
+    )
+    task_ids = [row[0] for row in task_ids_result.all()]
+    if not task_ids:
+        return
+
+    await db.execute(
+        delete(ScheduleBlock).where(
+            ScheduleBlock.task_id.in_(task_ids),
+            ScheduleBlock.source == ScheduleBlockSource.GOOGLE_CALENDAR,
+            ScheduleBlock.date >= start,
+            ScheduleBlock.date <= end,
+        )
+    )
+
+
+def _event_to_block_data(
+    event: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Convert a Google Calendar event dict to block fields, or None for all-day events."""
+    start_obj = event.get("start", {})
+    end_obj = event.get("end", {})
+
+    start_dt_str = start_obj.get("dateTime")
+    end_dt_str = end_obj.get("dateTime")
+
+    if not start_dt_str or not end_dt_str:
+        return None  # all-day event — no hour information
+
+    start_dt = datetime.fromisoformat(start_dt_str)
+    end_dt = datetime.fromisoformat(end_dt_str)
+
+    event_date = start_dt.astimezone(timezone.utc).date()
+    start_hour = Decimal(str(round(start_dt.hour + start_dt.minute / 60, 2)))
+    end_hour = Decimal(str(round(end_dt.hour + end_dt.minute / 60, 2)))
+
+    if end_hour <= start_hour:
+        end_hour = start_hour + Decimal("0.5")
+
+    return {"date": event_date, "start_hour": start_hour, "end_hour": end_hour}
+
+
+# Register with the global provider registry
+provider_registry.register("google_calendar", GoogleCalendarSyncProvider)

--- a/backend/tests/integration/test_google_calendar_sync.py
+++ b/backend/tests/integration/test_google_calendar_sync.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -20,7 +20,7 @@ async def test_callback_creates_external_sync_record(
     db_session: AsyncSession,
     test_user: User,
 ) -> None:
-    """GET /sync/google-calendar/callback creates an ExternalSync row with encrypted tokens."""
+    """GET /sync/google-calendar/callback creates an ExternalSync row with tokens."""
     fake_tokens = {
         "access_token": "integration-access",
         "refresh_token": "integration-refresh",
@@ -55,7 +55,9 @@ async def test_callback_creates_external_sync_record(
     assert "encrypted_access_token" in config
     assert "encrypted_refresh_token" in config
     assert decrypt_oauth_token(config["encrypted_access_token"]) == "integration-access"
-    assert decrypt_oauth_token(config["encrypted_refresh_token"]) == "integration-refresh"
+    assert (
+        decrypt_oauth_token(config["encrypted_refresh_token"]) == "integration-refresh"
+    )
 
 
 @pytest.mark.asyncio
@@ -64,7 +66,7 @@ async def test_sync_trigger_creates_schedule_blocks(
     db_session: AsyncSession,
     test_user: User,
 ) -> None:
-    """POST /sync/google_calendar/trigger creates ScheduleBlock rows for fetched events."""
+    """POST /sync/google_calendar/trigger creates ScheduleBlock rows for events."""
     # Pre-insert ExternalSync record with valid tokens
     future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
     sync_record = ExternalSync(

--- a/backend/tests/integration/test_google_calendar_sync.py
+++ b/backend/tests/integration/test_google_calendar_sync.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import decrypt_oauth_token, encrypt_oauth_token
+from app.models.external_sync import ExternalSync
+from app.models.schedule_block import ScheduleBlock
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_callback_creates_external_sync_record(
+    auth_client: AsyncClient,
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """GET /sync/google-calendar/callback creates an ExternalSync row with encrypted tokens."""
+    fake_tokens = {
+        "access_token": "integration-access",
+        "refresh_token": "integration-refresh",
+        "expires_in": 3600,
+    }
+
+    with patch(
+        "app.api.sync.exchange_code_for_tokens",
+        new_callable=AsyncMock,
+        return_value=fake_tokens,
+    ):
+        resp = await auth_client.get(
+            "/sync/google-calendar/callback",
+            params={"code": "auth-code", "state": str(test_user.id)},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["provider"] == "google_calendar"
+    assert data["status"] == "active"
+
+    # Verify DB row exists with encrypted tokens
+    result = await db_session.execute(
+        select(ExternalSync).where(
+            ExternalSync.user_id == test_user.id,
+            ExternalSync.provider == "google_calendar",
+        )
+    )
+    record = result.scalar_one_or_none()
+    assert record is not None
+    config = record.sync_config_json
+    assert "encrypted_access_token" in config
+    assert "encrypted_refresh_token" in config
+    assert decrypt_oauth_token(config["encrypted_access_token"]) == "integration-access"
+    assert decrypt_oauth_token(config["encrypted_refresh_token"]) == "integration-refresh"
+
+
+@pytest.mark.asyncio
+async def test_sync_trigger_creates_schedule_blocks(
+    auth_client: AsyncClient,
+    db_session: AsyncSession,
+    test_user: User,
+) -> None:
+    """POST /sync/google_calendar/trigger creates ScheduleBlock rows for fetched events."""
+    # Pre-insert ExternalSync record with valid tokens
+    future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    sync_record = ExternalSync(
+        user_id=test_user.id,
+        provider="google_calendar",
+        status="active",
+        sync_config_json={
+            "encrypted_access_token": encrypt_oauth_token("tok"),
+            "encrypted_refresh_token": encrypt_oauth_token("ref"),
+            "token_expiry": future,
+        },
+    )
+    db_session.add(sync_record)
+    await db_session.flush()
+
+    fake_events = [
+        {
+            "id": "evt-integration-1",
+            "summary": "Integration Test Meeting",
+            "start": {"dateTime": "2026-04-20T10:00:00+00:00"},
+            "end": {"dateTime": "2026-04-20T11:00:00+00:00"},
+        }
+    ]
+
+    with patch(
+        "app.services.google_calendar_provider.fetch_calendar_events",
+        new_callable=AsyncMock,
+        return_value=fake_events,
+    ):
+        resp = await auth_client.post("/sync/google_calendar/trigger")
+
+    assert resp.status_code == 200
+
+    # Verify ScheduleBlock was created
+    result = await db_session.execute(select(ScheduleBlock))
+    blocks = result.scalars().all()
+    google_blocks = [b for b in blocks if b.source == "google_calendar"]
+    assert len(google_blocks) >= 1
+    assert google_blocks[0].start_hour == 10
+    assert google_blocks[0].end_hour == 11
+
+
+@pytest.mark.asyncio
+async def test_callback_rejected_with_wrong_state(
+    auth_client: AsyncClient,
+    test_user: User,
+) -> None:
+    """GET /sync/google-calendar/callback with wrong state returns 400."""
+    resp = await auth_client.get(
+        "/sync/google-calendar/callback",
+        params={"code": "code", "state": "wrong-user-id"},
+    )
+    assert resp.status_code == 400

--- a/backend/tests/unit/test_google_calendar_provider.py
+++ b/backend/tests/unit/test_google_calendar_provider.py
@@ -9,7 +9,6 @@ import pytest
 from app.core.security import encrypt_oauth_token
 from app.services.sync_provider import provider_registry
 
-
 # ---------------------------------------------------------------------------
 # Provider registration
 # ---------------------------------------------------------------------------
@@ -18,7 +17,6 @@ from app.services.sync_provider import provider_registry
 def test_provider_registered_in_registry() -> None:
     """GoogleCalendarSyncProvider must be registered under 'google_calendar'."""
     import app.services.google_calendar_provider  # noqa: F401
-
     from app.services.google_calendar_provider import GoogleCalendarSyncProvider
 
     registered = provider_registry.get("google_calendar")
@@ -32,7 +30,7 @@ def test_provider_registered_in_registry() -> None:
 
 @pytest.mark.asyncio
 async def test_sync_creates_sentinel_project_task_and_block() -> None:
-    """sync() creates a sentinel project, task per event, and schedule block per event."""
+    """sync() creates a sentinel project, task per event, and block per event."""
     import app.services.google_calendar_provider  # noqa: F401
     from app.services.google_calendar_provider import GoogleCalendarSyncProvider
 
@@ -58,14 +56,17 @@ async def test_sync_creates_sentinel_project_task_and_block() -> None:
     db = AsyncMock()
     db.execute = AsyncMock(return_value=_mock_scalar_none())
 
-    with patch(
-        "app.services.google_calendar_provider.get_valid_access_token",
-        new_callable=AsyncMock,
-        return_value="access-token",
-    ), patch(
-        "app.services.google_calendar_provider.fetch_calendar_events",
-        new_callable=AsyncMock,
-        return_value=fake_events,
+    with (
+        patch(
+            "app.services.google_calendar_provider.get_valid_access_token",
+            new_callable=AsyncMock,
+            return_value="access-token",
+        ),
+        patch(
+            "app.services.google_calendar_provider.fetch_calendar_events",
+            new_callable=AsyncMock,
+            return_value=fake_events,
+        ),
     ):
         await provider.sync(db, sync_record)
 
@@ -97,14 +98,17 @@ async def test_sync_skips_all_day_events() -> None:
     db = AsyncMock()
     db.execute = AsyncMock(return_value=_mock_scalar_none())
 
-    with patch(
-        "app.services.google_calendar_provider.get_valid_access_token",
-        new_callable=AsyncMock,
-        return_value="access-token",
-    ), patch(
-        "app.services.google_calendar_provider.fetch_calendar_events",
-        new_callable=AsyncMock,
-        return_value=fake_events,
+    with (
+        patch(
+            "app.services.google_calendar_provider.get_valid_access_token",
+            new_callable=AsyncMock,
+            return_value="access-token",
+        ),
+        patch(
+            "app.services.google_calendar_provider.fetch_calendar_events",
+            new_callable=AsyncMock,
+            return_value=fake_events,
+        ),
     ):
         await provider.sync(db, sync_record)
 
@@ -120,10 +124,10 @@ async def test_sync_skips_all_day_events() -> None:
 @pytest.mark.asyncio
 async def test_sync_token_error_propagates() -> None:
     """sync() propagates HTTPException when token retrieval fails."""
+    from fastapi import HTTPException
+
     import app.services.google_calendar_provider  # noqa: F401
     from app.services.google_calendar_provider import GoogleCalendarSyncProvider
-
-    from fastapi import HTTPException
 
     provider = GoogleCalendarSyncProvider()
     sync_record = MagicMock()

--- a/backend/tests/unit/test_google_calendar_provider.py
+++ b/backend/tests/unit/test_google_calendar_provider.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.security import encrypt_oauth_token
+from app.services.sync_provider import provider_registry
+
+
+# ---------------------------------------------------------------------------
+# Provider registration
+# ---------------------------------------------------------------------------
+
+
+def test_provider_registered_in_registry() -> None:
+    """GoogleCalendarSyncProvider must be registered under 'google_calendar'."""
+    import app.services.google_calendar_provider  # noqa: F401
+
+    from app.services.google_calendar_provider import GoogleCalendarSyncProvider
+
+    registered = provider_registry.get("google_calendar")
+    assert registered is GoogleCalendarSyncProvider
+
+
+# ---------------------------------------------------------------------------
+# sync() — creates project, task, and schedule blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_creates_sentinel_project_task_and_block() -> None:
+    """sync() creates a sentinel project, task per event, and schedule block per event."""
+    import app.services.google_calendar_provider  # noqa: F401
+    from app.services.google_calendar_provider import GoogleCalendarSyncProvider
+
+    provider = GoogleCalendarSyncProvider()
+
+    sync_record = MagicMock()
+    sync_record.user_id = uuid.uuid4()
+    sync_record.sync_config_json = {
+        "encrypted_access_token": encrypt_oauth_token("tok"),
+        "encrypted_refresh_token": encrypt_oauth_token("ref"),
+        "token_expiry": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+    }
+
+    fake_events = [
+        {
+            "id": "evt1",
+            "summary": "Team Standup",
+            "start": {"dateTime": "2026-04-20T09:00:00+00:00"},
+            "end": {"dateTime": "2026-04-20T09:30:00+00:00"},
+        }
+    ]
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_mock_scalar_none())
+
+    with patch(
+        "app.services.google_calendar_provider.get_valid_access_token",
+        new_callable=AsyncMock,
+        return_value="access-token",
+    ), patch(
+        "app.services.google_calendar_provider.fetch_calendar_events",
+        new_callable=AsyncMock,
+        return_value=fake_events,
+    ):
+        await provider.sync(db, sync_record)
+
+    # db.add should be called at least once (project + task + block)
+    assert db.add.call_count >= 1
+    assert db.flush.called
+
+
+@pytest.mark.asyncio
+async def test_sync_skips_all_day_events() -> None:
+    """sync() skips events that have only start.date (all-day events)."""
+    import app.services.google_calendar_provider  # noqa: F401
+    from app.services.google_calendar_provider import GoogleCalendarSyncProvider
+
+    provider = GoogleCalendarSyncProvider()
+
+    sync_record = MagicMock()
+    sync_record.user_id = uuid.uuid4()
+
+    fake_events = [
+        {
+            "id": "all-day-evt",
+            "summary": "Holiday",
+            "start": {"date": "2026-04-20"},
+            "end": {"date": "2026-04-21"},
+        }
+    ]
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_mock_scalar_none())
+
+    with patch(
+        "app.services.google_calendar_provider.get_valid_access_token",
+        new_callable=AsyncMock,
+        return_value="access-token",
+    ), patch(
+        "app.services.google_calendar_provider.fetch_calendar_events",
+        new_callable=AsyncMock,
+        return_value=fake_events,
+    ):
+        await provider.sync(db, sync_record)
+
+    # Only the sentinel project may be created/looked up — no Task/ScheduleBlock adds
+    # Since all-day event is skipped, task + block creation should not happen
+    # We can verify by checking that add was not called with a ScheduleBlock
+    from app.models.schedule_block import ScheduleBlock
+
+    added_types = [type(call.args[0]) for call in db.add.call_args_list if call.args]
+    assert ScheduleBlock not in added_types
+
+
+@pytest.mark.asyncio
+async def test_sync_token_error_propagates() -> None:
+    """sync() propagates HTTPException when token retrieval fails."""
+    import app.services.google_calendar_provider  # noqa: F401
+    from app.services.google_calendar_provider import GoogleCalendarSyncProvider
+
+    from fastapi import HTTPException
+
+    provider = GoogleCalendarSyncProvider()
+    sync_record = MagicMock()
+    sync_record.user_id = uuid.uuid4()
+    sync_record.sync_config_json = {}
+    db = AsyncMock()
+
+    with patch(
+        "app.services.google_calendar_provider.get_valid_access_token",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=401, detail="not connected"),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await provider.sync(db, sync_record)
+
+    assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_scalar_none() -> MagicMock:
+    """Return a mock db.execute() result that yields scalar_one_or_none() == None."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    return result

--- a/backend/tests/unit/test_google_calendar_routes.py
+++ b/backend/tests/unit/test_google_calendar_routes.py
@@ -84,6 +84,7 @@ async def test_auth_returns_authorization_url(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_auth_requires_authentication(client: AsyncClient) -> None:
     """GET /sync/google-calendar/auth without JWT returns 401."""
+
     async def override_db() -> AsyncMock:  # type: ignore[misc]
         yield AsyncMock()
 
@@ -103,24 +104,28 @@ async def test_auth_requires_authentication(client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_callback_success_creates_sync_record(client: AsyncClient) -> None:
-    """GET /sync/google-calendar/callback with valid code returns 200 and sync record."""
+    """GET /sync/google-calendar/callback with valid code returns 200."""
     _setup_overrides()
     try:
-        with patch(
-            "app.api.sync.exchange_code_for_tokens",
-            new_callable=AsyncMock,
-            return_value={
-                "access_token": "access-abc",
-                "refresh_token": "refresh-xyz",
-                "expires_in": 3600,
-            },
-        ), patch(
-            "app.api.sync.store_tokens_in_sync_record",
-            new_callable=AsyncMock,
-        ), patch(
-            "app.api.sync.get_or_create_google_calendar_sync",
-            new_callable=AsyncMock,
-            return_value=_make_sync_response(),
+        with (
+            patch(
+                "app.api.sync.exchange_code_for_tokens",
+                new_callable=AsyncMock,
+                return_value={
+                    "access_token": "access-abc",
+                    "refresh_token": "refresh-xyz",
+                    "expires_in": 3600,
+                },
+            ),
+            patch(
+                "app.api.sync.store_tokens_in_sync_record",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "app.api.sync.get_or_create_google_calendar_sync",
+                new_callable=AsyncMock,
+                return_value=_make_sync_response(),
+            ),
         ):
             response = await client.get(
                 "/sync/google-calendar/callback",
@@ -152,6 +157,7 @@ async def test_callback_rejects_invalid_state(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_callback_requires_authentication(client: AsyncClient) -> None:
     """GET /sync/google-calendar/callback without JWT returns 401."""
+
     async def override_db() -> AsyncMock:  # type: ignore[misc]
         yield AsyncMock()
 

--- a/backend/tests/unit/test_google_calendar_routes.py
+++ b/backend/tests/unit/test_google_calendar_routes.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.main import app
+from app.schemas.sync import SyncStatusResponse
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+SYNC_ID = uuid.UUID("00000000-0000-0000-0000-bbbbbbbbbbbb")
+
+
+def _make_fake_user() -> MagicMock:
+    fake = MagicMock()
+    fake.id = USER_ID
+    fake.email = "gcal@example.com"
+    fake.name = "GCal User"
+    return fake
+
+
+def _make_sync_response() -> SyncStatusResponse:
+    return SyncStatusResponse(
+        id=SYNC_ID,
+        provider="google_calendar",
+        status="active",
+        last_synced_at=None,
+        sync_config_json={},
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+def _setup_overrides() -> None:
+    app.dependency_overrides[get_current_user] = _make_fake_user
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+
+
+def _clear_overrides() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /sync/google-calendar/auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_returns_authorization_url(client: AsyncClient) -> None:
+    """GET /sync/google-calendar/auth returns 200 with authorization_url."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.sync.build_authorization_url",
+            return_value="https://accounts.google.com/o/oauth2/v2/auth?scope=calendar",
+        ):
+            response = await client.get("/sync/google-calendar/auth")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "authorization_url" in data
+    assert data["authorization_url"].startswith("https://accounts.google.com")
+
+
+@pytest.mark.asyncio
+async def test_auth_requires_authentication(client: AsyncClient) -> None:
+    """GET /sync/google-calendar/auth without JWT returns 401."""
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.get("/sync/google-calendar/auth")
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /sync/google-calendar/callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_callback_success_creates_sync_record(client: AsyncClient) -> None:
+    """GET /sync/google-calendar/callback with valid code returns 200 and sync record."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.sync.exchange_code_for_tokens",
+            new_callable=AsyncMock,
+            return_value={
+                "access_token": "access-abc",
+                "refresh_token": "refresh-xyz",
+                "expires_in": 3600,
+            },
+        ), patch(
+            "app.api.sync.store_tokens_in_sync_record",
+            new_callable=AsyncMock,
+        ), patch(
+            "app.api.sync.get_or_create_google_calendar_sync",
+            new_callable=AsyncMock,
+            return_value=_make_sync_response(),
+        ):
+            response = await client.get(
+                "/sync/google-calendar/callback",
+                params={"code": "auth-code-123", "state": str(USER_ID)},
+            )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["provider"] == "google_calendar"
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_invalid_state(client: AsyncClient) -> None:
+    """GET /sync/google-calendar/callback with wrong state returns 400."""
+    _setup_overrides()
+    try:
+        response = await client.get(
+            "/sync/google-calendar/callback",
+            params={"code": "auth-code-123", "state": "wrong-state"},
+        )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_callback_requires_authentication(client: AsyncClient) -> None:
+    """GET /sync/google-calendar/callback without JWT returns 401."""
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        response = await client.get(
+            "/sync/google-calendar/callback",
+            params={"code": "auth-code-123", "state": str(USER_ID)},
+        )
+    finally:
+        _clear_overrides()
+
+    assert response.status_code == 401

--- a/backend/tests/unit/test_google_calendar_service.py
+++ b/backend/tests/unit/test_google_calendar_service.py
@@ -24,6 +24,22 @@ from app.services.google_calendar import (
 USER_ID = str(uuid.UUID("00000000-0000-0000-0000-000000000003"))
 
 
+def _make_httpx_mock(
+    method: str = "get", response_data: object = None, status: int = 200
+) -> MagicMock:
+    """Create a properly configured httpx.AsyncClient mock."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status
+    mock_resp.json.return_value = response_data or {}
+
+    mock_client = MagicMock()
+    coro = AsyncMock(return_value=mock_resp)
+    setattr(mock_client, method, coro)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
 # ---------------------------------------------------------------------------
 # build_authorization_url
 # ---------------------------------------------------------------------------
@@ -48,29 +64,22 @@ def test_build_authorization_url_state_matches_user_id(user_id: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# exchange_code_for_tokens
+# exchange_code_for_tokens (mock _post_to_token_endpoint)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_exchange_code_success_returns_tokens() -> None:
-    """exchange_code_for_tokens returns access and refresh tokens on success."""
+    """exchange_code_for_tokens returns access and refresh tokens."""
     fake_tokens = {
         "access_token": "access-abc",
         "refresh_token": "refresh-xyz",
         "expires_in": 3600,
     }
-    mock_resp = MagicMock()
-    mock_resp.status_code = 200
-    mock_resp.json.return_value = fake_tokens
-
-    mock_client = AsyncMock()
-    mock_client.post = AsyncMock(return_value=mock_resp)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-
     with patch(
-        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+        "app.services.google_calendar._post_to_token_endpoint",
+        new_callable=AsyncMock,
+        return_value=fake_tokens,
     ):
         result = await exchange_code_for_tokens("auth-code")
 
@@ -80,18 +89,11 @@ async def test_exchange_code_success_returns_tokens() -> None:
 
 @pytest.mark.asyncio
 async def test_exchange_code_failure_raises_http_exception() -> None:
-    """exchange_code_for_tokens raises HTTPException 401 when Google returns error."""
-    mock_resp = MagicMock()
-    mock_resp.status_code = 400
-    mock_resp.json.return_value = {"error": "invalid_grant"}
-
-    mock_client = AsyncMock()
-    mock_client.post = AsyncMock(return_value=mock_resp)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-
+    """exchange_code_for_tokens raises 401 when token endpoint fails."""
     with patch(
-        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+        "app.services.google_calendar._post_to_token_endpoint",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=401, detail="fail"),
     ):
         with pytest.raises(HTTPException) as exc_info:
             await exchange_code_for_tokens("bad-code")
@@ -99,28 +101,34 @@ async def test_exchange_code_failure_raises_http_exception() -> None:
     assert exc_info.value.status_code == 401
 
 
+@pytest.mark.asyncio
+async def test_exchange_code_raises_when_no_access_token_in_response() -> None:
+    """exchange_code_for_tokens raises 401 when response lacks access_token."""
+    with patch(
+        "app.services.google_calendar._post_to_token_endpoint",
+        new_callable=AsyncMock,
+        return_value={"token_type": "Bearer"},
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await exchange_code_for_tokens("code-no-token")
+
+    assert exc_info.value.status_code == 401
+
+
 # ---------------------------------------------------------------------------
-# refresh_access_token
+# refresh_access_token (mock _post_to_token_endpoint)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_refresh_access_token_success() -> None:
-    """refresh_access_token decrypts the refresh token and posts to Google."""
+    """refresh_access_token decrypts the refresh token and returns tokens."""
     encrypted = encrypt_oauth_token("my-refresh-token")
 
-    fake_response = {"access_token": "new-access", "expires_in": 3600}
-    mock_resp = MagicMock()
-    mock_resp.status_code = 200
-    mock_resp.json.return_value = fake_response
-
-    mock_client = AsyncMock()
-    mock_client.post = AsyncMock(return_value=mock_resp)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-
     with patch(
-        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+        "app.services.google_calendar._post_to_token_endpoint",
+        new_callable=AsyncMock,
+        return_value={"access_token": "new-access", "expires_in": 3600},
     ):
         result = await refresh_access_token(encrypted)
 
@@ -129,20 +137,29 @@ async def test_refresh_access_token_success() -> None:
 
 @pytest.mark.asyncio
 async def test_refresh_failure_raises_http_exception() -> None:
-    """refresh_access_token raises HTTPException 401 when Google returns error."""
+    """refresh_access_token raises 401 when token endpoint fails."""
     encrypted = encrypt_oauth_token("bad-refresh-token")
 
-    mock_resp = MagicMock()
-    mock_resp.status_code = 400
-    mock_resp.json.return_value = {"error": "invalid_grant"}
+    with patch(
+        "app.services.google_calendar._post_to_token_endpoint",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=401, detail="fail"),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_access_token(encrypted)
 
-    mock_client = AsyncMock()
-    mock_client.post = AsyncMock(return_value=mock_resp)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_refresh_raises_when_no_access_token_in_response() -> None:
+    """refresh_access_token raises 401 when response lacks access_token."""
+    encrypted = encrypt_oauth_token("refresh-token")
 
     with patch(
-        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+        "app.services.google_calendar._post_to_token_endpoint",
+        new_callable=AsyncMock,
+        return_value={"token_type": "Bearer"},
     ):
         with pytest.raises(HTTPException) as exc_info:
             await refresh_access_token(encrypted)
@@ -151,7 +168,7 @@ async def test_refresh_failure_raises_http_exception() -> None:
 
 
 # ---------------------------------------------------------------------------
-# fetch_calendar_events
+# fetch_calendar_events (httpx mock - only these use AsyncClient)
 # ---------------------------------------------------------------------------
 
 
@@ -159,17 +176,11 @@ async def test_refresh_failure_raises_http_exception() -> None:
 async def test_fetch_calendar_events_returns_list() -> None:
     """fetch_calendar_events returns a list of event dicts."""
     events = [{"id": "evt1", "summary": "Meeting"}]
-    mock_resp = MagicMock()
-    mock_resp.status_code = 200
-    mock_resp.json.return_value = {"items": events}
-
-    mock_client = AsyncMock()
-    mock_client.get = AsyncMock(return_value=mock_resp)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client = _make_httpx_mock("get", {"items": events}, 200)
 
     with patch(
-        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+        "app.services.google_calendar.httpx.AsyncClient",
+        return_value=mock_client,
     ):
         result = await fetch_calendar_events(
             "token", "2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z"
@@ -188,18 +199,18 @@ async def test_fetch_calendar_events_handles_pagination() -> None:
     mock_resp1 = MagicMock()
     mock_resp1.status_code = 200
     mock_resp1.json.return_value = page1
-
     mock_resp2 = MagicMock()
     mock_resp2.status_code = 200
     mock_resp2.json.return_value = page2
 
-    mock_client = AsyncMock()
+    mock_client = MagicMock()
     mock_client.get = AsyncMock(side_effect=[mock_resp1, mock_resp2])
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
     with patch(
-        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+        "app.services.google_calendar.httpx.AsyncClient",
+        return_value=mock_client,
     ):
         result = await fetch_calendar_events(
             "token", "2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z"
@@ -212,18 +223,12 @@ async def test_fetch_calendar_events_handles_pagination() -> None:
 
 @pytest.mark.asyncio
 async def test_fetch_calendar_events_raises_on_error() -> None:
-    """fetch_calendar_events raises HTTPException 502 when Google returns error."""
-    mock_resp = MagicMock()
-    mock_resp.status_code = 403
-    mock_resp.json.return_value = {"error": "forbidden"}
-
-    mock_client = AsyncMock()
-    mock_client.get = AsyncMock(return_value=mock_resp)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
+    """fetch_calendar_events raises HTTPException 502 on Google error."""
+    mock_client = _make_httpx_mock("get", {"error": "forbidden"}, 403)
 
     with patch(
-        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+        "app.services.google_calendar.httpx.AsyncClient",
+        return_value=mock_client,
     ):
         with pytest.raises(HTTPException) as exc_info:
             await fetch_calendar_events(
@@ -264,10 +269,12 @@ async def test_store_tokens_encrypts_access_and_refresh() -> None:
 
 @pytest.mark.asyncio
 async def test_store_tokens_preserves_existing_refresh_when_omitted() -> None:
-    """store_tokens_in_sync_record keeps old refresh token when token_data omits it."""
+    """store_tokens keeps old refresh token when token_data omits it."""
     old_encrypted_refresh = encrypt_oauth_token("old-refresh")
     sync_record = MagicMock()
-    sync_record.sync_config_json = {"encrypted_refresh_token": old_encrypted_refresh}
+    sync_record.sync_config_json = {
+        "encrypted_refresh_token": old_encrypted_refresh,
+    }
     db = AsyncMock()
 
     token_data = {"access_token": "new-access", "expires_in": 3600}
@@ -278,6 +285,47 @@ async def test_store_tokens_preserves_existing_refresh_when_omitted() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_store_tokens_sets_future_expiry() -> None:
+    """store_tokens_in_sync_record stores a future token_expiry."""
+    sync_record = MagicMock()
+    sync_record.sync_config_json = {}
+    db = AsyncMock()
+
+    before = datetime.now(UTC)
+    token_data = {
+        "access_token": "tok",
+        "refresh_token": "ref",
+        "expires_in": 3600,
+    }
+    await store_tokens_in_sync_record(db, sync_record, token_data)
+
+    expiry_str = sync_record.sync_config_json["token_expiry"]
+    assert expiry_str is not None
+    expiry = datetime.fromisoformat(expiry_str)
+    assert expiry > before
+
+
+@pytest.mark.asyncio
+async def test_store_tokens_expiry_reflects_expires_in() -> None:
+    """store_tokens sets token_expiry ~now + expires_in seconds."""
+    sync_record = MagicMock()
+    sync_record.sync_config_json = {}
+    db = AsyncMock()
+
+    token_data = {
+        "access_token": "tok",
+        "refresh_token": "ref",
+        "expires_in": 7200,
+    }
+    before = datetime.now(UTC)
+    await store_tokens_in_sync_record(db, sync_record, token_data)
+
+    expiry = datetime.fromisoformat(sync_record.sync_config_json["token_expiry"])
+    assert expiry > before + timedelta(seconds=7100)
+    assert expiry < before + timedelta(seconds=7300)
+
+
 # ---------------------------------------------------------------------------
 # get_valid_access_token
 # ---------------------------------------------------------------------------
@@ -285,7 +333,7 @@ async def test_store_tokens_preserves_existing_refresh_when_omitted() -> None:
 
 @pytest.mark.asyncio
 async def test_get_valid_token_returns_cached_when_not_expired() -> None:
-    """get_valid_access_token returns cached token without refreshing if still valid."""
+    """get_valid_access_token returns cached token without refreshing."""
     future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
     sync_record = MagicMock()
     sync_record.sync_config_json = {
@@ -296,7 +344,8 @@ async def test_get_valid_token_returns_cached_when_not_expired() -> None:
     db = AsyncMock()
 
     with patch(
-        "app.services.google_calendar.refresh_access_token", new_callable=AsyncMock
+        "app.services.google_calendar.refresh_access_token",
+        new_callable=AsyncMock,
     ) as mock_refresh:
         result = await get_valid_access_token(db, sync_record)
 
@@ -306,7 +355,7 @@ async def test_get_valid_token_returns_cached_when_not_expired() -> None:
 
 @pytest.mark.asyncio
 async def test_get_valid_token_refreshes_when_expired() -> None:
-    """get_valid_access_token refreshes the token when expiry has passed."""
+    """get_valid_access_token refreshes when expiry has passed."""
     past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
     sync_record = MagicMock()
     sync_record.sync_config_json = {
@@ -336,7 +385,7 @@ async def test_get_valid_token_refreshes_when_expired() -> None:
 
 @pytest.mark.asyncio
 async def test_get_valid_token_raises_when_no_tokens() -> None:
-    """get_valid_access_token raises 401 HTTPException when no tokens stored."""
+    """get_valid_access_token raises 401 when no tokens stored."""
     sync_record = MagicMock()
     sync_record.sync_config_json = {}
     db = AsyncMock()

--- a/backend/tests/unit/test_google_calendar_service.py
+++ b/backend/tests/unit/test_google_calendar_service.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from hypothesis import given, settings as hyp_settings
+from hypothesis import strategies as st
+
+from app.core.security import encrypt_oauth_token
+from app.services.google_calendar import (
+    GOOGLE_AUTH_URL,
+    GOOGLE_CALENDAR_SCOPE,
+    build_authorization_url,
+    exchange_code_for_tokens,
+    fetch_calendar_events,
+    get_valid_access_token,
+    refresh_access_token,
+    store_tokens_in_sync_record,
+)
+
+USER_ID = str(uuid.UUID("00000000-0000-0000-0000-000000000003"))
+
+
+# ---------------------------------------------------------------------------
+# build_authorization_url
+# ---------------------------------------------------------------------------
+
+
+def test_build_authorization_url_contains_required_params() -> None:
+    """Authorization URL must include scope, access_type=offline, state."""
+    url = build_authorization_url(USER_ID)
+    assert url.startswith(GOOGLE_AUTH_URL)
+    assert "calendar.readonly" in url
+    assert "access_type=offline" in url
+    assert "prompt=consent" in url
+    assert USER_ID in url
+
+
+@hyp_settings(max_examples=20)
+@given(st.uuids().map(str))
+def test_build_authorization_url_state_matches_user_id(user_id: str) -> None:
+    """State parameter in URL always equals the provided user_id."""
+    url = build_authorization_url(user_id)
+    assert f"state={user_id}" in url
+
+
+# ---------------------------------------------------------------------------
+# exchange_code_for_tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_success_returns_tokens() -> None:
+    """exchange_code_for_tokens returns access and refresh tokens on success."""
+    fake_tokens = {
+        "access_token": "access-abc",
+        "refresh_token": "refresh-xyz",
+        "expires_in": 3600,
+    }
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = fake_tokens
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+        result = await exchange_code_for_tokens("auth-code")
+
+    assert result["access_token"] == "access-abc"
+    assert result["refresh_token"] == "refresh-xyz"
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_failure_raises_http_exception() -> None:
+    """exchange_code_for_tokens raises HTTPException 401 when Google returns error."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 400
+    mock_resp.json.return_value = {"error": "invalid_grant"}
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            await exchange_code_for_tokens("bad-code")
+
+    assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# refresh_access_token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_success() -> None:
+    """refresh_access_token decrypts the refresh token and posts to Google."""
+    encrypted = encrypt_oauth_token("my-refresh-token")
+
+    fake_response = {"access_token": "new-access", "expires_in": 3600}
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = fake_response
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+        result = await refresh_access_token(encrypted)
+
+    assert result["access_token"] == "new-access"
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_raises_http_exception() -> None:
+    """refresh_access_token raises HTTPException 401 when Google returns error."""
+    encrypted = encrypt_oauth_token("bad-refresh-token")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 400
+    mock_resp.json.return_value = {"error": "invalid_grant"}
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            await refresh_access_token(encrypted)
+
+    assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# fetch_calendar_events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_calendar_events_returns_list() -> None:
+    """fetch_calendar_events returns a list of event dicts."""
+    events = [{"id": "evt1", "summary": "Meeting"}]
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"items": events}
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_calendar_events("token", "2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z")
+
+    assert len(result) == 1
+    assert result[0]["summary"] == "Meeting"
+
+
+@pytest.mark.asyncio
+async def test_fetch_calendar_events_handles_pagination() -> None:
+    """fetch_calendar_events follows nextPageToken to collect all events."""
+    page1 = {"items": [{"id": "e1"}], "nextPageToken": "tok123"}
+    page2 = {"items": [{"id": "e2"}]}
+
+    mock_resp1 = MagicMock()
+    mock_resp1.status_code = 200
+    mock_resp1.json.return_value = page1
+
+    mock_resp2 = MagicMock()
+    mock_resp2.status_code = 200
+    mock_resp2.json.return_value = page2
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=[mock_resp1, mock_resp2])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_calendar_events("token", "2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z")
+
+    assert len(result) == 2
+    assert result[0]["id"] == "e1"
+    assert result[1]["id"] == "e2"
+
+
+@pytest.mark.asyncio
+async def test_fetch_calendar_events_raises_on_error() -> None:
+    """fetch_calendar_events raises HTTPException 502 when Google returns error."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 403
+    mock_resp.json.return_value = {"error": "forbidden"}
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            await fetch_calendar_events("token", "2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z")
+
+    assert exc_info.value.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# store_tokens_in_sync_record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_store_tokens_encrypts_access_and_refresh() -> None:
+    """store_tokens_in_sync_record encrypts tokens before storing in sync_config_json."""
+    from app.core.security import decrypt_oauth_token
+
+    sync_record = MagicMock()
+    sync_record.sync_config_json = {}
+    db = AsyncMock()
+
+    token_data = {
+        "access_token": "plain-access",
+        "refresh_token": "plain-refresh",
+        "expires_in": 3600,
+    }
+    await store_tokens_in_sync_record(db, sync_record, token_data)
+
+    stored = sync_record.sync_config_json
+    assert stored["encrypted_access_token"] != "plain-access"
+    assert stored["encrypted_refresh_token"] != "plain-refresh"
+    assert decrypt_oauth_token(stored["encrypted_access_token"]) == "plain-access"
+    assert decrypt_oauth_token(stored["encrypted_refresh_token"]) == "plain-refresh"
+    assert "token_expiry" in stored
+
+
+@pytest.mark.asyncio
+async def test_store_tokens_preserves_existing_refresh_when_omitted() -> None:
+    """store_tokens_in_sync_record keeps old encrypted_refresh_token when token_data omits it."""
+    old_encrypted_refresh = encrypt_oauth_token("old-refresh")
+    sync_record = MagicMock()
+    sync_record.sync_config_json = {"encrypted_refresh_token": old_encrypted_refresh}
+    db = AsyncMock()
+
+    token_data = {"access_token": "new-access", "expires_in": 3600}
+    await store_tokens_in_sync_record(db, sync_record, token_data)
+
+    assert sync_record.sync_config_json["encrypted_refresh_token"] == old_encrypted_refresh
+
+
+# ---------------------------------------------------------------------------
+# get_valid_access_token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_valid_token_returns_cached_when_not_expired() -> None:
+    """get_valid_access_token returns the decrypted token without refreshing if still valid."""
+    future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    sync_record = MagicMock()
+    sync_record.sync_config_json = {
+        "encrypted_access_token": encrypt_oauth_token("cached-token"),
+        "encrypted_refresh_token": encrypt_oauth_token("refresh-token"),
+        "token_expiry": future,
+    }
+    db = AsyncMock()
+
+    with patch(
+        "app.services.google_calendar.refresh_access_token", new_callable=AsyncMock
+    ) as mock_refresh:
+        result = await get_valid_access_token(db, sync_record)
+
+    assert result == "cached-token"
+    mock_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_valid_token_refreshes_when_expired() -> None:
+    """get_valid_access_token refreshes the token when expiry has passed."""
+    past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    sync_record = MagicMock()
+    sync_record.sync_config_json = {
+        "encrypted_access_token": encrypt_oauth_token("old-token"),
+        "encrypted_refresh_token": encrypt_oauth_token("refresh-token"),
+        "token_expiry": past,
+    }
+    db = AsyncMock()
+
+    new_token_data = {"access_token": "fresh-token", "expires_in": 3600}
+
+    with patch(
+        "app.services.google_calendar.refresh_access_token",
+        new_callable=AsyncMock,
+        return_value=new_token_data,
+    ), patch(
+        "app.services.google_calendar.store_tokens_in_sync_record",
+        new_callable=AsyncMock,
+    ):
+        result = await get_valid_access_token(db, sync_record)
+
+    assert result == "fresh-token"
+
+
+@pytest.mark.asyncio
+async def test_get_valid_token_raises_when_no_tokens() -> None:
+    """get_valid_access_token raises 401 HTTPException when no tokens stored."""
+    sync_record = MagicMock()
+    sync_record.sync_config_json = {}
+    db = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_valid_access_token(db, sync_record)
+
+    assert exc_info.value.status_code == 401

--- a/backend/tests/unit/test_google_calendar_service.py
+++ b/backend/tests/unit/test_google_calendar_service.py
@@ -6,13 +6,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
-from hypothesis import given, settings as hyp_settings
+from hypothesis import given
+from hypothesis import settings as hyp_settings
 from hypothesis import strategies as st
 
 from app.core.security import encrypt_oauth_token
 from app.services.google_calendar import (
     GOOGLE_AUTH_URL,
-    GOOGLE_CALENDAR_SCOPE,
     build_authorization_url,
     exchange_code_for_tokens,
     fetch_calendar_events,
@@ -69,7 +69,9 @@ async def test_exchange_code_success_returns_tokens() -> None:
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+    with patch(
+        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+    ):
         result = await exchange_code_for_tokens("auth-code")
 
     assert result["access_token"] == "access-abc"
@@ -88,7 +90,9 @@ async def test_exchange_code_failure_raises_http_exception() -> None:
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+    with patch(
+        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+    ):
         with pytest.raises(HTTPException) as exc_info:
             await exchange_code_for_tokens("bad-code")
 
@@ -115,7 +119,9 @@ async def test_refresh_access_token_success() -> None:
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+    with patch(
+        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+    ):
         result = await refresh_access_token(encrypted)
 
     assert result["access_token"] == "new-access"
@@ -135,7 +141,9 @@ async def test_refresh_failure_raises_http_exception() -> None:
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+    with patch(
+        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+    ):
         with pytest.raises(HTTPException) as exc_info:
             await refresh_access_token(encrypted)
 
@@ -160,8 +168,12 @@ async def test_fetch_calendar_events_returns_list() -> None:
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
-        result = await fetch_calendar_events("token", "2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z")
+    with patch(
+        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+    ):
+        result = await fetch_calendar_events(
+            "token", "2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z"
+        )
 
     assert len(result) == 1
     assert result[0]["summary"] == "Meeting"
@@ -186,8 +198,12 @@ async def test_fetch_calendar_events_handles_pagination() -> None:
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
-        result = await fetch_calendar_events("token", "2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z")
+    with patch(
+        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+    ):
+        result = await fetch_calendar_events(
+            "token", "2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z"
+        )
 
     assert len(result) == 2
     assert result[0]["id"] == "e1"
@@ -206,9 +222,13 @@ async def test_fetch_calendar_events_raises_on_error() -> None:
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.services.google_calendar.httpx.AsyncClient", return_value=mock_client):
+    with patch(
+        "app.services.google_calendar.httpx.AsyncClient", return_value=mock_client
+    ):
         with pytest.raises(HTTPException) as exc_info:
-            await fetch_calendar_events("token", "2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z")
+            await fetch_calendar_events(
+                "token", "2026-01-01T00:00:00Z", "2026-01-08T00:00:00Z"
+            )
 
     assert exc_info.value.status_code == 502
 
@@ -220,7 +240,7 @@ async def test_fetch_calendar_events_raises_on_error() -> None:
 
 @pytest.mark.asyncio
 async def test_store_tokens_encrypts_access_and_refresh() -> None:
-    """store_tokens_in_sync_record encrypts tokens before storing in sync_config_json."""
+    """store_tokens_in_sync_record encrypts tokens before storing."""
     from app.core.security import decrypt_oauth_token
 
     sync_record = MagicMock()
@@ -244,7 +264,7 @@ async def test_store_tokens_encrypts_access_and_refresh() -> None:
 
 @pytest.mark.asyncio
 async def test_store_tokens_preserves_existing_refresh_when_omitted() -> None:
-    """store_tokens_in_sync_record keeps old encrypted_refresh_token when token_data omits it."""
+    """store_tokens_in_sync_record keeps old refresh token when token_data omits it."""
     old_encrypted_refresh = encrypt_oauth_token("old-refresh")
     sync_record = MagicMock()
     sync_record.sync_config_json = {"encrypted_refresh_token": old_encrypted_refresh}
@@ -253,7 +273,9 @@ async def test_store_tokens_preserves_existing_refresh_when_omitted() -> None:
     token_data = {"access_token": "new-access", "expires_in": 3600}
     await store_tokens_in_sync_record(db, sync_record, token_data)
 
-    assert sync_record.sync_config_json["encrypted_refresh_token"] == old_encrypted_refresh
+    assert (
+        sync_record.sync_config_json["encrypted_refresh_token"] == old_encrypted_refresh
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -263,7 +285,7 @@ async def test_store_tokens_preserves_existing_refresh_when_omitted() -> None:
 
 @pytest.mark.asyncio
 async def test_get_valid_token_returns_cached_when_not_expired() -> None:
-    """get_valid_access_token returns the decrypted token without refreshing if still valid."""
+    """get_valid_access_token returns cached token without refreshing if still valid."""
     future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
     sync_record = MagicMock()
     sync_record.sync_config_json = {
@@ -296,13 +318,16 @@ async def test_get_valid_token_refreshes_when_expired() -> None:
 
     new_token_data = {"access_token": "fresh-token", "expires_in": 3600}
 
-    with patch(
-        "app.services.google_calendar.refresh_access_token",
-        new_callable=AsyncMock,
-        return_value=new_token_data,
-    ), patch(
-        "app.services.google_calendar.store_tokens_in_sync_record",
-        new_callable=AsyncMock,
+    with (
+        patch(
+            "app.services.google_calendar.refresh_access_token",
+            new_callable=AsyncMock,
+            return_value=new_token_data,
+        ),
+        patch(
+            "app.services.google_calendar.store_tokens_in_sync_record",
+            new_callable=AsyncMock,
+        ),
     ):
         result = await get_valid_access_token(db, sync_record)
 


### PR DESCRIPTION
## Summary
- Add Google Calendar OAuth 2.0 flow with `GET /sync/google-calendar/auth` (consent URL) and `GET /sync/google-calendar/callback` (token exchange + encrypted storage)
- Implement `GoogleCalendarSyncProvider` that fetches calendar events and syncs them as `ScheduleBlock` rows with `source=google_calendar`, using sentinel Project/Task per user
- Add token refresh logic via `get_valid_access_token()` with automatic expiry detection and Fernet-encrypted token storage in `external_syncs.sync_config_json`

Closes #26

## What changed
- **New files (6):** `google_calendar.py` service, `google_calendar_provider.py` sync provider, 3 unit test files, 1 integration test file
- **Modified (5):** `config.py` (new redirect URI), `sync.py` (2 new routes), `sync.py` schema (auth response), `main.py` (provider registration), `.env.example`
- **No migration needed** — reuses existing `sync_config_json` JSONB column
- **No new dependencies** — uses existing `httpx` for all Google API calls

## Test plan
- [x] 470 unit tests pass (27 new for Google Calendar)
- [x] 3 integration tests pass (OAuth callback + sync trigger + state validation)
- [x] `ruff check` + `ruff format` clean
- [x] `mypy` clean on new files
- [x] Mutation testing: 78% score (93 killed + 75 timeout / 215 mutants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)