### PR TITLE
Implement AI Agent Group A: parallel analysts [#28]

### DIFF
--- a/backend/app/agents/__init__.py
+++ b/backend/app/agents/__init__.py
@@ -1,2 +1,3 @@
 """Pydantic AI agent definitions for FlowDay's AI pipeline."""
+
 from __future__ import annotations

--- a/backend/app/agents/__init__.py
+++ b/backend/app/agents/__init__.py
@@ -1,0 +1,2 @@
+"""Pydantic AI agent definitions for FlowDay's AI pipeline."""
+from __future__ import annotations

--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -1,0 +1,183 @@
+"""Shared agent utilities: metrics-instrumented runner and DB data-fetch helpers."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from pydantic_ai import Agent
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agents.schemas import (
+    GitHubSyncData,
+    ScheduleBlockData,
+    TaskData,
+    TimeEntryData,
+)
+from app.core.metrics import agent_latency_seconds
+from app.models.external_sync import ExternalSync, SyncProvider
+from app.models.project import Project
+from app.models.schedule_block import ScheduleBlock
+from app.models.task import Task
+from app.models.time_entry import TimeEntry
+
+
+async def run_with_metrics[T](
+    agent: Agent[Any, T],
+    name: str,
+    deps: Any,
+) -> T:
+    """Run an agent and record its wall-clock latency in Prometheus.
+
+    Args:
+        agent: The Pydantic AI agent to run.
+        name: Label value for the agent_latency_seconds metric.
+        deps: Typed deps dataclass to inject via RunContext.
+
+    Returns:
+        The agent's structured output.
+    """
+    start = time.perf_counter()
+    try:
+        result = await agent.run("Analyze and produce structured insights.", deps=deps)
+        return result.output
+    finally:
+        elapsed = time.perf_counter() - start
+        agent_latency_seconds.labels(agent_name=name).observe(elapsed)
+
+
+async def fetch_time_entries(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    analysis_date: date,
+) -> list[TimeEntryData]:
+    """Fetch completed time entries for the given user on the analysis date."""
+    day_start = datetime.combine(analysis_date, datetime.min.time(), tzinfo=UTC)
+    day_end = day_start + timedelta(days=1)
+
+    stmt = (
+        select(
+            TimeEntry.task_id,
+            Task.title.label("task_title"),
+            Project.name.label("project_name"),
+            TimeEntry.started_at,
+            TimeEntry.ended_at,
+            TimeEntry.duration_seconds,
+        )
+        .join(Task, TimeEntry.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            TimeEntry.started_at >= day_start,
+            TimeEntry.started_at < day_end,
+            TimeEntry.duration_seconds > 0,
+            Project.user_id == user_id,
+        )
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        TimeEntryData(
+            task_id=row.task_id,
+            task_title=row.task_title,
+            project_name=row.project_name,
+            started_at=row.started_at,
+            ended_at=row.ended_at,
+            duration_seconds=row.duration_seconds,
+        )
+        for row in rows
+    ]
+
+
+async def fetch_schedule_blocks(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    analysis_date: date,
+) -> list[ScheduleBlockData]:
+    """Fetch schedule blocks for the given user on the analysis date."""
+    stmt = (
+        select(
+            ScheduleBlock.task_id,
+            Task.title.label("task_title"),
+            ScheduleBlock.date,
+            ScheduleBlock.start_hour,
+            ScheduleBlock.end_hour,
+            ScheduleBlock.source,
+        )
+        .join(Task, ScheduleBlock.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            ScheduleBlock.date == analysis_date,
+            Project.user_id == user_id,
+        )
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        ScheduleBlockData(
+            task_id=row.task_id,
+            task_title=row.task_title,
+            date=row.date,
+            start_hour=float(row.start_hour),
+            end_hour=float(row.end_hour),
+            source=row.source.value if hasattr(row.source, "value") else row.source,
+        )
+        for row in rows
+    ]
+
+
+async def fetch_tasks(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> list[TaskData]:
+    """Fetch all tasks for the given user across all projects."""
+    stmt = (
+        select(
+            Task.id.label("task_id"),
+            Task.title,
+            Project.name.label("project_name"),
+            Task.status,
+            Task.priority,
+            Task.estimate_minutes,
+            Task.due_date,
+            Task.created_at,
+            Task.completed_at,
+        )
+        .join(Project, Task.project_id == Project.id)
+        .where(Project.user_id == user_id)
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        TaskData(
+            task_id=row.task_id,
+            title=row.title,
+            project_name=row.project_name,
+            status=row.status.value if hasattr(row.status, "value") else row.status,
+            priority=(
+                row.priority.value if hasattr(row.priority, "value") else row.priority
+            ),
+            estimate_minutes=row.estimate_minutes,
+            due_date=row.due_date,
+            created_at=row.created_at,
+            completed_at=row.completed_at,
+        )
+        for row in rows
+    ]
+
+
+async def fetch_github_sync(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> GitHubSyncData | None:
+    """Return GitHub sync metadata for the user, or None when not configured."""
+    stmt = select(ExternalSync).where(
+        ExternalSync.user_id == user_id,
+        ExternalSync.provider == SyncProvider.GITHUB,
+    )
+    record = (await db.execute(stmt)).scalar_one_or_none()
+    if record is None:
+        return None
+    return GitHubSyncData(
+        last_synced_at=record.last_synced_at,
+        sync_config=record.sync_config_json or {},
+    )

--- a/backend/app/agents/code_analyst.py
+++ b/backend/app/agents/code_analyst.py
@@ -1,0 +1,42 @@
+"""Code Analyst agent — analyzes GitHub sync data for code productivity insights."""
+from __future__ import annotations
+
+from pydantic_ai import Agent, RunContext
+
+from app.agents.schemas import CodeAnalystDeps, CodeAnalystResult
+from app.core.config import settings
+
+code_analyst: Agent[CodeAnalystDeps, CodeAnalystResult] = Agent(
+    model=settings.LLM_MODEL,
+    output_type=CodeAnalystResult,
+    deps_type=CodeAnalystDeps,
+    defer_model_check=True,
+    system_prompt=(
+        "You are a code productivity analyst. "
+        "Given GitHub sync metadata for a user, produce structured insights about "
+        "their code productivity. "
+        "When data_available is false (no GitHub sync configured), set all numeric "
+        "fields to 0, set data_available=false, avg_pr_cycle_hours and most_active_repo "
+        "to null, and provide a single insight explaining that GitHub is not connected. "
+        "Provide 2-4 concise, actionable insights otherwise."
+    ),
+)
+
+
+@code_analyst.instructions
+async def add_code_context(ctx: RunContext[CodeAnalystDeps]) -> str:
+    """Inject pre-fetched GitHub sync data into the prompt."""
+    deps = ctx.deps
+    if deps.github_sync is None:
+        return (
+            f"Analysis date: {deps.analysis_date}\n"
+            "GitHub sync: NOT CONFIGURED\n"
+            "data_available must be false. Return zeroed metrics."
+        )
+    sync = deps.github_sync
+    return (
+        f"Analysis date: {deps.analysis_date}\n"
+        f"Last synced at: {sync.last_synced_at}\n"
+        f"Sync configuration: {sync.sync_config}\n"
+        "data_available must be true."
+    )

--- a/backend/app/agents/code_analyst.py
+++ b/backend/app/agents/code_analyst.py
@@ -1,4 +1,5 @@
 """Code Analyst agent — analyzes GitHub sync data for code productivity insights."""
+
 from __future__ import annotations
 
 from pydantic_ai import Agent, RunContext
@@ -16,8 +17,9 @@ code_analyst: Agent[CodeAnalystDeps, CodeAnalystResult] = Agent(
         "Given GitHub sync metadata for a user, produce structured insights about "
         "their code productivity. "
         "When data_available is false (no GitHub sync configured), set all numeric "
-        "fields to 0, set data_available=false, avg_pr_cycle_hours and most_active_repo "
-        "to null, and provide a single insight explaining that GitHub is not connected. "
+        "fields to 0, set data_available=false, avg_pr_cycle_hours and "
+        "most_active_repo to null, and provide a single insight explaining that "
+        "GitHub is not connected. "
         "Provide 2-4 concise, actionable insights otherwise."
     ),
 )

--- a/backend/app/agents/meeting_analyst.py
+++ b/backend/app/agents/meeting_analyst.py
@@ -1,4 +1,5 @@
 """Meeting Analyst agent — analyzes Google Calendar data for meeting load insights."""
+
 from __future__ import annotations
 
 from pydantic_ai import Agent, RunContext
@@ -17,7 +18,8 @@ meeting_analyst: Agent[MeetingAnalystDeps, MeetingAnalystResult] = Agent(
         "You are a meeting load analyst. "
         "Given a list of calendar events for a user's day, produce structured insights "
         "about their meeting burden and available focus time. "
-        "All numeric fields must be >= 0. focus_time_hours = max(0, 8 - total_meeting_hours). "
+        "All numeric fields must be >= 0. "
+        "focus_time_hours = max(0, 8 - total_meeting_hours). "
         "Provide 2-4 concise, actionable insights in the insights list."
     ),
 )

--- a/backend/app/agents/meeting_analyst.py
+++ b/backend/app/agents/meeting_analyst.py
@@ -1,0 +1,46 @@
+"""Meeting Analyst agent — analyzes Google Calendar data for meeting load insights."""
+from __future__ import annotations
+
+from pydantic_ai import Agent, RunContext
+
+from app.agents.schemas import MeetingAnalystDeps, MeetingAnalystResult
+from app.core.config import settings
+
+_WORKDAY_HOURS = 8.0
+
+meeting_analyst: Agent[MeetingAnalystDeps, MeetingAnalystResult] = Agent(
+    model=settings.LLM_MODEL,
+    output_type=MeetingAnalystResult,
+    deps_type=MeetingAnalystDeps,
+    defer_model_check=True,
+    system_prompt=(
+        "You are a meeting load analyst. "
+        "Given a list of calendar events for a user's day, produce structured insights "
+        "about their meeting burden and available focus time. "
+        "All numeric fields must be >= 0. focus_time_hours = max(0, 8 - total_meeting_hours). "
+        "Provide 2-4 concise, actionable insights in the insights list."
+    ),
+)
+
+
+@meeting_analyst.instructions
+async def add_meeting_context(ctx: RunContext[MeetingAnalystDeps]) -> str:
+    """Inject pre-fetched calendar block data into the prompt."""
+    deps = ctx.deps
+    blocks = deps.calendar_blocks
+    meeting_count = len(blocks)
+    durations = [b.end_hour - b.start_hour for b in blocks]
+    total_hours = sum(durations)
+    avg_hours = total_hours / meeting_count if meeting_count > 0 else 0.0
+    longest_hours = max(durations) if durations else 0.0
+    focus_hours = max(0.0, _WORKDAY_HOURS - total_hours)
+
+    return (
+        f"Analysis date: {deps.analysis_date}\n"
+        f"Number of meetings: {meeting_count}\n"
+        f"Total meeting hours: {total_hours:.2f}\n"
+        f"Average meeting duration (hours): {avg_hours:.2f}\n"
+        f"Longest meeting (hours): {longest_hours:.2f}\n"
+        f"Focus time available (hours): {focus_hours:.2f}\n"
+        f"Meetings: {[b.model_dump() for b in blocks]}"
+    )

--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -1,0 +1,263 @@
+"""Group A orchestrator — runs four parallel analyst agents via asyncio.gather."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from datetime import UTC, date, datetime, timedelta
+from typing import Any, TypeVar
+
+from pydantic_ai import Agent
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agents.code_analyst import code_analyst
+from app.agents.meeting_analyst import meeting_analyst
+from app.agents.schemas import (
+    CodeAnalystDeps,
+    GitHubSyncData,
+    GroupAResult,
+    MeetingAnalystDeps,
+    ScheduleBlockData,
+    TaskAnalystDeps,
+    TaskData,
+    TimeAnalystDeps,
+    TimeEntryData,
+)
+from app.agents.task_analyst import task_analyst
+from app.agents.time_analyst import time_analyst
+from app.core.metrics import agent_latency_seconds
+from app.models.external_sync import ExternalSync, SyncProvider
+from app.models.project import Project
+from app.models.schedule_block import ScheduleBlock
+from app.models.task import Task
+from app.models.time_entry import TimeEntry
+
+log = logging.getLogger(__name__)
+
+_AgentResultT = TypeVar("_AgentResultT")
+
+
+async def _run_agent(
+    agent: Agent[Any, _AgentResultT],
+    name: str,
+    deps: Any,
+) -> _AgentResultT:
+    """Run a single agent, recording latency and propagating errors."""
+    start = time.perf_counter()
+    try:
+        result = await agent.run("Analyze and produce structured insights.", deps=deps)
+        return result.output
+    finally:
+        elapsed = time.perf_counter() - start
+        agent_latency_seconds.labels(agent_name=name).observe(elapsed)
+
+
+async def run_group_a(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    analysis_date: date,
+) -> GroupAResult:
+    """Run all four Group A analyst agents in parallel and return aggregated results.
+
+    Args:
+        db: Async database session for pre-fetching data.
+        user_id: The user whose data to analyze.
+        analysis_date: The reference date for the analysis.
+
+    Returns:
+        GroupAResult with individual agent outputs and any errors encountered.
+    """
+    time_entries, schedule_blocks, tasks, github_sync = await asyncio.gather(
+        _fetch_time_entries(db, user_id, analysis_date),
+        _fetch_schedule_blocks(db, user_id, analysis_date),
+        _fetch_tasks(db, user_id),
+        _fetch_github_sync(db, user_id),
+    )
+
+    calendar_blocks = [b for b in schedule_blocks if b.source == "google_calendar"]
+
+    time_deps = TimeAnalystDeps(
+        user_id=user_id,
+        analysis_date=analysis_date,
+        time_entries=time_entries,
+        schedule_blocks=[b for b in schedule_blocks if b.source == "manual"],
+    )
+    meeting_deps = MeetingAnalystDeps(
+        user_id=user_id,
+        analysis_date=analysis_date,
+        calendar_blocks=calendar_blocks,
+    )
+    code_deps = CodeAnalystDeps(
+        user_id=user_id,
+        analysis_date=analysis_date,
+        github_sync=github_sync,
+    )
+    task_deps = TaskAnalystDeps(
+        user_id=user_id,
+        analysis_date=analysis_date,
+        tasks=tasks,
+    )
+
+    errors: dict[str, str] = {}
+
+    async def _safe_run(agent: Agent[Any, Any], name: str, deps: Any) -> Any:
+        try:
+            return await _run_agent(agent, name, deps)
+        except Exception as exc:
+            log.error("Agent %s failed: %s", name, exc)
+            errors[name] = str(exc)
+            return None
+
+    time_result, meeting_result, code_result, task_result = await asyncio.gather(
+        _safe_run(time_analyst, "time_analyst", time_deps),
+        _safe_run(meeting_analyst, "meeting_analyst", meeting_deps),
+        _safe_run(code_analyst, "code_analyst", code_deps),
+        _safe_run(task_analyst, "task_analyst", task_deps),
+    )
+
+    return GroupAResult(
+        time_analysis=time_result,
+        meeting_analysis=meeting_result,
+        code_analysis=code_result,
+        task_analysis=task_result,
+        errors=errors,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Private data-fetching helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_time_entries(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    analysis_date: date,
+) -> list[TimeEntryData]:
+    """Fetch time entries for the given user on the analysis date."""
+    day_start = datetime.combine(analysis_date, datetime.min.time(), tzinfo=UTC)
+    day_end = day_start + timedelta(days=1)
+
+    stmt = (
+        select(
+            TimeEntry.task_id,
+            Task.title.label("task_title"),
+            Project.name.label("project_name"),
+            TimeEntry.started_at,
+            TimeEntry.ended_at,
+            TimeEntry.duration_seconds,
+        )
+        .join(Task, TimeEntry.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            TimeEntry.started_at >= day_start,
+            TimeEntry.started_at < day_end,
+            TimeEntry.duration_seconds > 0,
+            Project.user_id == user_id,
+        )
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        TimeEntryData(
+            task_id=row.task_id,
+            task_title=row.task_title,
+            project_name=row.project_name,
+            started_at=row.started_at,
+            ended_at=row.ended_at,
+            duration_seconds=row.duration_seconds,
+        )
+        for row in rows
+    ]
+
+
+async def _fetch_schedule_blocks(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    analysis_date: date,
+) -> list[ScheduleBlockData]:
+    """Fetch schedule blocks for the given user on the analysis date."""
+    stmt = (
+        select(
+            ScheduleBlock.task_id,
+            Task.title.label("task_title"),
+            ScheduleBlock.date,
+            ScheduleBlock.start_hour,
+            ScheduleBlock.end_hour,
+            ScheduleBlock.source,
+        )
+        .join(Task, ScheduleBlock.task_id == Task.id)
+        .join(Project, Task.project_id == Project.id)
+        .where(
+            ScheduleBlock.date == analysis_date,
+            Project.user_id == user_id,
+        )
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        ScheduleBlockData(
+            task_id=row.task_id,
+            task_title=row.task_title,
+            date=row.date,
+            start_hour=float(row.start_hour),
+            end_hour=float(row.end_hour),
+            source=row.source.value if hasattr(row.source, "value") else row.source,
+        )
+        for row in rows
+    ]
+
+
+async def _fetch_tasks(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> list[TaskData]:
+    """Fetch all active tasks for the given user."""
+    stmt = (
+        select(
+            Task.id.label("task_id"),
+            Task.title,
+            Project.name.label("project_name"),
+            Task.status,
+            Task.priority,
+            Task.estimate_minutes,
+            Task.due_date,
+            Task.created_at,
+            Task.completed_at,
+        )
+        .join(Project, Task.project_id == Project.id)
+        .where(Project.user_id == user_id)
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        TaskData(
+            task_id=row.task_id,
+            title=row.title,
+            project_name=row.project_name,
+            status=row.status.value if hasattr(row.status, "value") else row.status,
+            priority=row.priority.value if hasattr(row.priority, "value") else row.priority,
+            estimate_minutes=row.estimate_minutes,
+            due_date=row.due_date,
+            created_at=row.created_at,
+            completed_at=row.completed_at,
+        )
+        for row in rows
+    ]
+
+
+async def _fetch_github_sync(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> GitHubSyncData | None:
+    """Fetch the GitHub ExternalSync record for the given user, if it exists."""
+    stmt = select(ExternalSync).where(
+        ExternalSync.user_id == user_id,
+        ExternalSync.provider == SyncProvider.GITHUB,
+    )
+    result = (await db.execute(stmt)).scalar_one_or_none()
+    if result is None:
+        return None
+    return GitHubSyncData(
+        last_synced_at=result.last_synced_at,
+        sync_config=result.sync_config_json or {},
+    )

--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -1,57 +1,45 @@
 """Group A orchestrator — runs four parallel analyst agents via asyncio.gather."""
+
 from __future__ import annotations
 
 import asyncio
 import logging
-import time
 import uuid
-from datetime import UTC, date, datetime, timedelta
-from typing import Any, TypeVar
+from datetime import date
+from typing import Any
 
 from pydantic_ai import Agent
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.agents.base import (
+    fetch_github_sync,
+    fetch_schedule_blocks,
+    fetch_tasks,
+    fetch_time_entries,
+    run_with_metrics,
+)
 from app.agents.code_analyst import code_analyst
 from app.agents.meeting_analyst import meeting_analyst
 from app.agents.schemas import (
     CodeAnalystDeps,
-    GitHubSyncData,
     GroupAResult,
     MeetingAnalystDeps,
-    ScheduleBlockData,
     TaskAnalystDeps,
-    TaskData,
     TimeAnalystDeps,
-    TimeEntryData,
 )
 from app.agents.task_analyst import task_analyst
 from app.agents.time_analyst import time_analyst
-from app.core.metrics import agent_latency_seconds
-from app.models.external_sync import ExternalSync, SyncProvider
-from app.models.project import Project
-from app.models.schedule_block import ScheduleBlock
-from app.models.task import Task
-from app.models.time_entry import TimeEntry
 
 log = logging.getLogger(__name__)
 
-_AgentResultT = TypeVar("_AgentResultT")
-
 
 async def _run_agent(
-    agent: Agent[Any, _AgentResultT],
+    agent: Agent[Any, Any],
     name: str,
     deps: Any,
-) -> _AgentResultT:
-    """Run a single agent, recording latency and propagating errors."""
-    start = time.perf_counter()
-    try:
-        result = await agent.run("Analyze and produce structured insights.", deps=deps)
-        return result.output
-    finally:
-        elapsed = time.perf_counter() - start
-        agent_latency_seconds.labels(agent_name=name).observe(elapsed)
+) -> Any:
+    """Thin wrapper kept for testability — delegates to run_with_metrics."""
+    return await run_with_metrics(agent, name, deps)
 
 
 async def run_group_a(
@@ -70,13 +58,11 @@ async def run_group_a(
         GroupAResult with individual agent outputs and any errors encountered.
     """
     time_entries, schedule_blocks, tasks, github_sync = await asyncio.gather(
-        _fetch_time_entries(db, user_id, analysis_date),
-        _fetch_schedule_blocks(db, user_id, analysis_date),
-        _fetch_tasks(db, user_id),
-        _fetch_github_sync(db, user_id),
+        fetch_time_entries(db, user_id, analysis_date),
+        fetch_schedule_blocks(db, user_id, analysis_date),
+        fetch_tasks(db, user_id),
+        fetch_github_sync(db, user_id),
     )
-
-    calendar_blocks = [b for b in schedule_blocks if b.source == "google_calendar"]
 
     time_deps = TimeAnalystDeps(
         user_id=user_id,
@@ -87,7 +73,7 @@ async def run_group_a(
     meeting_deps = MeetingAnalystDeps(
         user_id=user_id,
         analysis_date=analysis_date,
-        calendar_blocks=calendar_blocks,
+        calendar_blocks=[b for b in schedule_blocks if b.source == "google_calendar"],
     )
     code_deps = CodeAnalystDeps(
         user_id=user_id,
@@ -123,141 +109,4 @@ async def run_group_a(
         code_analysis=code_result,
         task_analysis=task_result,
         errors=errors,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Private data-fetching helpers
-# ---------------------------------------------------------------------------
-
-
-async def _fetch_time_entries(
-    db: AsyncSession,
-    user_id: uuid.UUID,
-    analysis_date: date,
-) -> list[TimeEntryData]:
-    """Fetch time entries for the given user on the analysis date."""
-    day_start = datetime.combine(analysis_date, datetime.min.time(), tzinfo=UTC)
-    day_end = day_start + timedelta(days=1)
-
-    stmt = (
-        select(
-            TimeEntry.task_id,
-            Task.title.label("task_title"),
-            Project.name.label("project_name"),
-            TimeEntry.started_at,
-            TimeEntry.ended_at,
-            TimeEntry.duration_seconds,
-        )
-        .join(Task, TimeEntry.task_id == Task.id)
-        .join(Project, Task.project_id == Project.id)
-        .where(
-            TimeEntry.started_at >= day_start,
-            TimeEntry.started_at < day_end,
-            TimeEntry.duration_seconds > 0,
-            Project.user_id == user_id,
-        )
-    )
-    rows = (await db.execute(stmt)).all()
-    return [
-        TimeEntryData(
-            task_id=row.task_id,
-            task_title=row.task_title,
-            project_name=row.project_name,
-            started_at=row.started_at,
-            ended_at=row.ended_at,
-            duration_seconds=row.duration_seconds,
-        )
-        for row in rows
-    ]
-
-
-async def _fetch_schedule_blocks(
-    db: AsyncSession,
-    user_id: uuid.UUID,
-    analysis_date: date,
-) -> list[ScheduleBlockData]:
-    """Fetch schedule blocks for the given user on the analysis date."""
-    stmt = (
-        select(
-            ScheduleBlock.task_id,
-            Task.title.label("task_title"),
-            ScheduleBlock.date,
-            ScheduleBlock.start_hour,
-            ScheduleBlock.end_hour,
-            ScheduleBlock.source,
-        )
-        .join(Task, ScheduleBlock.task_id == Task.id)
-        .join(Project, Task.project_id == Project.id)
-        .where(
-            ScheduleBlock.date == analysis_date,
-            Project.user_id == user_id,
-        )
-    )
-    rows = (await db.execute(stmt)).all()
-    return [
-        ScheduleBlockData(
-            task_id=row.task_id,
-            task_title=row.task_title,
-            date=row.date,
-            start_hour=float(row.start_hour),
-            end_hour=float(row.end_hour),
-            source=row.source.value if hasattr(row.source, "value") else row.source,
-        )
-        for row in rows
-    ]
-
-
-async def _fetch_tasks(
-    db: AsyncSession,
-    user_id: uuid.UUID,
-) -> list[TaskData]:
-    """Fetch all active tasks for the given user."""
-    stmt = (
-        select(
-            Task.id.label("task_id"),
-            Task.title,
-            Project.name.label("project_name"),
-            Task.status,
-            Task.priority,
-            Task.estimate_minutes,
-            Task.due_date,
-            Task.created_at,
-            Task.completed_at,
-        )
-        .join(Project, Task.project_id == Project.id)
-        .where(Project.user_id == user_id)
-    )
-    rows = (await db.execute(stmt)).all()
-    return [
-        TaskData(
-            task_id=row.task_id,
-            title=row.title,
-            project_name=row.project_name,
-            status=row.status.value if hasattr(row.status, "value") else row.status,
-            priority=row.priority.value if hasattr(row.priority, "value") else row.priority,
-            estimate_minutes=row.estimate_minutes,
-            due_date=row.due_date,
-            created_at=row.created_at,
-            completed_at=row.completed_at,
-        )
-        for row in rows
-    ]
-
-
-async def _fetch_github_sync(
-    db: AsyncSession,
-    user_id: uuid.UUID,
-) -> GitHubSyncData | None:
-    """Fetch the GitHub ExternalSync record for the given user, if it exists."""
-    stmt = select(ExternalSync).where(
-        ExternalSync.user_id == user_id,
-        ExternalSync.provider == SyncProvider.GITHUB,
-    )
-    result = (await db.execute(stmt)).scalar_one_or_none()
-    if result is None:
-        return None
-    return GitHubSyncData(
-        last_synced_at=result.last_synced_at,
-        sync_config=result.sync_config_json or {},
     )

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -59,3 +59,28 @@ class TimeAnalystResult(BaseModel):
     most_active_project: str | None
     avg_session_minutes: float
     insights: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Meeting Analyst
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MeetingAnalystDeps:
+    """Dependencies injected into the Meeting Analyst via RunContext."""
+
+    user_id: uuid.UUID
+    analysis_date: date
+    calendar_blocks: list[ScheduleBlockData] = field(default_factory=list)
+
+
+class MeetingAnalystResult(BaseModel):
+    """Structured output produced by the Meeting Analyst agent."""
+
+    total_meeting_hours: float
+    meeting_count: int
+    avg_meeting_duration_hours: float
+    longest_meeting_hours: float
+    focus_time_hours: float
+    insights: list[str]

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -1,4 +1,5 @@
 """Pydantic schemas for agent deps and result types (Group A parallel analysts)."""
+
 from __future__ import annotations
 
 import uuid
@@ -6,7 +7,6 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 
 from pydantic import BaseModel, Field
-
 
 # ---------------------------------------------------------------------------
 # Shared data transfer objects (pre-fetched from DB before agent calls)

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -1,0 +1,61 @@
+"""Pydantic schemas for agent deps and result types (Group A parallel analysts)."""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import date, datetime
+
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# Shared data transfer objects (pre-fetched from DB before agent calls)
+# ---------------------------------------------------------------------------
+
+
+class TimeEntryData(BaseModel):
+    """A single time entry pre-fetched for the Time Analyst."""
+
+    task_id: uuid.UUID
+    task_title: str
+    project_name: str
+    started_at: datetime
+    ended_at: datetime | None
+    duration_seconds: int
+
+
+class ScheduleBlockData(BaseModel):
+    """A schedule block pre-fetched for Time / Meeting analysts."""
+
+    task_id: uuid.UUID
+    task_title: str
+    date: date
+    start_hour: float
+    end_hour: float
+    source: str  # "manual" | "google_calendar"
+
+
+# ---------------------------------------------------------------------------
+# Time Analyst
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TimeAnalystDeps:
+    """Dependencies injected into the Time Analyst via RunContext."""
+
+    user_id: uuid.UUID
+    analysis_date: date
+    time_entries: list[TimeEntryData] = field(default_factory=list)
+    schedule_blocks: list[ScheduleBlockData] = field(default_factory=list)
+
+
+class TimeAnalystResult(BaseModel):
+    """Structured output produced by the Time Analyst agent."""
+
+    total_tracked_hours: float
+    total_planned_hours: float
+    utilization_pct: float
+    most_active_project: str | None
+    avg_session_minutes: float
+    insights: list[str]

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -5,7 +5,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import date, datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 # ---------------------------------------------------------------------------
@@ -156,3 +156,18 @@ class TaskAnalystResult(BaseModel):
     avg_completion_hours: float | None
     priority_distribution: dict[str, int]
     insights: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Group A aggregate result
+# ---------------------------------------------------------------------------
+
+
+class GroupAResult(BaseModel):
+    """Aggregated output from all four Group A parallel analyst agents."""
+
+    time_analysis: TimeAnalystResult | None = None
+    meeting_analysis: MeetingAnalystResult | None = None
+    code_analysis: CodeAnalystResult | None = None
+    task_analysis: TaskAnalystResult | None = None
+    errors: dict[str, str] = Field(default_factory=dict)

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -84,3 +84,35 @@ class MeetingAnalystResult(BaseModel):
     longest_meeting_hours: float
     focus_time_hours: float
     insights: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Code Analyst
+# ---------------------------------------------------------------------------
+
+
+class GitHubSyncData(BaseModel):
+    """GitHub sync metadata — populated when a GitHub sync record exists."""
+
+    last_synced_at: datetime | None
+    sync_config: dict[str, object]
+
+
+@dataclass
+class CodeAnalystDeps:
+    """Dependencies injected into the Code Analyst via RunContext."""
+
+    user_id: uuid.UUID
+    analysis_date: date
+    github_sync: GitHubSyncData | None = None
+
+
+class CodeAnalystResult(BaseModel):
+    """Structured output produced by the Code Analyst agent."""
+
+    data_available: bool
+    commits_count: int
+    pull_requests_count: int
+    avg_pr_cycle_hours: float | None
+    most_active_repo: str | None
+    insights: list[str]

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -116,3 +116,43 @@ class CodeAnalystResult(BaseModel):
     avg_pr_cycle_hours: float | None
     most_active_repo: str | None
     insights: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Task Analyst
+# ---------------------------------------------------------------------------
+
+
+class TaskData(BaseModel):
+    """A single task pre-fetched for the Task Analyst."""
+
+    task_id: uuid.UUID
+    title: str
+    project_name: str
+    status: str  # "todo" | "in_progress" | "done"
+    priority: str  # "low" | "medium" | "high" | "urgent"
+    estimate_minutes: int | None
+    due_date: date | None
+    created_at: datetime
+    completed_at: datetime | None
+
+
+@dataclass
+class TaskAnalystDeps:
+    """Dependencies injected into the Task Analyst via RunContext."""
+
+    user_id: uuid.UUID
+    analysis_date: date
+    tasks: list[TaskData] = field(default_factory=list)
+
+
+class TaskAnalystResult(BaseModel):
+    """Structured output produced by the Task Analyst agent."""
+
+    total_tasks: int
+    completed_tasks: int
+    completion_rate_pct: float
+    overdue_tasks: int
+    avg_completion_hours: float | None
+    priority_distribution: dict[str, int]
+    insights: list[str]

--- a/backend/app/agents/task_analyst.py
+++ b/backend/app/agents/task_analyst.py
@@ -1,0 +1,65 @@
+"""Task Analyst agent — analyzes Task completion data for task management insights."""
+from __future__ import annotations
+
+from pydantic_ai import Agent, RunContext
+
+from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult
+from app.core.config import settings
+
+task_analyst: Agent[TaskAnalystDeps, TaskAnalystResult] = Agent(
+    model=settings.LLM_MODEL,
+    output_type=TaskAnalystResult,
+    deps_type=TaskAnalystDeps,
+    defer_model_check=True,
+    system_prompt=(
+        "You are a task management analyst. "
+        "Given a list of tasks for a user, produce structured insights about their "
+        "task completion patterns, priority breakdown, and overdue items. "
+        "completion_rate_pct = (completed_tasks / total_tasks * 100) if total_tasks > 0 else 0. "
+        "overdue_tasks = tasks with due_date < analysis_date and status != 'done'. "
+        "All numeric fields must be >= 0. completion_rate_pct must be between 0 and 100. "
+        "Provide 2-4 concise, actionable insights in the insights list."
+    ),
+)
+
+
+@task_analyst.instructions
+async def add_task_context(ctx: RunContext[TaskAnalystDeps]) -> str:
+    """Inject pre-fetched task data into the prompt."""
+    deps = ctx.deps
+    tasks = deps.tasks
+    total = len(tasks)
+    completed = sum(1 for t in tasks if t.status == "done")
+    completion_rate = (completed / total * 100) if total > 0 else 0.0
+
+    overdue = sum(
+        1
+        for t in tasks
+        if t.due_date is not None
+        and t.due_date < deps.analysis_date
+        and t.status != "done"
+    )
+
+    priority_dist: dict[str, int] = {}
+    for t in tasks:
+        priority_dist[t.priority] = priority_dist.get(t.priority, 0) + 1
+
+    completion_times = [
+        (t.completed_at - t.created_at).total_seconds() / 3600.0
+        for t in tasks
+        if t.completed_at is not None
+    ]
+    avg_completion = (
+        sum(completion_times) / len(completion_times) if completion_times else None
+    )
+
+    return (
+        f"Analysis date: {deps.analysis_date}\n"
+        f"Total tasks: {total}\n"
+        f"Completed tasks: {completed}\n"
+        f"Completion rate: {completion_rate:.1f}%\n"
+        f"Overdue tasks: {overdue}\n"
+        f"Average completion time (hours): {avg_completion}\n"
+        f"Priority distribution: {priority_dist}\n"
+        f"Tasks: {[t.model_dump() for t in tasks]}"
+    )

--- a/backend/app/agents/task_analyst.py
+++ b/backend/app/agents/task_analyst.py
@@ -1,4 +1,5 @@
 """Task Analyst agent — analyzes Task completion data for task management insights."""
+
 from __future__ import annotations
 
 from pydantic_ai import Agent, RunContext
@@ -15,9 +16,9 @@ task_analyst: Agent[TaskAnalystDeps, TaskAnalystResult] = Agent(
         "You are a task management analyst. "
         "Given a list of tasks for a user, produce structured insights about their "
         "task completion patterns, priority breakdown, and overdue items. "
-        "completion_rate_pct = (completed_tasks / total_tasks * 100) if total_tasks > 0 else 0. "
+        "completion_rate_pct = (completed / total * 100) if total > 0 else 0. "
         "overdue_tasks = tasks with due_date < analysis_date and status != 'done'. "
-        "All numeric fields must be >= 0. completion_rate_pct must be between 0 and 100. "
+        "All numeric fields must be >= 0. completion_rate_pct between 0 and 100. "
         "Provide 2-4 concise, actionable insights in the insights list."
     ),
 )

--- a/backend/app/agents/time_analyst.py
+++ b/backend/app/agents/time_analyst.py
@@ -1,4 +1,5 @@
 """Time Analyst agent — analyzes TimeEntry data for time utilization insights."""
+
 from __future__ import annotations
 
 from pydantic_ai import Agent, RunContext
@@ -27,14 +28,10 @@ async def add_time_context(ctx: RunContext[TimeAnalystDeps]) -> str:
     deps = ctx.deps
     total_tracked = sum(e.duration_seconds for e in deps.time_entries) / 3600.0
     total_planned = sum(
-        b.end_hour - b.start_hour
-        for b in deps.schedule_blocks
-        if b.source == "manual"
+        b.end_hour - b.start_hour for b in deps.schedule_blocks if b.source == "manual"
     )
     sessions = len(deps.time_entries)
-    avg_session = (
-        (total_tracked * 60 / sessions) if sessions > 0 else 0.0
-    )
+    avg_session = (total_tracked * 60 / sessions) if sessions > 0 else 0.0
 
     projects: dict[str, float] = {}
     for entry in deps.time_entries:

--- a/backend/app/agents/time_analyst.py
+++ b/backend/app/agents/time_analyst.py
@@ -1,0 +1,55 @@
+"""Time Analyst agent — analyzes TimeEntry data for time utilization insights."""
+from __future__ import annotations
+
+from pydantic_ai import Agent, RunContext
+
+from app.agents.schemas import TimeAnalystDeps, TimeAnalystResult
+from app.core.config import settings
+
+time_analyst: Agent[TimeAnalystDeps, TimeAnalystResult] = Agent(
+    model=settings.LLM_MODEL,
+    output_type=TimeAnalystResult,
+    deps_type=TimeAnalystDeps,
+    defer_model_check=True,
+    system_prompt=(
+        "You are a time utilization analyst. "
+        "Given time tracking data for a user's work day, produce structured insights "
+        "about how their time was spent. "
+        "All numeric fields must be >= 0. "
+        "Provide 2-4 concise, actionable insights in the insights list."
+    ),
+)
+
+
+@time_analyst.instructions
+async def add_time_context(ctx: RunContext[TimeAnalystDeps]) -> str:
+    """Inject pre-fetched time entry data into the prompt."""
+    deps = ctx.deps
+    total_tracked = sum(e.duration_seconds for e in deps.time_entries) / 3600.0
+    total_planned = sum(
+        b.end_hour - b.start_hour
+        for b in deps.schedule_blocks
+        if b.source == "manual"
+    )
+    sessions = len(deps.time_entries)
+    avg_session = (
+        (total_tracked * 60 / sessions) if sessions > 0 else 0.0
+    )
+
+    projects: dict[str, float] = {}
+    for entry in deps.time_entries:
+        projects[entry.project_name] = (
+            projects.get(entry.project_name, 0.0) + entry.duration_seconds / 3600.0
+        )
+    most_active = max(projects, key=lambda k: projects[k]) if projects else None
+
+    return (
+        f"Analysis date: {deps.analysis_date}\n"
+        f"Total tracked hours: {total_tracked:.2f}\n"
+        f"Total planned hours: {total_planned:.2f}\n"
+        f"Number of sessions: {sessions}\n"
+        f"Average session length (minutes): {avg_session:.1f}\n"
+        f"Most active project: {most_active or 'none'}\n"
+        f"Time entries: {[e.model_dump() for e in deps.time_entries]}\n"
+        f"Schedule blocks: {[b.model_dump() for b in deps.schedule_blocks]}"
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -40,6 +40,10 @@ class Settings(BaseSettings):
     GITHUB_REDIRECT_URI: str = "http://localhost:5060/auth/github/callback"
     GITHUB_SYNC_REDIRECT_URI: str = "http://localhost:5060/sync/github/callback"
 
+    # AI / LLM (provider-agnostic pydantic-ai model strings)
+    LLM_MODEL: str = "openai:gpt-4o-mini"
+    LLM_JUDGE_MODEL: str = "google-gla:gemini-1.5-flash"
+
     # Monitoring (optional — silently disabled when absent)
     SENTRY_DSN: str | None = None
     PROMETHEUS_ENABLED: bool = True

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "redis>=5.0.0",
     "prometheus-fastapi-instrumentator>=7.0.0",
     "prometheus-client>=0.20.0",
+    "pydantic-ai>=0.0.20",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/unit/agents/test_code_analyst.py
+++ b/backend/tests/unit/agents/test_code_analyst.py
@@ -6,11 +6,11 @@ from datetime import UTC, date, datetime
 import pytest
 from pydantic_ai.models.test import TestModel
 
+from app.agents.schemas import GitHubSyncData
+
 
 @pytest.fixture
-def sample_github_sync():
-    from app.agents.schemas import GitHubSyncData
-
+def sample_github_sync() -> GitHubSyncData:
     return GitHubSyncData(
         last_synced_at=datetime(2026, 4, 14, 8, 0, tzinfo=UTC),
         sync_config={"repo_count": 3, "most_active_repo": "FlowDay"},
@@ -18,7 +18,9 @@ def sample_github_sync():
 
 
 @pytest.mark.asyncio
-async def test_code_analyst_result_conforms_to_schema(sample_github_sync):
+async def test_code_analyst_result_conforms_to_schema(
+    sample_github_sync: GitHubSyncData,
+) -> None:
     """Agent with TestModel returns a valid CodeAnalystResult schema."""
     from app.agents.code_analyst import code_analyst
     from app.agents.schemas import CodeAnalystDeps, CodeAnalystResult
@@ -41,7 +43,7 @@ async def test_code_analyst_result_conforms_to_schema(sample_github_sync):
 
 
 @pytest.mark.asyncio
-async def test_code_analyst_no_github_sync():
+async def test_code_analyst_no_github_sync() -> None:
     """Agent returns data_available=False when github_sync is None."""
     from app.agents.code_analyst import code_analyst
     from app.agents.schemas import CodeAnalystDeps, CodeAnalystResult

--- a/backend/tests/unit/agents/test_code_analyst.py
+++ b/backend/tests/unit/agents/test_code_analyst.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+
+import pytest
+from pydantic_ai.models.test import TestModel
+
+
+@pytest.fixture
+def sample_github_sync():
+    from app.agents.schemas import GitHubSyncData
+
+    return GitHubSyncData(
+        last_synced_at=datetime(2026, 4, 14, 8, 0, tzinfo=timezone.utc),
+        sync_config={"repo_count": 3, "most_active_repo": "FlowDay"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_code_analyst_result_conforms_to_schema(sample_github_sync):
+    """Agent with TestModel returns a valid CodeAnalystResult schema."""
+    from app.agents.code_analyst import code_analyst
+    from app.agents.schemas import CodeAnalystDeps, CodeAnalystResult
+
+    deps = CodeAnalystDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        github_sync=sample_github_sync,
+    )
+
+    with code_analyst.override(model=TestModel()):
+        result = await code_analyst.run("Analyze code activity", deps=deps)
+
+    output = result.output
+    assert isinstance(output, CodeAnalystResult)
+    assert isinstance(output.data_available, bool)
+    assert output.commits_count >= 0
+    assert output.pull_requests_count >= 0
+    assert isinstance(output.insights, list)
+
+
+@pytest.mark.asyncio
+async def test_code_analyst_no_github_sync():
+    """Agent returns data_available=False when github_sync is None."""
+    from app.agents.code_analyst import code_analyst
+    from app.agents.schemas import CodeAnalystDeps, CodeAnalystResult
+
+    deps = CodeAnalystDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        github_sync=None,
+    )
+
+    with code_analyst.override(model=TestModel()):
+        result = await code_analyst.run("Analyze code activity", deps=deps)
+
+    output = result.output
+    assert isinstance(output, CodeAnalystResult)
+    assert output.data_available is False

--- a/backend/tests/unit/agents/test_code_analyst.py
+++ b/backend/tests/unit/agents/test_code_analyst.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 
 import pytest
 from pydantic_ai.models.test import TestModel
@@ -12,7 +12,7 @@ def sample_github_sync():
     from app.agents.schemas import GitHubSyncData
 
     return GitHubSyncData(
-        last_synced_at=datetime(2026, 4, 14, 8, 0, tzinfo=timezone.utc),
+        last_synced_at=datetime(2026, 4, 14, 8, 0, tzinfo=UTC),
         sync_config={"repo_count": 3, "most_active_repo": "FlowDay"},
     )
 

--- a/backend/tests/unit/agents/test_meeting_analyst.py
+++ b/backend/tests/unit/agents/test_meeting_analyst.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+from pydantic_ai.models.test import TestModel
+
+
+@pytest.fixture
+def sample_calendar_blocks() -> list:
+    from app.agents.schemas import ScheduleBlockData
+
+    return [
+        ScheduleBlockData(
+            task_id=uuid.uuid4(),
+            task_title="Team standup",
+            date=date(2026, 4, 14),
+            start_hour=9.0,
+            end_hour=9.5,
+            source="google_calendar",
+        ),
+        ScheduleBlockData(
+            task_id=uuid.uuid4(),
+            task_title="Sprint planning",
+            date=date(2026, 4, 14),
+            start_hour=10.0,
+            end_hour=12.0,
+            source="google_calendar",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_meeting_analyst_result_conforms_to_schema(sample_calendar_blocks):
+    """Agent with TestModel returns a valid MeetingAnalystResult schema."""
+    from app.agents.meeting_analyst import meeting_analyst
+    from app.agents.schemas import MeetingAnalystDeps, MeetingAnalystResult
+
+    deps = MeetingAnalystDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        calendar_blocks=sample_calendar_blocks,
+    )
+
+    with meeting_analyst.override(model=TestModel()):
+        result = await meeting_analyst.run("Analyze meetings", deps=deps)
+
+    output = result.output
+    assert isinstance(output, MeetingAnalystResult)
+    assert output.total_meeting_hours >= 0
+    assert output.meeting_count >= 0
+    assert output.avg_meeting_duration_hours >= 0
+    assert output.longest_meeting_hours >= 0
+    assert output.focus_time_hours >= 0
+    assert isinstance(output.insights, list)
+
+
+@pytest.mark.asyncio
+async def test_meeting_analyst_no_calendar_blocks():
+    """Agent handles empty calendar blocks without error."""
+    from app.agents.meeting_analyst import meeting_analyst
+    from app.agents.schemas import MeetingAnalystDeps, MeetingAnalystResult
+
+    deps = MeetingAnalystDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        calendar_blocks=[],
+    )
+
+    with meeting_analyst.override(model=TestModel()):
+        result = await meeting_analyst.run("Analyze meetings", deps=deps)
+
+    output = result.output
+    assert isinstance(output, MeetingAnalystResult)
+    assert output.total_meeting_hours >= 0
+    assert isinstance(output.insights, list)

--- a/backend/tests/unit/agents/test_meeting_analyst.py
+++ b/backend/tests/unit/agents/test_meeting_analyst.py
@@ -6,11 +6,11 @@ from datetime import date
 import pytest
 from pydantic_ai.models.test import TestModel
 
+from app.agents.schemas import ScheduleBlockData
+
 
 @pytest.fixture
-def sample_calendar_blocks() -> list:
-    from app.agents.schemas import ScheduleBlockData
-
+def sample_calendar_blocks() -> list[ScheduleBlockData]:
     return [
         ScheduleBlockData(
             task_id=uuid.uuid4(),
@@ -32,7 +32,9 @@ def sample_calendar_blocks() -> list:
 
 
 @pytest.mark.asyncio
-async def test_meeting_analyst_result_conforms_to_schema(sample_calendar_blocks):
+async def test_meeting_analyst_result_conforms_to_schema(
+    sample_calendar_blocks: list[ScheduleBlockData],
+) -> None:
     """Agent with TestModel returns a valid MeetingAnalystResult schema."""
     from app.agents.meeting_analyst import meeting_analyst
     from app.agents.schemas import MeetingAnalystDeps, MeetingAnalystResult
@@ -57,7 +59,7 @@ async def test_meeting_analyst_result_conforms_to_schema(sample_calendar_blocks)
 
 
 @pytest.mark.asyncio
-async def test_meeting_analyst_no_calendar_blocks():
+async def test_meeting_analyst_no_calendar_blocks() -> None:
     """Agent handles empty calendar blocks without error."""
     from app.agents.meeting_analyst import meeting_analyst
     from app.agents.schemas import MeetingAnalystDeps, MeetingAnalystResult

--- a/backend/tests/unit/agents/test_orchestrator.py
+++ b/backend/tests/unit/agents/test_orchestrator.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai.models.test import TestModel
+
+
+@pytest.fixture
+def user_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def analysis_date() -> date:
+    return date(2026, 4, 14)
+
+
+@pytest.fixture
+def mock_db():
+    """AsyncSession mock with empty query results."""
+    db = AsyncMock()
+    empty_result = MagicMock()
+    empty_result.all.return_value = []
+    empty_result.scalars.return_value.all.return_value = []
+    empty_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = empty_result
+    return db
+
+
+@pytest.mark.asyncio
+async def test_run_group_a_returns_all_four_results(
+    mock_db, user_id, analysis_date
+):
+    """run_group_a returns GroupAResult with all four analyst outputs."""
+    from app.agents.orchestrator import run_group_a
+    from app.agents.schemas import GroupAResult
+
+    from app.agents import time_analyst as ta_mod
+    from app.agents import meeting_analyst as ma_mod
+    from app.agents import code_analyst as ca_mod
+    from app.agents import task_analyst as tk_mod
+
+    with (
+        ta_mod.time_analyst.override(model=TestModel()),
+        ma_mod.meeting_analyst.override(model=TestModel()),
+        ca_mod.code_analyst.override(model=TestModel()),
+        tk_mod.task_analyst.override(model=TestModel()),
+    ):
+        result = await run_group_a(mock_db, user_id, analysis_date)
+
+    assert isinstance(result, GroupAResult)
+    assert result.time_analysis is not None
+    assert result.meeting_analysis is not None
+    assert result.code_analysis is not None
+    assert result.task_analysis is not None
+    assert result.errors == {}
+
+
+@pytest.mark.asyncio
+async def test_run_group_a_isolates_single_agent_failure(
+    mock_db, user_id, analysis_date
+):
+    """A single agent failure does not prevent the other three from succeeding."""
+    from app.agents.orchestrator import run_group_a
+    from app.agents.schemas import GroupAResult
+
+    from app.agents import time_analyst as ta_mod
+    from app.agents import meeting_analyst as ma_mod
+    from app.agents import code_analyst as ca_mod
+    from app.agents import task_analyst as tk_mod
+
+    # Make time_analyst raise, others succeed via TestModel
+    with (
+        ta_mod.time_analyst.override(model=TestModel(call_tools=["final_result"])),
+        ma_mod.meeting_analyst.override(model=TestModel()),
+        ca_mod.code_analyst.override(model=TestModel()),
+        tk_mod.task_analyst.override(model=TestModel()),
+    ):
+        with patch(
+            "app.agents.orchestrator._run_agent",
+            wraps=_failing_time_analyst_wrapper,
+        ):
+            result = await run_group_a(mock_db, user_id, analysis_date)
+
+    assert isinstance(result, GroupAResult)
+    # Other three should succeed
+    assert result.meeting_analysis is not None
+    assert result.code_analysis is not None
+    assert result.task_analysis is not None
+    # Time analyst failed
+    assert result.time_analysis is None
+    assert "time_analyst" in result.errors
+
+
+@pytest.mark.asyncio
+async def test_run_group_a_records_latency_metrics(
+    mock_db, user_id, analysis_date
+):
+    """run_group_a observes agent_latency_seconds for each agent."""
+    from app.agents.orchestrator import run_group_a
+
+    from app.agents import time_analyst as ta_mod
+    from app.agents import meeting_analyst as ma_mod
+    from app.agents import code_analyst as ca_mod
+    from app.agents import task_analyst as tk_mod
+
+    from app.core.metrics import agent_latency_seconds
+
+    with (
+        ta_mod.time_analyst.override(model=TestModel()),
+        ma_mod.meeting_analyst.override(model=TestModel()),
+        ca_mod.code_analyst.override(model=TestModel()),
+        tk_mod.task_analyst.override(model=TestModel()),
+        patch.object(
+            agent_latency_seconds, "labels", wraps=agent_latency_seconds.labels
+        ) as mock_labels,
+    ):
+        await run_group_a(mock_db, user_id, analysis_date)
+
+    assert mock_labels.call_count == 4
+    called_agent_names = {
+        call.kwargs.get("agent_name") or call.args[0]
+        for call in mock_labels.call_args_list
+    }
+    assert called_agent_names == {
+        "time_analyst",
+        "meeting_analyst",
+        "code_analyst",
+        "task_analyst",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers for failure isolation test
+# ---------------------------------------------------------------------------
+
+_call_count = 0
+
+
+async def _failing_time_analyst_wrapper(agent, name, deps):
+    """Simulate time_analyst failing, others succeeding normally."""
+    global _call_count
+    _call_count += 1
+    if name == "time_analyst":
+        raise RuntimeError("Simulated time_analyst failure")
+    # Delegate to real _run_agent logic for others
+    from app.agents.orchestrator import _run_agent
+
+    return await _run_agent(agent, name, deps)

--- a/backend/tests/unit/agents/test_orchestrator.py
+++ b/backend/tests/unit/agents/test_orchestrator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date, datetime, timezone
+from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -31,17 +31,14 @@ def mock_db():
 
 
 @pytest.mark.asyncio
-async def test_run_group_a_returns_all_four_results(
-    mock_db, user_id, analysis_date
-):
+async def test_run_group_a_returns_all_four_results(mock_db, user_id, analysis_date):
     """run_group_a returns GroupAResult with all four analyst outputs."""
+    from app.agents import code_analyst as ca_mod
+    from app.agents import meeting_analyst as ma_mod
+    from app.agents import task_analyst as tk_mod
+    from app.agents import time_analyst as ta_mod
     from app.agents.orchestrator import run_group_a
     from app.agents.schemas import GroupAResult
-
-    from app.agents import time_analyst as ta_mod
-    from app.agents import meeting_analyst as ma_mod
-    from app.agents import code_analyst as ca_mod
-    from app.agents import task_analyst as tk_mod
 
     with (
         ta_mod.time_analyst.override(model=TestModel()),
@@ -65,12 +62,11 @@ async def test_run_group_a_isolates_single_agent_failure(
 ):
     """A single agent failure does not prevent the other three from succeeding."""
     import app.agents.orchestrator as orch_mod
+    from app.agents import code_analyst as ca_mod
+    from app.agents import meeting_analyst as ma_mod
+    from app.agents import task_analyst as tk_mod
     from app.agents.orchestrator import run_group_a
     from app.agents.schemas import GroupAResult
-
-    from app.agents import meeting_analyst as ma_mod
-    from app.agents import code_analyst as ca_mod
-    from app.agents import task_analyst as tk_mod
 
     # Capture real _run_agent before patching to avoid recursion
     real_run_agent = orch_mod._run_agent
@@ -97,17 +93,13 @@ async def test_run_group_a_isolates_single_agent_failure(
 
 
 @pytest.mark.asyncio
-async def test_run_group_a_records_latency_metrics(
-    mock_db, user_id, analysis_date
-):
+async def test_run_group_a_records_latency_metrics(mock_db, user_id, analysis_date):
     """run_group_a observes agent_latency_seconds for each agent."""
-    from app.agents.orchestrator import run_group_a
-
-    from app.agents import time_analyst as ta_mod
-    from app.agents import meeting_analyst as ma_mod
     from app.agents import code_analyst as ca_mod
+    from app.agents import meeting_analyst as ma_mod
     from app.agents import task_analyst as tk_mod
-
+    from app.agents import time_analyst as ta_mod
+    from app.agents.orchestrator import run_group_a
     from app.core.metrics import agent_latency_seconds
 
     with (
@@ -132,5 +124,3 @@ async def test_run_group_a_records_latency_metrics(
         "code_analyst",
         "task_analyst",
     }
-
-

--- a/backend/tests/unit/agents/test_orchestrator.py
+++ b/backend/tests/unit/agents/test_orchestrator.py
@@ -64,33 +64,34 @@ async def test_run_group_a_isolates_single_agent_failure(
     mock_db, user_id, analysis_date
 ):
     """A single agent failure does not prevent the other three from succeeding."""
+    import app.agents.orchestrator as orch_mod
     from app.agents.orchestrator import run_group_a
     from app.agents.schemas import GroupAResult
 
-    from app.agents import time_analyst as ta_mod
     from app.agents import meeting_analyst as ma_mod
     from app.agents import code_analyst as ca_mod
     from app.agents import task_analyst as tk_mod
 
-    # Make time_analyst raise, others succeed via TestModel
+    # Capture real _run_agent before patching to avoid recursion
+    real_run_agent = orch_mod._run_agent
+
+    async def selective_failure(agent, name, deps):
+        if name == "time_analyst":
+            raise RuntimeError("Simulated time_analyst failure")
+        return await real_run_agent(agent, name, deps)
+
     with (
-        ta_mod.time_analyst.override(model=TestModel(call_tools=["final_result"])),
         ma_mod.meeting_analyst.override(model=TestModel()),
         ca_mod.code_analyst.override(model=TestModel()),
         tk_mod.task_analyst.override(model=TestModel()),
+        patch("app.agents.orchestrator._run_agent", side_effect=selective_failure),
     ):
-        with patch(
-            "app.agents.orchestrator._run_agent",
-            wraps=_failing_time_analyst_wrapper,
-        ):
-            result = await run_group_a(mock_db, user_id, analysis_date)
+        result = await run_group_a(mock_db, user_id, analysis_date)
 
     assert isinstance(result, GroupAResult)
-    # Other three should succeed
     assert result.meeting_analysis is not None
     assert result.code_analysis is not None
     assert result.task_analysis is not None
-    # Time analyst failed
     assert result.time_analysis is None
     assert "time_analyst" in result.errors
 
@@ -133,20 +134,3 @@ async def test_run_group_a_records_latency_metrics(
     }
 
 
-# ---------------------------------------------------------------------------
-# Helpers for failure isolation test
-# ---------------------------------------------------------------------------
-
-_call_count = 0
-
-
-async def _failing_time_analyst_wrapper(agent, name, deps):
-    """Simulate time_analyst failing, others succeeding normally."""
-    global _call_count
-    _call_count += 1
-    if name == "time_analyst":
-        raise RuntimeError("Simulated time_analyst failure")
-    # Delegate to real _run_agent logic for others
-    from app.agents.orchestrator import _run_agent
-
-    return await _run_agent(agent, name, deps)

--- a/backend/tests/unit/agents/test_orchestrator.py
+++ b/backend/tests/unit/agents/test_orchestrator.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import uuid
 from datetime import date
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic_ai import Agent
 from pydantic_ai.models.test import TestModel
 
 
@@ -19,7 +21,7 @@ def analysis_date() -> date:
 
 
 @pytest.fixture
-def mock_db():
+def mock_db() -> AsyncMock:
     """AsyncSession mock with empty query results."""
     db = AsyncMock()
     empty_result = MagicMock()
@@ -31,7 +33,9 @@ def mock_db():
 
 
 @pytest.mark.asyncio
-async def test_run_group_a_returns_all_four_results(mock_db, user_id, analysis_date):
+async def test_run_group_a_returns_all_four_results(
+    mock_db: AsyncMock, user_id: uuid.UUID, analysis_date: date
+) -> None:
     """run_group_a returns GroupAResult with all four analyst outputs."""
     from app.agents import code_analyst as ca_mod
     from app.agents import meeting_analyst as ma_mod
@@ -58,8 +62,8 @@ async def test_run_group_a_returns_all_four_results(mock_db, user_id, analysis_d
 
 @pytest.mark.asyncio
 async def test_run_group_a_isolates_single_agent_failure(
-    mock_db, user_id, analysis_date
-):
+    mock_db: AsyncMock, user_id: uuid.UUID, analysis_date: date
+) -> None:
     """A single agent failure does not prevent the other three from succeeding."""
     import app.agents.orchestrator as orch_mod
     from app.agents import code_analyst as ca_mod
@@ -71,7 +75,7 @@ async def test_run_group_a_isolates_single_agent_failure(
     # Capture real _run_agent before patching to avoid recursion
     real_run_agent = orch_mod._run_agent
 
-    async def selective_failure(agent, name, deps):
+    async def selective_failure(agent: Agent[Any, Any], name: str, deps: Any) -> Any:
         if name == "time_analyst":
             raise RuntimeError("Simulated time_analyst failure")
         return await real_run_agent(agent, name, deps)
@@ -93,7 +97,9 @@ async def test_run_group_a_isolates_single_agent_failure(
 
 
 @pytest.mark.asyncio
-async def test_run_group_a_records_latency_metrics(mock_db, user_id, analysis_date):
+async def test_run_group_a_records_latency_metrics(
+    mock_db: AsyncMock, user_id: uuid.UUID, analysis_date: date
+) -> None:
     """run_group_a observes agent_latency_seconds for each agent."""
     from app.agents import code_analyst as ca_mod
     from app.agents import meeting_analyst as ma_mod

--- a/backend/tests/unit/agents/test_task_analyst.py
+++ b/backend/tests/unit/agents/test_task_analyst.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 
 import pytest
 from pydantic_ai.models.test import TestModel
@@ -11,7 +11,7 @@ from pydantic_ai.models.test import TestModel
 def sample_tasks() -> list:
     from app.agents.schemas import TaskData
 
-    now = datetime(2026, 4, 14, 10, 0, tzinfo=timezone.utc)
+    now = datetime(2026, 4, 14, 10, 0, tzinfo=UTC)
     return [
         TaskData(
             task_id=uuid.uuid4(),
@@ -21,7 +21,7 @@ def sample_tasks() -> list:
             priority="high",
             estimate_minutes=60,
             due_date=date(2026, 4, 14),
-            created_at=datetime(2026, 4, 13, 9, 0, tzinfo=timezone.utc),
+            created_at=datetime(2026, 4, 13, 9, 0, tzinfo=UTC),
             completed_at=now,
         ),
         TaskData(
@@ -32,7 +32,7 @@ def sample_tasks() -> list:
             priority="high",
             estimate_minutes=120,
             due_date=date(2026, 4, 13),  # overdue
-            created_at=datetime(2026, 4, 12, 9, 0, tzinfo=timezone.utc),
+            created_at=datetime(2026, 4, 12, 9, 0, tzinfo=UTC),
             completed_at=None,
         ),
         TaskData(
@@ -43,7 +43,7 @@ def sample_tasks() -> list:
             priority="medium",
             estimate_minutes=30,
             due_date=None,
-            created_at=datetime(2026, 4, 14, 8, 0, tzinfo=timezone.utc),
+            created_at=datetime(2026, 4, 14, 8, 0, tzinfo=UTC),
             completed_at=None,
         ),
     ]
@@ -77,10 +77,8 @@ async def test_task_analyst_result_conforms_to_schema(sample_tasks):
 @pytest.mark.asyncio
 async def test_task_analyst_no_completed_tasks():
     """Completion rate is 0 when all tasks are in todo state."""
-    from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult
+    from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult, TaskData
     from app.agents.task_analyst import task_analyst
-
-    from app.agents.schemas import TaskData
 
     tasks = [
         TaskData(
@@ -91,7 +89,7 @@ async def test_task_analyst_no_completed_tasks():
             priority="low",
             estimate_minutes=None,
             due_date=None,
-            created_at=datetime(2026, 4, 14, 8, 0, tzinfo=timezone.utc),
+            created_at=datetime(2026, 4, 14, 8, 0, tzinfo=UTC),
             completed_at=None,
         )
     ]

--- a/backend/tests/unit/agents/test_task_analyst.py
+++ b/backend/tests/unit/agents/test_task_analyst.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+
+import pytest
+from pydantic_ai.models.test import TestModel
+
+
+@pytest.fixture
+def sample_tasks() -> list:
+    from app.agents.schemas import TaskData
+
+    now = datetime(2026, 4, 14, 10, 0, tzinfo=timezone.utc)
+    return [
+        TaskData(
+            task_id=uuid.uuid4(),
+            title="Write unit tests",
+            project_name="FlowDay",
+            status="done",
+            priority="high",
+            estimate_minutes=60,
+            due_date=date(2026, 4, 14),
+            created_at=datetime(2026, 4, 13, 9, 0, tzinfo=timezone.utc),
+            completed_at=now,
+        ),
+        TaskData(
+            task_id=uuid.uuid4(),
+            title="Implement agents",
+            project_name="FlowDay",
+            status="in_progress",
+            priority="high",
+            estimate_minutes=120,
+            due_date=date(2026, 4, 13),  # overdue
+            created_at=datetime(2026, 4, 12, 9, 0, tzinfo=timezone.utc),
+            completed_at=None,
+        ),
+        TaskData(
+            task_id=uuid.uuid4(),
+            title="Update docs",
+            project_name="FlowDay",
+            status="todo",
+            priority="medium",
+            estimate_minutes=30,
+            due_date=None,
+            created_at=datetime(2026, 4, 14, 8, 0, tzinfo=timezone.utc),
+            completed_at=None,
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_task_analyst_result_conforms_to_schema(sample_tasks):
+    """Agent with TestModel returns a valid TaskAnalystResult schema."""
+    from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult
+    from app.agents.task_analyst import task_analyst
+
+    deps = TaskAnalystDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        tasks=sample_tasks,
+    )
+
+    with task_analyst.override(model=TestModel()):
+        result = await task_analyst.run("Analyze tasks", deps=deps)
+
+    output = result.output
+    assert isinstance(output, TaskAnalystResult)
+    assert output.total_tasks >= 0
+    assert output.completed_tasks >= 0
+    assert 0.0 <= output.completion_rate_pct <= 100.0
+    assert output.overdue_tasks >= 0
+    assert isinstance(output.priority_distribution, dict)
+    assert isinstance(output.insights, list)
+
+
+@pytest.mark.asyncio
+async def test_task_analyst_no_completed_tasks():
+    """Completion rate is 0 when all tasks are in todo state."""
+    from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult
+    from app.agents.task_analyst import task_analyst
+
+    from app.agents.schemas import TaskData
+
+    tasks = [
+        TaskData(
+            task_id=uuid.uuid4(),
+            title="Todo item",
+            project_name="FlowDay",
+            status="todo",
+            priority="low",
+            estimate_minutes=None,
+            due_date=None,
+            created_at=datetime(2026, 4, 14, 8, 0, tzinfo=timezone.utc),
+            completed_at=None,
+        )
+    ]
+
+    deps = TaskAnalystDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        tasks=tasks,
+    )
+
+    with task_analyst.override(model=TestModel()):
+        result = await task_analyst.run("Analyze tasks", deps=deps)
+
+    output = result.output
+    assert isinstance(output, TaskAnalystResult)
+    # TestModel returns 0 for int fields and 0.0 for float fields
+    assert output.completion_rate_pct >= 0.0

--- a/backend/tests/unit/agents/test_task_analyst.py
+++ b/backend/tests/unit/agents/test_task_analyst.py
@@ -6,11 +6,11 @@ from datetime import UTC, date, datetime
 import pytest
 from pydantic_ai.models.test import TestModel
 
+from app.agents.schemas import TaskData
+
 
 @pytest.fixture
-def sample_tasks() -> list:
-    from app.agents.schemas import TaskData
-
+def sample_tasks() -> list[TaskData]:
     now = datetime(2026, 4, 14, 10, 0, tzinfo=UTC)
     return [
         TaskData(
@@ -50,7 +50,9 @@ def sample_tasks() -> list:
 
 
 @pytest.mark.asyncio
-async def test_task_analyst_result_conforms_to_schema(sample_tasks):
+async def test_task_analyst_result_conforms_to_schema(
+    sample_tasks: list[TaskData],
+) -> None:
     """Agent with TestModel returns a valid TaskAnalystResult schema."""
     from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult
     from app.agents.task_analyst import task_analyst
@@ -75,9 +77,9 @@ async def test_task_analyst_result_conforms_to_schema(sample_tasks):
 
 
 @pytest.mark.asyncio
-async def test_task_analyst_no_completed_tasks():
+async def test_task_analyst_no_completed_tasks() -> None:
     """Completion rate is 0 when all tasks are in todo state."""
-    from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult, TaskData
+    from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult
     from app.agents.task_analyst import task_analyst
 
     tasks = [

--- a/backend/tests/unit/agents/test_time_analyst.py
+++ b/backend/tests/unit/agents/test_time_analyst.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+
+import pytest
+from pydantic_ai.models.test import TestModel
+
+
+@pytest.fixture
+def sample_time_entries() -> list:
+    from app.agents.schemas import TimeEntryData
+
+    task_id = uuid.uuid4()
+    return [
+        TimeEntryData(
+            task_id=task_id,
+            task_title="Write tests",
+            project_name="FlowDay",
+            started_at=datetime(2026, 4, 14, 9, 0, tzinfo=timezone.utc),
+            ended_at=datetime(2026, 4, 14, 11, 0, tzinfo=timezone.utc),
+            duration_seconds=7200,
+        ),
+        TimeEntryData(
+            task_id=task_id,
+            task_title="Write tests",
+            project_name="FlowDay",
+            started_at=datetime(2026, 4, 14, 13, 0, tzinfo=timezone.utc),
+            ended_at=datetime(2026, 4, 14, 14, 0, tzinfo=timezone.utc),
+            duration_seconds=3600,
+        ),
+    ]
+
+
+@pytest.fixture
+def sample_schedule_blocks() -> list:
+    from app.agents.schemas import ScheduleBlockData
+
+    return [
+        ScheduleBlockData(
+            task_id=uuid.uuid4(),
+            task_title="Write tests",
+            date=date(2026, 4, 14),
+            start_hour=9.0,
+            end_hour=12.0,
+            source="manual",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_time_analyst_result_conforms_to_schema(
+    sample_time_entries, sample_schedule_blocks
+):
+    """Agent with TestModel returns a valid TimeAnalystResult schema."""
+    from app.agents.schemas import TimeAnalystDeps, TimeAnalystResult
+    from app.agents.time_analyst import time_analyst
+
+    deps = TimeAnalystDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        time_entries=sample_time_entries,
+        schedule_blocks=sample_schedule_blocks,
+    )
+
+    with time_analyst.override(model=TestModel()):
+        result = await time_analyst.run("Analyze time usage", deps=deps)
+
+    output = result.output
+    assert isinstance(output, TimeAnalystResult)
+    assert output.total_tracked_hours >= 0
+    assert output.total_planned_hours >= 0
+    assert output.utilization_pct >= 0
+    assert isinstance(output.insights, list)
+    assert isinstance(output.avg_session_minutes, float)
+
+
+@pytest.mark.asyncio
+async def test_time_analyst_empty_time_entries():
+    """Agent handles empty time entries without error."""
+    from app.agents.schemas import TimeAnalystDeps, TimeAnalystResult
+    from app.agents.time_analyst import time_analyst
+
+    deps = TimeAnalystDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        time_entries=[],
+        schedule_blocks=[],
+    )
+
+    with time_analyst.override(model=TestModel()):
+        result = await time_analyst.run("Analyze time usage", deps=deps)
+
+    output = result.output
+    assert isinstance(output, TimeAnalystResult)
+    assert output.total_tracked_hours >= 0
+    assert isinstance(output.insights, list)

--- a/backend/tests/unit/agents/test_time_analyst.py
+++ b/backend/tests/unit/agents/test_time_analyst.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 
 import pytest
 from pydantic_ai.models.test import TestModel
@@ -17,16 +17,16 @@ def sample_time_entries() -> list:
             task_id=task_id,
             task_title="Write tests",
             project_name="FlowDay",
-            started_at=datetime(2026, 4, 14, 9, 0, tzinfo=timezone.utc),
-            ended_at=datetime(2026, 4, 14, 11, 0, tzinfo=timezone.utc),
+            started_at=datetime(2026, 4, 14, 9, 0, tzinfo=UTC),
+            ended_at=datetime(2026, 4, 14, 11, 0, tzinfo=UTC),
             duration_seconds=7200,
         ),
         TimeEntryData(
             task_id=task_id,
             task_title="Write tests",
             project_name="FlowDay",
-            started_at=datetime(2026, 4, 14, 13, 0, tzinfo=timezone.utc),
-            ended_at=datetime(2026, 4, 14, 14, 0, tzinfo=timezone.utc),
+            started_at=datetime(2026, 4, 14, 13, 0, tzinfo=UTC),
+            ended_at=datetime(2026, 4, 14, 14, 0, tzinfo=UTC),
             duration_seconds=3600,
         ),
     ]

--- a/backend/tests/unit/agents/test_time_analyst.py
+++ b/backend/tests/unit/agents/test_time_analyst.py
@@ -6,11 +6,11 @@ from datetime import UTC, date, datetime
 import pytest
 from pydantic_ai.models.test import TestModel
 
+from app.agents.schemas import ScheduleBlockData, TimeEntryData
+
 
 @pytest.fixture
-def sample_time_entries() -> list:
-    from app.agents.schemas import TimeEntryData
-
+def sample_time_entries() -> list[TimeEntryData]:
     task_id = uuid.uuid4()
     return [
         TimeEntryData(
@@ -33,9 +33,7 @@ def sample_time_entries() -> list:
 
 
 @pytest.fixture
-def sample_schedule_blocks() -> list:
-    from app.agents.schemas import ScheduleBlockData
-
+def sample_schedule_blocks() -> list[ScheduleBlockData]:
     return [
         ScheduleBlockData(
             task_id=uuid.uuid4(),
@@ -50,8 +48,9 @@ def sample_schedule_blocks() -> list:
 
 @pytest.mark.asyncio
 async def test_time_analyst_result_conforms_to_schema(
-    sample_time_entries, sample_schedule_blocks
-):
+    sample_time_entries: list[TimeEntryData],
+    sample_schedule_blocks: list[ScheduleBlockData],
+) -> None:
     """Agent with TestModel returns a valid TimeAnalystResult schema."""
     from app.agents.schemas import TimeAnalystDeps, TimeAnalystResult
     from app.agents.time_analyst import time_analyst
@@ -76,7 +75,7 @@ async def test_time_analyst_result_conforms_to_schema(
 
 
 @pytest.mark.asyncio
-async def test_time_analyst_empty_time_entries():
+async def test_time_analyst_empty_time_entries() -> None:
     """Agent handles empty time entries without error."""
     from app.agents.schemas import TimeAnalystDeps, TimeAnalystResult
     from app.agents.time_analyst import time_analyst


### PR DESCRIPTION
## Summary

Implements the four parallel Group A analyst agents using Pydantic AI (issue #28).

- **Time Analyst** — analyzes `TimeEntry` data, produces `TimeAnalystResult` with utilization metrics and insights
- **Meeting Analyst** — analyzes Google Calendar `ScheduleBlock` data (source=`google_calendar`), produces `MeetingAnalystResult` with meeting load metrics
- **Code Analyst** — analyzes GitHub sync metadata, produces `CodeAnalystResult` (graceful `data_available: false` when GitHub not connected)
- **Task Analyst** — analyzes `Task` completion data, produces `TaskAnalystResult` with completion rate, overdue count, and priority distribution
- **Orchestrator** (`run_group_a`) — runs all four agents concurrently via `asyncio.gather` with per-agent error isolation and Prometheus `agent_latency_seconds` instrumentation

## Architecture

- Each agent uses Pydantic AI 1.x API: `output_type`, `deps_type`, `defer_model_check=True`, `@agent.instructions` for dynamic context
- Pre-fetched data pattern: DB queries happen in the orchestrator before agents run; agents receive typed `deps` dataclasses (no raw DB sessions)
- LLM provider-agnostic: `settings.LLM_MODEL` and `settings.LLM_JUDGE_MODEL` strings in `config.py`
- Shared helpers extracted to `app/agents/base.py`: `run_with_metrics[T]()`, `fetch_time_entries()`, `fetch_schedule_blocks()`, `fetch_tasks()`, `fetch_github_sync()`

## Test plan

- [ ] `pytest backend/tests/unit/agents/ -x -q` — 9 unit tests passing (TestModel, no real LLM calls)
- [ ] `ruff check . && ruff format .` — clean (verified)
- [ ] 518 total unit tests passing, 0 regressions

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)