### PR TITLE
Implement AI Agent Group A: parallel analysts [#28]

### DIFF
--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -157,7 +157,6 @@ class TaskAnalystResult(BaseModel):
     avg_completion_hours: float | None
     priority_distribution: dict[str, int]
     insights: list[str]
-<<<<<<< HEAD
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -8,7 +8,6 @@ from datetime import date, datetime
 
 from pydantic import BaseModel, Field
 
-
 # ---------------------------------------------------------------------------
 # Shared data transfer objects (pre-fetched from DB before agent calls)
 # ---------------------------------------------------------------------------

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -85,6 +85,7 @@ class MeetingAnalystResult(BaseModel):
     longest_meeting_hours: float
     focus_time_hours: float
     insights: list[str]
+<<<<<<< HEAD
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -85,7 +85,6 @@ class MeetingAnalystResult(BaseModel):
     longest_meeting_hours: float
     focus_time_hours: float
     insights: list[str]
-<<<<<<< HEAD
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +117,7 @@ class CodeAnalystResult(BaseModel):
     avg_pr_cycle_hours: float | None
     most_active_repo: str | None
     insights: list[str]
+<<<<<<< HEAD
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -8,6 +8,7 @@ from datetime import date, datetime
 
 from pydantic import BaseModel, Field
 
+
 # ---------------------------------------------------------------------------
 # Shared data transfer objects (pre-fetched from DB before agent calls)
 # ---------------------------------------------------------------------------

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -117,7 +117,6 @@ class CodeAnalystResult(BaseModel):
     avg_pr_cycle_hours: float | None
     most_active_repo: str | None
     insights: list[str]
-<<<<<<< HEAD
 
 
 # ---------------------------------------------------------------------------
@@ -158,6 +157,7 @@ class TaskAnalystResult(BaseModel):
     avg_completion_hours: float | None
     priority_distribution: dict[str, int]
     insights: list[str]
+<<<<<<< HEAD
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/agents/test_code_analyst.py
+++ b/backend/tests/unit/agents/test_code_analyst.py
@@ -6,6 +6,9 @@ from datetime import UTC, date, datetime
 import pytest
 from pydantic_ai.models.test import TestModel
 
+# CONFLICT RESOLUTION NOTE:
+# Option A (chosen): top-level import + typed fixture `GitHubSyncData` + `-> None` annotations + `UTC`
+# Option B (incoming): inline import inside fixture + untyped fixture + no return type annotations + `timezone.utc`
 from app.agents.schemas import GitHubSyncData
 
 

--- a/backend/tests/unit/agents/test_code_analyst.py
+++ b/backend/tests/unit/agents/test_code_analyst.py
@@ -7,8 +7,8 @@ import pytest
 from pydantic_ai.models.test import TestModel
 
 # CONFLICT RESOLUTION NOTE:
-# Option A (chosen): top-level import + typed fixture `GitHubSyncData` + `-> None` annotations + `UTC`
-# Option B (incoming): inline import inside fixture + untyped fixture + no return type annotations + `timezone.utc`
+# Option A (chosen): top-level import + typed fixture + `-> None` annotations + `UTC`
+# Option B (incoming): inline import + untyped fixture + no annotations + `timezone.utc`
 from app.agents.schemas import GitHubSyncData
 
 

--- a/backend/tests/unit/agents/test_meeting_analyst.py
+++ b/backend/tests/unit/agents/test_meeting_analyst.py
@@ -7,8 +7,8 @@ import pytest
 from pydantic_ai.models.test import TestModel
 
 # CONFLICT RESOLUTION NOTE:
-# Option A (chosen): top-level import + typed fixture `list[ScheduleBlockData]` + `-> None` annotations
-# Option B (incoming): inline import inside fixture + untyped `list` + no return type annotations
+# Option A (chosen): top-level import + typed fixture + `-> None` annotations
+# Option B (incoming): inline import inside fixture + untyped `list` + no annotations
 from app.agents.schemas import ScheduleBlockData
 
 

--- a/backend/tests/unit/agents/test_meeting_analyst.py
+++ b/backend/tests/unit/agents/test_meeting_analyst.py
@@ -6,6 +6,9 @@ from datetime import date
 import pytest
 from pydantic_ai.models.test import TestModel
 
+# CONFLICT RESOLUTION NOTE:
+# Option A (chosen): top-level import + typed fixture `list[ScheduleBlockData]` + `-> None` annotations
+# Option B (incoming): inline import inside fixture + untyped `list` + no return type annotations
 from app.agents.schemas import ScheduleBlockData
 
 

--- a/backend/tests/unit/agents/test_orchestrator.py
+++ b/backend/tests/unit/agents/test_orchestrator.py
@@ -9,6 +9,12 @@ import pytest
 from pydantic_ai import Agent
 from pydantic_ai.models.test import TestModel
 
+# CONFLICT RESOLUTION NOTE:
+# Option A (chosen — main): typed fixtures + `Any`/`Agent` imports + inline `selective_failure`
+#   closure (no global state) for the isolation test
+# Option B (incoming): untyped fixtures + module-level `_failing_time_analyst_wrapper`
+#   with `global _call_count` side-effect counter
+
 
 @pytest.fixture
 def user_id() -> uuid.UUID:

--- a/backend/tests/unit/agents/test_orchestrator.py
+++ b/backend/tests/unit/agents/test_orchestrator.py
@@ -72,6 +72,7 @@ async def test_run_group_a_isolates_single_agent_failure(
 ) -> None:
     """A single agent failure does not prevent the other three from succeeding."""
     import app.agents.orchestrator as orch_mod
+<<<<<<< HEAD
     from app.agents import code_analyst as ca_mod
     from app.agents import meeting_analyst as ma_mod
     from app.agents import task_analyst as tk_mod
@@ -86,6 +87,23 @@ async def test_run_group_a_isolates_single_agent_failure(
             raise RuntimeError("Simulated time_analyst failure")
         return await real_run_agent(agent, name, deps)
 
+=======
+    from app.agents.orchestrator import run_group_a
+    from app.agents.schemas import GroupAResult
+
+    from app.agents import meeting_analyst as ma_mod
+    from app.agents import code_analyst as ca_mod
+    from app.agents import task_analyst as tk_mod
+
+    # Capture real _run_agent before patching to avoid recursion
+    real_run_agent = orch_mod._run_agent
+
+    async def selective_failure(agent, name, deps):
+        if name == "time_analyst":
+            raise RuntimeError("Simulated time_analyst failure")
+        return await real_run_agent(agent, name, deps)
+
+>>>>>>> de81fab ([#28][GREEN] implement: GroupAResult schema, run_group_a orchestrator with asyncio.gather, error isolation, and Prometheus metrics)
     with (
         ma_mod.meeting_analyst.override(model=TestModel()),
         ca_mod.code_analyst.override(model=TestModel()),

--- a/backend/tests/unit/agents/test_orchestrator.py
+++ b/backend/tests/unit/agents/test_orchestrator.py
@@ -72,7 +72,6 @@ async def test_run_group_a_isolates_single_agent_failure(
 ) -> None:
     """A single agent failure does not prevent the other three from succeeding."""
     import app.agents.orchestrator as orch_mod
-<<<<<<< HEAD
     from app.agents import code_analyst as ca_mod
     from app.agents import meeting_analyst as ma_mod
     from app.agents import task_analyst as tk_mod
@@ -87,23 +86,6 @@ async def test_run_group_a_isolates_single_agent_failure(
             raise RuntimeError("Simulated time_analyst failure")
         return await real_run_agent(agent, name, deps)
 
-=======
-    from app.agents.orchestrator import run_group_a
-    from app.agents.schemas import GroupAResult
-
-    from app.agents import meeting_analyst as ma_mod
-    from app.agents import code_analyst as ca_mod
-    from app.agents import task_analyst as tk_mod
-
-    # Capture real _run_agent before patching to avoid recursion
-    real_run_agent = orch_mod._run_agent
-
-    async def selective_failure(agent, name, deps):
-        if name == "time_analyst":
-            raise RuntimeError("Simulated time_analyst failure")
-        return await real_run_agent(agent, name, deps)
-
->>>>>>> de81fab ([#28][GREEN] implement: GroupAResult schema, run_group_a orchestrator with asyncio.gather, error isolation, and Prometheus metrics)
     with (
         ma_mod.meeting_analyst.override(model=TestModel()),
         ca_mod.code_analyst.override(model=TestModel()),

--- a/backend/tests/unit/agents/test_orchestrator.py
+++ b/backend/tests/unit/agents/test_orchestrator.py
@@ -10,10 +10,8 @@ from pydantic_ai import Agent
 from pydantic_ai.models.test import TestModel
 
 # CONFLICT RESOLUTION NOTE:
-# Option A (chosen — main): typed fixtures + `Any`/`Agent` imports + inline `selective_failure`
-#   closure (no global state) for the isolation test
-# Option B (incoming): untyped fixtures + module-level `_failing_time_analyst_wrapper`
-#   with `global _call_count` side-effect counter
+# Option A (chosen): typed fixtures + inline closure (no global state)
+# Option B (incoming): untyped fixtures + module-level wrapper with global counter
 
 
 @pytest.fixture

--- a/backend/tests/unit/agents/test_task_analyst.py
+++ b/backend/tests/unit/agents/test_task_analyst.py
@@ -6,6 +6,9 @@ from datetime import UTC, date, datetime
 import pytest
 from pydantic_ai.models.test import TestModel
 
+# CONFLICT RESOLUTION NOTE:
+# Option A (chosen): top-level import + typed fixture `list[TaskData]` + `-> None` annotations + `UTC`
+# Option B (incoming): inline import inside fixture + untyped `list` + no return type annotations + `timezone.utc`
 from app.agents.schemas import TaskData
 
 

--- a/backend/tests/unit/agents/test_task_analyst.py
+++ b/backend/tests/unit/agents/test_task_analyst.py
@@ -82,7 +82,7 @@ async def test_task_analyst_result_conforms_to_schema(
 @pytest.mark.asyncio
 async def test_task_analyst_no_completed_tasks() -> None:
     """Completion rate is 0 when all tasks are in todo state."""
-    from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult, TaskData
+    from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult
     from app.agents.task_analyst import task_analyst
 
     tasks = [

--- a/backend/tests/unit/agents/test_task_analyst.py
+++ b/backend/tests/unit/agents/test_task_analyst.py
@@ -82,7 +82,7 @@ async def test_task_analyst_result_conforms_to_schema(
 @pytest.mark.asyncio
 async def test_task_analyst_no_completed_tasks() -> None:
     """Completion rate is 0 when all tasks are in todo state."""
-    from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult
+    from app.agents.schemas import TaskAnalystDeps, TaskAnalystResult, TaskData
     from app.agents.task_analyst import task_analyst
 
     tasks = [

--- a/backend/tests/unit/agents/test_task_analyst.py
+++ b/backend/tests/unit/agents/test_task_analyst.py
@@ -7,8 +7,8 @@ import pytest
 from pydantic_ai.models.test import TestModel
 
 # CONFLICT RESOLUTION NOTE:
-# Option A (chosen): top-level import + typed fixture `list[TaskData]` + `-> None` annotations + `UTC`
-# Option B (incoming): inline import inside fixture + untyped `list` + no return type annotations + `timezone.utc`
+# Option A (chosen): top-level import + typed fixture + `-> None` annotations + `UTC`
+# Option B (incoming): inline import + untyped `list` + no annotations + `timezone.utc`
 from app.agents.schemas import TaskData
 
 


### PR DESCRIPTION
## Summary

- Implements all four Group A parallel analyst agents (`time_analyst`, `meeting_analyst`, `code_analyst`, `task_analyst`) running via `asyncio.gather` with per-agent error isolation
- Adds `GroupAResult` schema aggregating all four outputs plus an `errors` dict for partial failures
- Extracts shared DB fetch helpers into `app/agents/base.py` and `run_with_metrics` for Prometheus latency recording
- Full TDD: RED/GREEN/REFACTOR cycles for each agent and the orchestrator

## Test plan

- [ ] `pytest tests/unit/agents/` — all agent schema and orchestrator tests pass
- [ ] Verify `run_group_a` returns all four results with `TestModel`
- [ ] Verify single-agent failure isolation: one agent raising does not block the other three
- [ ] Verify `agent_latency_seconds` Prometheus metric is observed for all four agents

## Related

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)