### PR TITLE
[#29] Implement AI Agent Group B: Pattern Detector

### DIFF
--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -20,10 +20,13 @@ from app.agents.base import (
 )
 from app.agents.code_analyst import code_analyst
 from app.agents.meeting_analyst import meeting_analyst
+from app.agents.pattern_detector import pattern_detector
 from app.agents.schemas import (
     CodeAnalystDeps,
     GroupAResult,
     MeetingAnalystDeps,
+    PatternDetectorDeps,
+    PatternDetectorResult,
     TaskAnalystDeps,
     TimeAnalystDeps,
 )
@@ -110,3 +113,26 @@ async def run_group_a(
         task_analysis=task_result,
         errors=errors,
     )
+
+
+async def run_group_b(
+    group_a_result: GroupAResult,
+    user_id: uuid.UUID,
+    analysis_date: date,
+) -> PatternDetectorResult:
+    """Run the Pattern Detector agent (Group B) on Group A outputs.
+
+    Args:
+        group_a_result: Aggregated output from all Group A analysts.
+        user_id: The user whose data was analyzed.
+        analysis_date: The reference date for the analysis.
+
+    Returns:
+        PatternDetectorResult with detected cross-source patterns and summary.
+    """
+    deps = PatternDetectorDeps(
+        user_id=user_id,
+        analysis_date=analysis_date,
+        group_a_result=group_a_result,
+    )
+    return await run_with_metrics(pattern_detector, "pattern_detector", deps)

--- a/backend/app/agents/pattern_detector.py
+++ b/backend/app/agents/pattern_detector.py
@@ -14,7 +14,8 @@ pattern_detector: Agent[PatternDetectorDeps, PatternDetectorResult] = Agent(
     defer_model_check=True,
     system_prompt=(
         "You are a cross-source pattern detector. "
-        "Given structured outputs from four analyst agents (time, meeting, code, task), "
+        "Given structured outputs from four analyst agents "
+        "(time, meeting, code, task), "
         "identify correlations and patterns across data sources. "
         "Each pattern must have a category indicating which sources it correlates "
         "(e.g. 'time-meeting', 'code-task', 'time-task', 'meeting-task'). "

--- a/backend/app/agents/pattern_detector.py
+++ b/backend/app/agents/pattern_detector.py
@@ -1,0 +1,95 @@
+"""Pattern Detector agent — finds cross-source correlations in Group A outputs."""
+
+from __future__ import annotations
+
+from pydantic_ai import Agent, RunContext
+
+from app.agents.schemas import PatternDetectorDeps, PatternDetectorResult
+from app.core.config import settings
+
+pattern_detector: Agent[PatternDetectorDeps, PatternDetectorResult] = Agent(
+    model=settings.LLM_MODEL,
+    output_type=PatternDetectorResult,
+    deps_type=PatternDetectorDeps,
+    defer_model_check=True,
+    system_prompt=(
+        "You are a cross-source pattern detector. "
+        "Given structured outputs from four analyst agents (time, meeting, code, task), "
+        "identify correlations and patterns across data sources. "
+        "Each pattern must have a category indicating which sources it correlates "
+        "(e.g. 'time-meeting', 'code-task', 'time-task', 'meeting-task'). "
+        "Confidence scores must be between 0.0 and 1.0. "
+        "Evidence must reference specific data points from the analyst outputs. "
+        "Provide 2-5 patterns with actionable recommendations. "
+        "If some analyst outputs are missing, only detect patterns from available data."
+    ),
+)
+
+
+@pattern_detector.instructions
+async def add_group_a_context(ctx: RunContext[PatternDetectorDeps]) -> str:
+    """Serialize Group A results into the prompt for cross-correlation analysis."""
+    deps = ctx.deps
+    ga = deps.group_a_result
+    sections = [f"Analysis date: {deps.analysis_date}"]
+
+    if ga.time_analysis:
+        t = ga.time_analysis
+        sections.append(
+            f"TIME ANALYSIS:\n"
+            f"  Tracked hours: {t.total_tracked_hours:.2f}\n"
+            f"  Planned hours: {t.total_planned_hours:.2f}\n"
+            f"  Utilization: {t.utilization_pct:.1f}%\n"
+            f"  Most active project: {t.most_active_project or 'none'}\n"
+            f"  Avg session: {t.avg_session_minutes:.1f} min\n"
+            f"  Insights: {t.insights}"
+        )
+    else:
+        sections.append("TIME ANALYSIS: unavailable")
+
+    if ga.meeting_analysis:
+        m = ga.meeting_analysis
+        sections.append(
+            f"MEETING ANALYSIS:\n"
+            f"  Meeting hours: {m.total_meeting_hours:.2f}\n"
+            f"  Meeting count: {m.meeting_count}\n"
+            f"  Avg duration: {m.avg_meeting_duration_hours:.2f}h\n"
+            f"  Focus time: {m.focus_time_hours:.2f}h\n"
+            f"  Insights: {m.insights}"
+        )
+    else:
+        sections.append("MEETING ANALYSIS: unavailable")
+
+    if ga.code_analysis:
+        c = ga.code_analysis
+        sections.append(
+            f"CODE ANALYSIS:\n"
+            f"  Data available: {c.data_available}\n"
+            f"  Commits: {c.commits_count}\n"
+            f"  PRs: {c.pull_requests_count}\n"
+            f"  Avg PR cycle: {c.avg_pr_cycle_hours}h\n"
+            f"  Most active repo: {c.most_active_repo or 'none'}\n"
+            f"  Insights: {c.insights}"
+        )
+    else:
+        sections.append("CODE ANALYSIS: unavailable")
+
+    if ga.task_analysis:
+        tk = ga.task_analysis
+        sections.append(
+            f"TASK ANALYSIS:\n"
+            f"  Total tasks: {tk.total_tasks}\n"
+            f"  Completed: {tk.completed_tasks}\n"
+            f"  Completion rate: {tk.completion_rate_pct:.1f}%\n"
+            f"  Overdue: {tk.overdue_tasks}\n"
+            f"  Avg completion time: {tk.avg_completion_hours}h\n"
+            f"  Priority distribution: {tk.priority_distribution}\n"
+            f"  Insights: {tk.insights}"
+        )
+    else:
+        sections.append("TASK ANALYSIS: unavailable")
+
+    if ga.errors:
+        sections.append(f"ERRORS: {ga.errors}")
+
+    return "\n\n".join(sections)

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -171,3 +171,34 @@ class GroupAResult(BaseModel):
     code_analysis: CodeAnalystResult | None = None
     task_analysis: TaskAnalystResult | None = None
     errors: dict[str, str] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Pattern Detector (Group B)
+# ---------------------------------------------------------------------------
+
+
+class CrossPattern(BaseModel):
+    """A single cross-source correlation pattern detected by the Pattern Detector."""
+
+    category: str  # e.g. "time-meeting", "code-task", "time-task", "meeting-task"
+    pattern: str  # human-readable description of the correlation
+    confidence: float = Field(ge=0.0, le=1.0)
+    evidence: list[str]  # specific data points from Group A supporting this pattern
+    recommendation: str  # actionable suggestion
+
+
+@dataclass
+class PatternDetectorDeps:
+    """Dependencies injected into the Pattern Detector via RunContext."""
+
+    user_id: uuid.UUID
+    analysis_date: date
+    group_a_result: GroupAResult
+
+
+class PatternDetectorResult(BaseModel):
+    """Structured output produced by the Pattern Detector agent."""
+
+    patterns: list[CrossPattern]
+    summary: str

--- a/backend/tests/unit/agents/test_pattern_detector.py
+++ b/backend/tests/unit/agents/test_pattern_detector.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+from pydantic_ai.models.test import TestModel
+
+from app.agents.schemas import (
+    CodeAnalystResult,
+    GroupAResult,
+    MeetingAnalystResult,
+    TaskAnalystResult,
+    TimeAnalystResult,
+)
+
+
+@pytest.fixture
+def full_group_a_result() -> GroupAResult:
+    return GroupAResult(
+        time_analysis=TimeAnalystResult(
+            total_tracked_hours=6.5,
+            total_planned_hours=8.0,
+            utilization_pct=81.25,
+            most_active_project="FlowDay",
+            avg_session_minutes=97.5,
+            insights=["Good focus time", "Utilization above 80%"],
+        ),
+        meeting_analysis=MeetingAnalystResult(
+            total_meeting_hours=2.5,
+            meeting_count=3,
+            avg_meeting_duration_hours=0.83,
+            longest_meeting_hours=1.0,
+            focus_time_hours=5.5,
+            insights=["Moderate meeting load"],
+        ),
+        code_analysis=CodeAnalystResult(
+            data_available=True,
+            commits_count=5,
+            pull_requests_count=2,
+            avg_pr_cycle_hours=4.0,
+            most_active_repo="flowday-main",
+            insights=["Steady commit pace"],
+        ),
+        task_analysis=TaskAnalystResult(
+            total_tasks=12,
+            completed_tasks=4,
+            completion_rate_pct=33.3,
+            overdue_tasks=2,
+            avg_completion_hours=3.5,
+            priority_distribution={"high": 3, "medium": 5, "low": 4},
+            insights=["2 overdue tasks need attention"],
+        ),
+        errors={},
+    )
+
+
+@pytest.fixture
+def partial_group_a_result() -> GroupAResult:
+    """Group A result with time and code analysis missing (simulating failures)."""
+    return GroupAResult(
+        time_analysis=None,
+        meeting_analysis=MeetingAnalystResult(
+            total_meeting_hours=3.0,
+            meeting_count=4,
+            avg_meeting_duration_hours=0.75,
+            longest_meeting_hours=1.5,
+            focus_time_hours=5.0,
+            insights=["Heavy meeting day"],
+        ),
+        code_analysis=None,
+        task_analysis=TaskAnalystResult(
+            total_tasks=8,
+            completed_tasks=2,
+            completion_rate_pct=25.0,
+            overdue_tasks=3,
+            avg_completion_hours=None,
+            priority_distribution={"high": 4, "medium": 3, "low": 1},
+            insights=["Low completion rate", "3 overdue tasks"],
+        ),
+        errors={"time_analyst": "timeout", "code_analyst": "no github"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_pattern_detector_result_conforms_to_schema(
+    full_group_a_result: GroupAResult,
+) -> None:
+    """Agent with TestModel returns a valid PatternDetectorResult schema."""
+    from app.agents.pattern_detector import pattern_detector
+    from app.agents.schemas import PatternDetectorDeps, PatternDetectorResult
+
+    deps = PatternDetectorDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+    )
+
+    with pattern_detector.override(model=TestModel()):
+        result = await pattern_detector.run(
+            "Analyze and produce structured insights.", deps=deps
+        )
+
+    output = result.output
+    assert isinstance(output, PatternDetectorResult)
+    assert isinstance(output.patterns, list)
+    assert isinstance(output.summary, str)
+
+
+@pytest.mark.asyncio
+async def test_pattern_detector_handles_partial_group_a(
+    partial_group_a_result: GroupAResult,
+) -> None:
+    """Agent handles partial Group A output (some analysts failed) without error."""
+    from app.agents.pattern_detector import pattern_detector
+    from app.agents.schemas import PatternDetectorDeps, PatternDetectorResult
+
+    deps = PatternDetectorDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=partial_group_a_result,
+    )
+
+    with pattern_detector.override(model=TestModel()):
+        result = await pattern_detector.run(
+            "Analyze and produce structured insights.", deps=deps
+        )
+
+    output = result.output
+    assert isinstance(output, PatternDetectorResult)
+    assert isinstance(output.patterns, list)
+    assert isinstance(output.summary, str)

--- a/backend/tests/unit/agents/test_pattern_detector.py
+++ b/backend/tests/unit/agents/test_pattern_detector.py
@@ -130,3 +130,116 @@ async def test_pattern_detector_handles_partial_group_a(
     assert isinstance(output, PatternDetectorResult)
     assert isinstance(output.patterns, list)
     assert isinstance(output.summary, str)
+
+
+@pytest.mark.asyncio
+async def test_pattern_detector_handles_all_none_group_a() -> None:
+    """Agent handles all-None Group A output (catastrophic failure) without error."""
+    from app.agents.pattern_detector import pattern_detector
+    from app.agents.schemas import PatternDetectorDeps, PatternDetectorResult
+
+    all_none = GroupAResult(
+        time_analysis=None,
+        meeting_analysis=None,
+        code_analysis=None,
+        task_analysis=None,
+        errors={
+            "time_analyst": "timeout",
+            "meeting_analyst": "timeout",
+            "code_analyst": "timeout",
+            "task_analyst": "timeout",
+        },
+    )
+    deps = PatternDetectorDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=all_none,
+    )
+
+    with pattern_detector.override(model=TestModel()):
+        result = await pattern_detector.run(
+            "Analyze and produce structured insights.", deps=deps
+        )
+
+    output = result.output
+    assert isinstance(output, PatternDetectorResult)
+    assert isinstance(output.patterns, list)
+    assert isinstance(output.summary, str)
+
+
+@pytest.mark.asyncio
+async def test_pattern_detector_each_pattern_has_required_fields(
+    full_group_a_result: GroupAResult,
+) -> None:
+    """Each CrossPattern in the output has all required fields with valid values."""
+    from app.agents.pattern_detector import pattern_detector
+    from app.agents.schemas import CrossPattern, PatternDetectorDeps
+
+    deps = PatternDetectorDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+    )
+
+    with pattern_detector.override(model=TestModel()):
+        result = await pattern_detector.run(
+            "Analyze and produce structured insights.", deps=deps
+        )
+
+    for p in result.output.patterns:
+        assert isinstance(p, CrossPattern)
+        assert isinstance(p.category, str)
+        assert isinstance(p.pattern, str)
+        assert 0.0 <= p.confidence <= 1.0
+        assert isinstance(p.evidence, list)
+        assert isinstance(p.recommendation, str)
+
+
+@pytest.mark.asyncio
+async def test_pattern_detector_metrics_recorded(
+    full_group_a_result: GroupAResult,
+) -> None:
+    """run_with_metrics records latency under 'pattern_detector' label."""
+    from unittest.mock import patch
+
+    from app.agents.base import run_with_metrics
+    from app.agents.pattern_detector import pattern_detector
+    from app.agents.schemas import PatternDetectorDeps
+    from app.core.metrics import agent_latency_seconds
+
+    deps = PatternDetectorDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+    )
+
+    with (
+        pattern_detector.override(model=TestModel()),
+        patch.object(
+            agent_latency_seconds, "labels", wraps=agent_latency_seconds.labels
+        ) as mock_labels,
+    ):
+        await run_with_metrics(pattern_detector, "pattern_detector", deps)
+
+    mock_labels.assert_called_once_with(agent_name="pattern_detector")
+
+
+@pytest.mark.asyncio
+async def test_run_group_b_returns_pattern_detector_result(
+    full_group_a_result: GroupAResult,
+) -> None:
+    """run_group_b returns a valid PatternDetectorResult."""
+    import app.agents.pattern_detector as pd_mod
+    from app.agents.orchestrator import run_group_b
+    from app.agents.schemas import PatternDetectorResult
+
+    with pd_mod.pattern_detector.override(model=TestModel()):
+        result = await run_group_b(
+            group_a_result=full_group_a_result,
+            user_id=uuid.uuid4(),
+            analysis_date=date(2026, 4, 14),
+        )
+
+    assert isinstance(result, PatternDetectorResult)
+    assert isinstance(result.patterns, list)
+    assert isinstance(result.summary, str)


### PR DESCRIPTION
## Summary

Closes #29

- Add `CrossPattern`, `PatternDetectorDeps`, `PatternDetectorResult` schemas to `app/agents/schemas.py`
- Implement `pattern_detector` agent (`app/agents/pattern_detector.py`) — receives all Group A outputs, formats them into a structured prompt, and produces cross-source correlation patterns with confidence scores and evidence
- Add `run_group_b()` to `app/agents/orchestrator.py` — runs pattern detector via `run_with_metrics` (Prometheus latency recorded under `"pattern_detector"` label)
- 6 new unit tests covering: schema conformance, partial/all-None Group A handling, field validation, metrics recording, and `run_group_b` integration

## TDD Cycles

- `[#29][RED]` → `[#29][GREEN]`: output schema + agent implementation
- `[#29][RED]` → `[#29][GREEN]`: cross-correlation tests + `run_group_b`
- `[#29][REFACTOR]`: ruff line-length fix

## Test plan

- [ ] `pytest tests/unit/agents/test_pattern_detector.py -v` — 6 tests pass
- [ ] `pytest tests/unit/agents/ -v` — all 17 agent unit tests pass
- [ ] `ruff check app/agents/` — no lint errors
- [ ] `mypy app/agents/` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)