### PR TITLE
Fix review findings for Google Calendar OAuth

### DIFF
--- a/backend/app/api/sync.py
+++ b/backend/app/api/sync.py
@@ -13,6 +13,7 @@ from app.services.google_calendar import (
     exchange_code_for_tokens,
     get_or_create_google_calendar_sync,
     store_tokens_in_sync_record,
+    verify_state,
 )
 from app.services.sync_service import get_sync_status, trigger_sync
 
@@ -57,7 +58,7 @@ async def google_calendar_callback_route(
     db: AsyncSession = Depends(get_db),
 ) -> SyncStatusResponse:
     """Handle Google Calendar OAuth callback, store tokens, and return sync record."""
-    if state != str(current_user.id):
+    if not verify_state(state, str(current_user.id)):
         raise HTTPException(status_code=400, detail="Invalid OAuth state parameter")
 
     token_data = await exchange_code_for_tokens(code)

--- a/backend/app/services/google_calendar.py
+++ b/backend/app/services/google_calendar.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
@@ -21,6 +23,19 @@ GOOGLE_CALENDAR_EVENTS_URL = (
 )
 
 
+def _sign_state(user_id: str) -> str:
+    """Create an HMAC-signed state parameter: user_id.signature."""
+    sig = hmac.new(
+        settings.SECRET_KEY.encode(), user_id.encode(), hashlib.sha256
+    ).hexdigest()[:16]
+    return f"{user_id}.{sig}"
+
+
+def verify_state(state: str, user_id: str) -> bool:
+    """Verify that state was signed by this server for this user."""
+    return hmac.compare_digest(state, _sign_state(user_id))
+
+
 def build_authorization_url(user_id: str) -> str:
     """Build the Google OAuth consent URL for calendar access."""
     params = {
@@ -30,7 +45,7 @@ def build_authorization_url(user_id: str) -> str:
         "scope": GOOGLE_CALENDAR_SCOPE,
         "access_type": "offline",
         "prompt": "consent",
-        "state": user_id,
+        "state": _sign_state(user_id),
     }
     return f"{GOOGLE_AUTH_URL}?{urlencode(params)}"
 
@@ -86,7 +101,7 @@ async def store_tokens_in_sync_record(
     token_data: dict[str, Any],
 ) -> None:
     """Encrypt and persist access/refresh tokens in sync_config_json."""
-    expires_in: int = token_data.get("expires_in", 3600)
+    expires_in = int(token_data.get("expires_in", 3600))
     expiry = (datetime.now(UTC) + timedelta(seconds=expires_in)).isoformat()
 
     current_config: dict[str, Any] = dict(sync_record.sync_config_json or {})

--- a/backend/app/services/google_calendar_provider.py
+++ b/backend/app/services/google_calendar_provider.py
@@ -38,10 +38,12 @@ class GoogleCalendarSyncProvider(BaseSyncProvider):
 
         project = await _get_or_create_sentinel_project(db, sync_record.user_id)
 
-        # Delete existing google_calendar blocks for user in the date range
+        # Delete existing tasks + blocks (CASCADE) for the sentinel project
         sync_start = now.date()
         sync_end = (now + timedelta(days=_SYNC_DAYS_AHEAD)).date()
-        await _delete_existing_blocks(db, sync_record.user_id, sync_start, sync_end)
+        await _delete_existing_tasks_and_blocks(
+            db, sync_record.user_id, sync_start, sync_end
+        )
 
         for event in events:
             block_data = _event_to_block_data(event)
@@ -90,34 +92,32 @@ async def _get_or_create_sentinel_project(
     return project
 
 
-async def _delete_existing_blocks(
+async def _delete_existing_tasks_and_blocks(
     db: AsyncSession,
     user_id: Any,
     start: date,
     end: date,
 ) -> None:
-    """Delete google_calendar ScheduleBlocks for a user within the date range."""
-    # ScheduleBlock → Task → Project (user_id)
+    """Delete sentinel Tasks (and their ScheduleBlocks via CASCADE) in date range."""
+    # Find task IDs that have google_calendar blocks in the date range
     task_ids_result = await db.execute(
         select(Task.id)
         .join(Project, Task.project_id == Project.id)
+        .join(ScheduleBlock, ScheduleBlock.task_id == Task.id)
         .where(
             Project.user_id == user_id,
             Project.name == _SENTINEL_PROJECT_NAME,
+            ScheduleBlock.source == ScheduleBlockSource.GOOGLE_CALENDAR,
+            ScheduleBlock.date >= start,
+            ScheduleBlock.date <= end,
         )
     )
     task_ids = [row[0] for row in task_ids_result.all()]
     if not task_ids:
         return
 
-    await db.execute(
-        delete(ScheduleBlock).where(
-            ScheduleBlock.task_id.in_(task_ids),
-            ScheduleBlock.source == ScheduleBlockSource.GOOGLE_CALENDAR,
-            ScheduleBlock.date >= start,
-            ScheduleBlock.date <= end,
-        )
-    )
+    # Deleting tasks cascades to their schedule blocks
+    await db.execute(delete(Task).where(Task.id.in_(task_ids)))
 
 
 def _event_to_block_data(
@@ -133,12 +133,12 @@ def _event_to_block_data(
     if not start_dt_str or not end_dt_str:
         return None  # all-day event — no hour information
 
-    start_dt = datetime.fromisoformat(start_dt_str)
-    end_dt = datetime.fromisoformat(end_dt_str)
+    start_utc = datetime.fromisoformat(start_dt_str).astimezone(UTC)
+    end_utc = datetime.fromisoformat(end_dt_str).astimezone(UTC)
 
-    event_date = start_dt.astimezone(UTC).date()
-    start_hour = Decimal(str(round(start_dt.hour + start_dt.minute / 60, 2)))
-    end_hour = Decimal(str(round(end_dt.hour + end_dt.minute / 60, 2)))
+    event_date = start_utc.date()
+    start_hour = Decimal(str(round(start_utc.hour + start_utc.minute / 60, 2)))
+    end_hour = Decimal(str(round(end_utc.hour + end_utc.minute / 60, 2)))
 
     if end_hour <= start_hour:
         end_hour = start_hour + Decimal("0.5")

--- a/backend/tests/integration/test_google_calendar_sync.py
+++ b/backend/tests/integration/test_google_calendar_sync.py
@@ -12,6 +12,7 @@ from app.core.security import decrypt_oauth_token, encrypt_oauth_token
 from app.models.external_sync import ExternalSync
 from app.models.schedule_block import ScheduleBlock
 from app.models.user import User
+from app.services.google_calendar import _sign_state
 
 
 @pytest.mark.asyncio
@@ -34,7 +35,7 @@ async def test_callback_creates_external_sync_record(
     ):
         resp = await auth_client.get(
             "/sync/google-calendar/callback",
-            params={"code": "auth-code", "state": str(test_user.id)},
+            params={"code": "auth-code", "state": _sign_state(str(test_user.id))},
         )
 
     assert resp.status_code == 200

--- a/backend/tests/unit/test_google_calendar_routes.py
+++ b/backend/tests/unit/test_google_calendar_routes.py
@@ -12,6 +12,7 @@ from app.core.database import get_db
 from app.core.deps import get_current_user
 from app.main import app
 from app.schemas.sync import SyncStatusResponse
+from app.services.google_calendar import _sign_state
 
 USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
 SYNC_ID = uuid.UUID("00000000-0000-0000-0000-bbbbbbbbbbbb")
@@ -129,7 +130,7 @@ async def test_callback_success_creates_sync_record(client: AsyncClient) -> None
         ):
             response = await client.get(
                 "/sync/google-calendar/callback",
-                params={"code": "auth-code-123", "state": str(USER_ID)},
+                params={"code": "auth-code-123", "state": _sign_state(str(USER_ID))},
             )
     finally:
         _clear_overrides()

--- a/backend/tests/unit/test_google_calendar_service.py
+++ b/backend/tests/unit/test_google_calendar_service.py
@@ -13,12 +13,14 @@ from hypothesis import strategies as st
 from app.core.security import encrypt_oauth_token
 from app.services.google_calendar import (
     GOOGLE_AUTH_URL,
+    _sign_state,
     build_authorization_url,
     exchange_code_for_tokens,
     fetch_calendar_events,
     get_valid_access_token,
     refresh_access_token,
     store_tokens_in_sync_record,
+    verify_state,
 )
 
 USER_ID = str(uuid.UUID("00000000-0000-0000-0000-000000000003"))
@@ -57,10 +59,22 @@ def test_build_authorization_url_contains_required_params() -> None:
 
 @hyp_settings(max_examples=20)
 @given(st.uuids().map(str))
-def test_build_authorization_url_state_matches_user_id(user_id: str) -> None:
-    """State parameter in URL always equals the provided user_id."""
+def test_build_authorization_url_state_contains_user_id(user_id: str) -> None:
+    """State parameter in URL contains the user_id as a prefix."""
     url = build_authorization_url(user_id)
-    assert f"state={user_id}" in url
+    assert f"state={user_id}." in url
+
+
+def test_verify_state_accepts_valid_signature() -> None:
+    """verify_state returns True for a correctly signed state."""
+    signed = _sign_state(USER_ID)
+    assert verify_state(signed, USER_ID) is True
+
+
+def test_verify_state_rejects_tampered_signature() -> None:
+    """verify_state returns False for a tampered state."""
+    assert verify_state("wrong-state", USER_ID) is False
+    assert verify_state(f"{USER_ID}.badsig", USER_ID) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix UTC hour normalization bug in `_event_to_block_data` — hours/minutes now extracted from UTC-converted datetime, not local timezone
- Replace `_delete_existing_blocks` with `_delete_existing_tasks_and_blocks` — deletes Task rows so ScheduleBlocks cascade, preventing orphan task accumulation
- Add HMAC-signed OAuth state parameter using `SECRET_KEY` with constant-time verification via `verify_state()`
- Add defensive `int()` cast on `expires_in` from Google token response

## Test plan
- [x] 472 unit tests pass (2 new: `test_verify_state_accepts_valid_signature`, `test_verify_state_rejects_tampered_signature`)
- [x] `ruff check` clean
- [x] All existing Google Calendar tests updated for signed state

🤖 Generated with [Claude Code](https://claude.com/claude-code)