### PR TITLE
[#36] feat: OAuth login flow UI (LoginPage, OAuthCallbackPage, ProtectedRoute)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -19,7 +19,12 @@ from app.core.security import (
     encrypt_oauth_token,
 )
 from app.models.user import User
-from app.schemas.user import RefreshRequest, TokenResponse, UserResponse
+from app.schemas.user import (
+    OAuthCallbackRequest,
+    RefreshRequest,
+    TokenResponse,
+    UserResponse,
+)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -79,9 +84,9 @@ async def _handle_oauth_callback(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/google/callback", response_model=TokenResponse)
+@router.post("/google/callback", response_model=TokenResponse)
 async def google_callback(
-    code: str, db: AsyncSession = Depends(get_db)
+    body: OAuthCallbackRequest, db: AsyncSession = Depends(get_db)
 ) -> TokenResponse:
     """Exchange Google OAuth authorization code for JWT token pair."""
     if settings.GOOGLE_CLIENT_ID is None or settings.GOOGLE_CLIENT_SECRET is None:
@@ -95,7 +100,7 @@ async def google_callback(
         token_resp = await client.post(
             "https://oauth2.googleapis.com/token",
             data={
-                "code": code,
+                "code": body.code,
                 "client_id": settings.GOOGLE_CLIENT_ID,
                 "client_secret": settings.GOOGLE_CLIENT_SECRET,
                 "redirect_uri": settings.GOOGLE_REDIRECT_URI,
@@ -138,9 +143,9 @@ async def google_callback(
     )
 
 
-@router.get("/github/callback", response_model=TokenResponse)
+@router.post("/github/callback", response_model=TokenResponse)
 async def github_callback(
-    code: str, db: AsyncSession = Depends(get_db)
+    body: OAuthCallbackRequest, db: AsyncSession = Depends(get_db)
 ) -> TokenResponse:
     """Exchange GitHub OAuth authorization code for JWT token pair."""
     if settings.GITHUB_CLIENT_ID is None or settings.GITHUB_CLIENT_SECRET is None:
@@ -154,7 +159,7 @@ async def github_callback(
         token_resp = await client.post(
             "https://github.com/login/oauth/access_token",
             data={
-                "code": code,
+                "code": body.code,
                 "client_id": settings.GITHUB_CLIENT_ID,
                 "client_secret": settings.GITHUB_CLIENT_SECRET,
                 "redirect_uri": settings.GITHUB_REDIRECT_URI,

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 
 class UserResponse(BaseModel):
@@ -44,4 +44,4 @@ class RefreshRequest(BaseModel):
 class OAuthCallbackRequest(BaseModel):
     """Request body for OAuth code exchange — keeps the code out of the URL."""
 
-    code: str
+    code: str = Field(min_length=1)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -39,3 +39,9 @@ class RefreshRequest(BaseModel):
     """Request body for token refresh."""
 
     refresh_token: str
+
+
+class OAuthCallbackRequest(BaseModel):
+    """Request body for OAuth code exchange — keeps the code out of the URL."""
+
+    code: str

--- a/backend/tests/integration/test_auth.py
+++ b/backend/tests/integration/test_auth.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -49,4 +51,107 @@ async def test_refresh_token_as_access_returns_401(
         headers={"Authorization": f"Bearer {token}"},
     ) as ac:
         resp = await ac.get("/auth/me")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/{provider}/callback — contract tests
+# ---------------------------------------------------------------------------
+
+
+async def test_google_callback_rejects_get(db_session: AsyncSession) -> None:
+    """GET /auth/google/callback must return 405 — route is now POST only."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get("/auth/google/callback", params={"code": "test"})
+    assert resp.status_code == 405
+
+
+async def test_github_callback_rejects_get(db_session: AsyncSession) -> None:
+    """GET /auth/github/callback must return 405 — route is now POST only."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get("/auth/github/callback", params={"code": "test"})
+    assert resp.status_code == 405
+
+
+async def test_google_callback_returns_501_when_not_configured(
+    db_session: AsyncSession,
+) -> None:
+    """POST /auth/google/callback returns 501 when Google OAuth is not configured."""
+    with patch("app.api.auth.settings") as mock_settings:
+        mock_settings.GOOGLE_CLIENT_ID = None
+        mock_settings.GOOGLE_CLIENT_SECRET = None
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/auth/google/callback", json={"code": "test-code"})
+    assert resp.status_code == 501
+
+
+async def test_github_callback_returns_501_when_not_configured(
+    db_session: AsyncSession,
+) -> None:
+    """POST /auth/github/callback returns 501 when GitHub OAuth is not configured."""
+    with patch("app.api.auth.settings") as mock_settings:
+        mock_settings.GITHUB_CLIENT_ID = None
+        mock_settings.GITHUB_CLIENT_SECRET = None
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/auth/github/callback", json={"code": "test-code"})
+    assert resp.status_code == 501
+
+
+async def test_google_callback_returns_401_on_bad_code(
+    db_session: AsyncSession,
+) -> None:
+    """POST /auth/google/callback returns 401 when Google rejects the code."""
+    mock_token_resp = MagicMock()
+    mock_token_resp.status_code = 400
+
+    mock_httpx_client = AsyncMock()
+    mock_httpx_client.__aenter__ = AsyncMock(return_value=mock_httpx_client)
+    mock_httpx_client.__aexit__ = AsyncMock(return_value=False)
+    mock_httpx_client.post = AsyncMock(return_value=mock_token_resp)
+
+    with (
+        patch("app.api.auth.settings") as mock_settings,
+        patch("app.api.auth.httpx.AsyncClient", return_value=mock_httpx_client),
+    ):
+        mock_settings.GOOGLE_CLIENT_ID = "gid"
+        mock_settings.GOOGLE_CLIENT_SECRET = "gsecret"
+        mock_settings.GOOGLE_REDIRECT_URI = "http://localhost:5173/auth/google/callback"
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/auth/google/callback", json={"code": "bad-code"})
+    assert resp.status_code == 401
+
+
+async def test_github_callback_returns_401_on_bad_code(
+    db_session: AsyncSession,
+) -> None:
+    """POST /auth/github/callback returns 401 when GitHub rejects the code."""
+    mock_token_resp = MagicMock()
+    mock_token_resp.status_code = 400
+
+    mock_httpx_client = AsyncMock()
+    mock_httpx_client.__aenter__ = AsyncMock(return_value=mock_httpx_client)
+    mock_httpx_client.__aexit__ = AsyncMock(return_value=False)
+    mock_httpx_client.post = AsyncMock(return_value=mock_token_resp)
+
+    with (
+        patch("app.api.auth.settings") as mock_settings,
+        patch("app.api.auth.httpx.AsyncClient", return_value=mock_httpx_client),
+    ):
+        mock_settings.GITHUB_CLIENT_ID = "ghid"
+        mock_settings.GITHUB_CLIENT_SECRET = "ghsecret"
+        mock_settings.GITHUB_REDIRECT_URI = "http://localhost:5173/auth/github/callback"
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/auth/github/callback", json={"code": "bad-code"})
     assert resp.status_code == 401

--- a/backend/tests/unit/test_auth_routes.py
+++ b/backend/tests/unit/test_auth_routes.py
@@ -152,7 +152,7 @@ def _mock_db_session() -> AsyncMock:
 async def test_google_callback_creates_user_and_returns_jwt(
     auth_client: AsyncClient,
 ) -> None:
-    """GET /auth/google/callback with valid code returns JWT pair."""
+    """POST /auth/google/callback with valid code returns JWT pair."""
     token_resp = httpx.Response(200, json={"access_token": "google-token-123"})
     userinfo_resp = httpx.Response(
         200, json={"email": "user@gmail.com", "name": "Google User"}
@@ -173,8 +173,8 @@ async def test_google_callback_creates_user_and_returns_jwt(
             mock_settings.GOOGLE_CLIENT_SECRET = "test-secret"
             mock_settings.GOOGLE_REDIRECT_URI = "http://localhost/callback"
 
-            response = await auth_client.get(
-                "/auth/google/callback", params={"code": "auth-code-123"}
+            response = await auth_client.post(
+                "/auth/google/callback", json={"code": "auth-code-123"}
             )
     finally:
         app.dependency_overrides.clear()
@@ -190,7 +190,7 @@ async def test_google_callback_creates_user_and_returns_jwt(
 async def test_github_callback_creates_user_and_returns_jwt(
     auth_client: AsyncClient,
 ) -> None:
-    """GET /auth/github/callback with valid code returns JWT pair."""
+    """POST /auth/github/callback with valid code returns JWT pair."""
     token_resp = httpx.Response(200, json={"access_token": "github-token-456"})
     userinfo_resp = httpx.Response(
         200,
@@ -216,8 +216,8 @@ async def test_github_callback_creates_user_and_returns_jwt(
             mock_settings.GITHUB_CLIENT_SECRET = "test-secret"
             mock_settings.GITHUB_REDIRECT_URI = "http://localhost/callback"
 
-            response = await auth_client.get(
-                "/auth/github/callback", params={"code": "auth-code-456"}
+            response = await auth_client.post(
+                "/auth/github/callback", json={"code": "auth-code-456"}
             )
     finally:
         app.dependency_overrides.clear()
@@ -254,8 +254,8 @@ async def test_oauth_callback_existing_user_updates_token(
             mock_settings.GOOGLE_CLIENT_SECRET = "test-secret"
             mock_settings.GOOGLE_REDIRECT_URI = "http://localhost/callback"
 
-            response = await auth_client.get(
-                "/auth/google/callback", params={"code": "auth-code-second"}
+            response = await auth_client.post(
+                "/auth/google/callback", json={"code": "auth-code-second"}
             )
     finally:
         app.dependency_overrides.clear()

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,9 @@
+# Google OAuth — register at https://console.cloud.google.com/
+# Authorized redirect URI must include: http://localhost:5173/auth/google/callback
+# Also set GOOGLE_REDIRECT_URI=http://localhost:5173/auth/google/callback in backend/.env
+VITE_GOOGLE_CLIENT_ID=
+
+# GitHub OAuth — register at https://github.com/settings/developers
+# Authorization callback URL: http://localhost:5173/auth/github/callback
+# Also set GITHUB_REDIRECT_URI=http://localhost:5173/auth/github/callback in backend/.env
+VITE_GITHUB_CLIENT_ID=

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,30 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import App from './App'
+import { useAuthStore } from './stores/authStore'
+import type { TokenPair, User } from './types/auth'
 
 const future = { v7_startTransition: true, v7_relativeSplatPath: true } as const
+
+const mockTokens: TokenPair = {
+  access_token: 'access-abc',
+  refresh_token: 'refresh-xyz',
+  token_type: 'bearer',
+}
+
+const mockUser: User = {
+  id: 'usr-1',
+  email: 'alice@example.com',
+  name: 'Alice',
+  settings_json: {},
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  useAuthStore.setState({ user: null, tokens: null, isAuthenticated: false })
+})
 
 describe('App', () => {
   it('renders without crashing', () => {
@@ -29,7 +50,7 @@ describe('App', () => {
   it('provides QueryClient to the component tree without error', () => {
     expect(() =>
       render(
-        <MemoryRouter initialEntries={['/dashboard']} future={future}>
+        <MemoryRouter initialEntries={['/login']} future={future}>
           <App />
         </MemoryRouter>,
       ),
@@ -37,7 +58,7 @@ describe('App', () => {
   })
 })
 
-describe('Routing', () => {
+describe('Routing — unauthenticated', () => {
   it('renders login page at /login', () => {
     render(
       <MemoryRouter initialEntries={['/login']} future={future}>
@@ -47,7 +68,50 @@ describe('Routing', () => {
     expect(screen.getByTestId('page-login')).toBeInTheDocument()
   })
 
-  it('renders dashboard page at /dashboard', () => {
+  it('redirects /dashboard to /login when not authenticated', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']} future={future}>
+        <App />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('page-login')).toBeInTheDocument()
+    expect(screen.queryByTestId('page-dashboard')).not.toBeInTheDocument()
+  })
+
+  it('redirects /planner to /login when not authenticated', () => {
+    render(
+      <MemoryRouter initialEntries={['/planner']} future={future}>
+        <App />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('page-login')).toBeInTheDocument()
+  })
+
+  it('redirects /review to /login when not authenticated', () => {
+    render(
+      <MemoryRouter initialEntries={['/review']} future={future}>
+        <App />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('page-login')).toBeInTheDocument()
+  })
+
+  it('redirects unknown routes to /login', () => {
+    render(
+      <MemoryRouter initialEntries={['/unknown-path']} future={future}>
+        <App />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('page-login')).toBeInTheDocument()
+  })
+})
+
+describe('Routing — authenticated', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ user: mockUser, tokens: mockTokens, isAuthenticated: true })
+  })
+
+  it('renders dashboard page at /dashboard when authenticated', () => {
     render(
       <MemoryRouter initialEntries={['/dashboard']} future={future}>
         <App />
@@ -56,7 +120,7 @@ describe('Routing', () => {
     expect(screen.getByTestId('page-dashboard')).toBeInTheDocument()
   })
 
-  it('renders planner page at /planner', () => {
+  it('renders planner page at /planner when authenticated', () => {
     render(
       <MemoryRouter initialEntries={['/planner']} future={future}>
         <App />
@@ -65,21 +129,12 @@ describe('Routing', () => {
     expect(screen.getByTestId('page-planner')).toBeInTheDocument()
   })
 
-  it('renders review page at /review', () => {
+  it('renders review page at /review when authenticated', () => {
     render(
       <MemoryRouter initialEntries={['/review']} future={future}>
         <App />
       </MemoryRouter>,
     )
     expect(screen.getByTestId('page-review')).toBeInTheDocument()
-  })
-
-  it('redirects unknown routes to login', () => {
-    render(
-      <MemoryRouter initialEntries={['/unknown-path']} future={future}>
-        <App />
-      </MemoryRouter>,
-    )
-    expect(screen.getByTestId('page-login')).toBeInTheDocument()
   })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import LoginPage from './pages/LoginPage'
 import DashboardPage from './pages/DashboardPage'
 import PlannerPage from './pages/PlannerPage'
 import ReviewPage from './pages/ReviewPage'
+import OAuthCallbackPage from './pages/OAuthCallbackPage'
+import ProtectedRoute from './components/ProtectedRoute'
 import './index.css'
 
 function App(): React.JSX.Element {
@@ -10,9 +12,31 @@ function App(): React.JSX.Element {
     <div className="dark-bg">
       <Routes>
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/dashboard" element={<DashboardPage />} />
-        <Route path="/planner" element={<PlannerPage />} />
-        <Route path="/review" element={<ReviewPage />} />
+        <Route path="/auth/:provider/callback" element={<OAuthCallbackPage />} />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <DashboardPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/planner"
+          element={
+            <ProtectedRoute>
+              <PlannerPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/review"
+          element={
+            <ProtectedRoute>
+              <ReviewPage />
+            </ProtectedRoute>
+          }
+        />
         <Route path="*" element={<Navigate to="/login" replace />} />
       </Routes>
     </div>

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -20,10 +20,20 @@ export async function exchangeOAuthCode(
   return res.json() as Promise<TokenPair>
 }
 
+export class AuthError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message)
+    this.name = 'AuthError'
+  }
+}
+
 export async function fetchCurrentUser(signal?: AbortSignal): Promise<User> {
   const res = await apiClient.get('/auth/me', signal)
   if (!res.ok) {
-    throw new Error('Failed to fetch current user')
+    throw new AuthError('Failed to fetch current user', res.status)
   }
   return res.json() as Promise<User>
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -6,8 +6,13 @@ export async function exchangeOAuthCode(
   code: string,
   signal?: AbortSignal,
 ): Promise<TokenPair> {
-  const url = `/auth/${provider}/callback?code=${encodeURIComponent(code)}`
-  const res = await fetch(url, { signal })
+  const url = `/auth/${provider}/callback`
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+    signal,
+  })
   if (!res.ok) {
     const data = await res.json().catch(() => ({}))
     throw new Error((data as { detail?: string }).detail ?? 'OAuth exchange failed')

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -5,7 +5,11 @@ export async function exchangeOAuthCode(
   provider: 'google' | 'github',
   code: string,
 ): Promise<TokenPair> {
-  const res = await fetch(`/auth/${provider}/callback?code=${encodeURIComponent(code)}`)
+  const res = await fetch(`/auth/${provider}/callback`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  })
   if (!res.ok) {
     const data = await res.json().catch(() => ({}))
     throw new Error((data as { detail?: string }).detail ?? 'OAuth exchange failed')

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -4,12 +4,10 @@ import type { TokenPair, User } from '../types/auth'
 export async function exchangeOAuthCode(
   provider: 'google' | 'github',
   code: string,
+  signal?: AbortSignal,
 ): Promise<TokenPair> {
-  const res = await fetch(`/auth/${provider}/callback`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code }),
-  })
+  const url = `/auth/${provider}/callback?code=${encodeURIComponent(code)}`
+  const res = await fetch(url, { signal })
   if (!res.ok) {
     const data = await res.json().catch(() => ({}))
     throw new Error((data as { detail?: string }).detail ?? 'OAuth exchange failed')
@@ -17,8 +15,8 @@ export async function exchangeOAuthCode(
   return res.json() as Promise<TokenPair>
 }
 
-export async function fetchCurrentUser(): Promise<User> {
-  const res = await apiClient.get('/auth/me')
+export async function fetchCurrentUser(signal?: AbortSignal): Promise<User> {
+  const res = await apiClient.get('/auth/me', signal)
   if (!res.ok) {
     throw new Error('Failed to fetch current user')
   }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -38,14 +38,3 @@ export async function fetchCurrentUser(signal?: AbortSignal): Promise<User> {
   return res.json() as Promise<User>
 }
 
-export async function refreshTokens(refreshToken: string): Promise<TokenPair> {
-  const res = await fetch('/auth/refresh', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ refresh_token: refreshToken }),
-  })
-  if (!res.ok) {
-    throw new Error('Token refresh failed')
-  }
-  return res.json() as Promise<TokenPair>
-}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,34 @@
+import { apiClient } from './client'
+import type { TokenPair, User } from '../types/auth'
+
+export async function exchangeOAuthCode(
+  provider: 'google' | 'github',
+  code: string,
+): Promise<TokenPair> {
+  const res = await fetch(`/auth/${provider}/callback?code=${encodeURIComponent(code)}`)
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error((data as { detail?: string }).detail ?? 'OAuth exchange failed')
+  }
+  return res.json() as Promise<TokenPair>
+}
+
+export async function fetchCurrentUser(): Promise<User> {
+  const res = await apiClient.get('/auth/me')
+  if (!res.ok) {
+    throw new Error('Failed to fetch current user')
+  }
+  return res.json() as Promise<User>
+}
+
+export async function refreshTokens(refreshToken: string): Promise<TokenPair> {
+  const res = await fetch('/auth/refresh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  })
+  if (!res.ok) {
+    throw new Error('Token refresh failed')
+  }
+  return res.json() as Promise<TokenPair>
+}

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useAuthStore } from '../stores/authStore'
+import type { TokenPair } from '../types/auth'
+
+const mockTokens: TokenPair = {
+  access_token: 'access-abc',
+  refresh_token: 'refresh-xyz',
+  token_type: 'bearer',
+}
+
+const newTokens: TokenPair = {
+  access_token: 'access-new',
+  refresh_token: 'refresh-xyz',
+  token_type: 'bearer',
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  useAuthStore.setState({ user: null, tokens: null, isAuthenticated: false })
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('apiClient', () => {
+  it('attaches Authorization header when tokens exist in store', async () => {
+    const { apiClient } = await import('./client')
+    useAuthStore.getState().setTokens(mockTokens)
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: '1' }), { status: 200 }),
+    )
+
+    await apiClient.get('/auth/me')
+
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const [, init] = fetchSpy.mock.calls[0]
+    const headers = new Headers(init?.headers)
+    expect(headers.get('Authorization')).toBe('Bearer access-abc')
+  })
+
+  it('does not attach Authorization header when no tokens in store', async () => {
+    const { apiClient } = await import('./client')
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    )
+
+    await apiClient.get('/some/public/endpoint')
+
+    const [, init] = fetchSpy.mock.calls[0]
+    const headers = new Headers(init?.headers)
+    expect(headers.get('Authorization')).toBeNull()
+  })
+
+  it('on 401 calls /auth/refresh, updates store, and retries original request', async () => {
+    const { apiClient } = await import('./client')
+    useAuthStore.getState().setTokens(mockTokens)
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('{}', { status: 401 })) // original fails
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(newTokens), { status: 200 }),
+      ) // refresh succeeds
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: '1' }), { status: 200 }),
+      ) // retry succeeds
+
+    await apiClient.get('/auth/me')
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3)
+    // Second call must be to /auth/refresh
+    const refreshCall = fetchSpy.mock.calls[1]
+    expect(refreshCall[0]).toContain('/auth/refresh')
+    // Store must have new tokens
+    expect(useAuthStore.getState().tokens?.access_token).toBe('access-new')
+  })
+
+  it('on 401 with failed refresh calls logout and does not retry', async () => {
+    const { apiClient } = await import('./client')
+    useAuthStore.getState().setTokens(mockTokens)
+
+    const logoutSpy = vi.spyOn(useAuthStore.getState(), 'logout')
+
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('{}', { status: 401 })) // original fails
+      .mockResolvedValueOnce(new Response('{}', { status: 401 })) // refresh fails
+
+    await apiClient.get('/auth/me')
+
+    expect(logoutSpy).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -35,6 +35,7 @@ async function request(
   method: string,
   url: string,
   body?: unknown,
+  signal?: AbortSignal,
 ): Promise<Response> {
   const tokens = useAuthStore.getState().tokens
 
@@ -45,7 +46,7 @@ async function request(
     headers['Authorization'] = `Bearer ${tokens.access_token}`
   }
 
-  const init: RequestInit = { method, headers }
+  const init: RequestInit = { method, headers, signal }
   if (body !== undefined) {
     init.body = JSON.stringify(body)
   }
@@ -59,7 +60,7 @@ async function request(
     // Retry with new access token
     return fetch(url, {
       ...init,
-      headers: { ...headers, Authorization: `Bearer ${newTokens.access_token}` },
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${newTokens.access_token}` },
     })
   }
 
@@ -67,6 +68,6 @@ async function request(
 }
 
 export const apiClient = {
-  get: (url: string): Promise<Response> => request('GET', url),
-  post: (url: string, body?: unknown): Promise<Response> => request('POST', url, body),
+  get: (url: string, signal?: AbortSignal): Promise<Response> => request('GET', url, undefined, signal),
+  post: (url: string, body?: unknown, signal?: AbortSignal): Promise<Response> => request('POST', url, body, signal),
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,72 @@
+import { useAuthStore } from '../stores/authStore'
+import type { TokenPair } from '../types/auth'
+
+let refreshPromise: Promise<TokenPair | null> | null = null
+
+async function attemptRefresh(): Promise<TokenPair | null> {
+  if (refreshPromise) return refreshPromise
+
+  refreshPromise = (async () => {
+    const tokens = useAuthStore.getState().tokens
+    if (!tokens) return null
+
+    const res = await fetch('/auth/refresh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refresh_token: tokens.refresh_token }),
+    })
+
+    if (!res.ok) {
+      useAuthStore.getState().logout()
+      return null
+    }
+
+    const newTokens: TokenPair = await res.json()
+    useAuthStore.getState().setTokens(newTokens)
+    return newTokens
+  })().finally(() => {
+    refreshPromise = null
+  })
+
+  return refreshPromise
+}
+
+async function request(
+  method: string,
+  url: string,
+  body?: unknown,
+): Promise<Response> {
+  const tokens = useAuthStore.getState().tokens
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  if (tokens) {
+    headers['Authorization'] = `Bearer ${tokens.access_token}`
+  }
+
+  const init: RequestInit = { method, headers }
+  if (body !== undefined) {
+    init.body = JSON.stringify(body)
+  }
+
+  const res = await fetch(url, init)
+
+  if (res.status === 401 && tokens) {
+    const newTokens = await attemptRefresh()
+    if (!newTokens) return res
+
+    // Retry with new access token
+    return fetch(url, {
+      ...init,
+      headers: { ...headers, Authorization: `Bearer ${newTokens.access_token}` },
+    })
+  }
+
+  return res
+}
+
+export const apiClient = {
+  get: (url: string): Promise<Response> => request('GET', url),
+  post: (url: string, body?: unknown): Promise<Response> => request('POST', url, body),
+}

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import ProtectedRoute from './ProtectedRoute'
+import { useAuthStore } from '../stores/authStore'
+import type { TokenPair, User } from '../types/auth'
+
+const future = { v7_startTransition: true, v7_relativeSplatPath: true } as const
+
+const mockTokens: TokenPair = {
+  access_token: 'access-abc',
+  refresh_token: 'refresh-xyz',
+  token_type: 'bearer',
+}
+
+const mockUser: User = {
+  id: 'usr-1',
+  email: 'alice@example.com',
+  name: 'Alice',
+  settings_json: {},
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+function renderProtected(initialPath = '/dashboard'): void {
+  render(
+    <MemoryRouter initialEntries={[initialPath]} future={future}>
+      <Routes>
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <div data-testid="protected-content" />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="/login" element={<div data-testid="page-login" />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  useAuthStore.setState({ user: null, tokens: null, isAuthenticated: false })
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ProtectedRoute', () => {
+  it('redirects to /login when not authenticated', () => {
+    renderProtected()
+    expect(screen.getByTestId('page-login')).toBeInTheDocument()
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument()
+  })
+
+  it('renders children when authenticated', () => {
+    useAuthStore.setState({ user: mockUser, tokens: mockTokens, isAuthenticated: true })
+    renderProtected()
+    expect(screen.getByTestId('protected-content')).toBeInTheDocument()
+    expect(screen.queryByTestId('page-login')).not.toBeInTheDocument()
+  })
+
+  it('fetches /auth/me when tokens exist but user is null', async () => {
+    useAuthStore.setState({ user: null, tokens: mockTokens, isAuthenticated: true })
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(mockUser), { status: 200 }),
+    )
+
+    renderProtected()
+
+    await waitFor(() =>
+      expect(useAuthStore.getState().user).toEqual(mockUser),
+    )
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    expect(fetchSpy.mock.calls[0][0]).toContain('/auth/me')
+  })
+
+  it('logs out and redirects when /auth/me fetch fails', async () => {
+    useAuthStore.setState({ user: null, tokens: mockTokens, isAuthenticated: true })
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('{}', { status: 401 }),
+    )
+
+    renderProtected()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('page-login')).toBeInTheDocument(),
+    )
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+  })
+})

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -106,4 +106,20 @@ describe('ProtectedRoute', () => {
     )
     expect(useAuthStore.getState().isAuthenticated).toBe(false)
   })
+
+  it('shows error message and keeps session when /auth/me returns 5xx', async () => {
+    useAuthStore.setState({ user: null, tokens: mockTokens, isAuthenticated: true })
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('{}', { status: 503 }),
+    )
+
+    renderProtected()
+
+    await waitFor(() =>
+      expect(screen.getByTestId('auth-error')).toBeInTheDocument(),
+    )
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+    expect(useAuthStore.getState().tokens).toEqual(mockTokens)
+  })
 })

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -79,6 +79,14 @@ describe('ProtectedRoute', () => {
     expect(fetchSpy.mock.calls[0][0]).toContain('/auth/me')
   })
 
+  it('shows loading state instead of children when tokens exist but user is null', () => {
+    useAuthStore.setState({ user: null, tokens: mockTokens, isAuthenticated: true })
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {})) // never resolves
+    renderProtected()
+    expect(screen.getByTestId('auth-loading')).toBeInTheDocument()
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument()
+  })
+
   it('logs out and redirects when /auth/me fetch fails', async () => {
     useAuthStore.setState({ user: null, tokens: mockTokens, isAuthenticated: true })
 

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -41,7 +41,12 @@ function renderProtected(initialPath = '/dashboard'): void {
 
 beforeEach(() => {
   localStorage.clear()
-  useAuthStore.setState({ user: null, tokens: null, isAuthenticated: false })
+  useAuthStore.setState({
+    user: null,
+    tokens: null,
+    isAuthenticated: false,
+    isUserLoading: false,
+  })
   vi.restoreAllMocks()
 })
 
@@ -90,9 +95,9 @@ describe('ProtectedRoute', () => {
   it('logs out and redirects when /auth/me fetch fails', async () => {
     useAuthStore.setState({ user: null, tokens: mockTokens, isAuthenticated: true })
 
-    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-      new Response('{}', { status: 401 }),
-    )
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('{}', { status: 401 })) // /auth/me
+      .mockResolvedValueOnce(new Response('{}', { status: 401 })) // /auth/refresh
 
     renderProtected()
 

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -19,7 +19,10 @@ function ProtectedRoute({ children }: ProtectedRouteProps): React.JSX.Element {
       fetchCurrentUser()
         .then(setUser)
         .catch((err: unknown) => {
-          if (err instanceof AuthError && (err.status === 401 || err.status === 403)) {
+          if (err instanceof AuthError && err.status >= 500) {
+            // Server error — don't destroy the session, just stop loading
+            setUserLoading(false)
+          } else {
             logout()
             navigate('/login', { replace: true })
           }

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -8,11 +8,13 @@ interface ProtectedRouteProps {
 }
 
 function ProtectedRoute({ children }: ProtectedRouteProps): React.JSX.Element {
-  const { isAuthenticated, tokens, user, setUser, logout } = useAuthStore()
+  const { isAuthenticated, tokens, user, setUser, setUserLoading, isUserLoading, logout } =
+    useAuthStore()
   const navigate = useNavigate()
 
   useEffect(() => {
-    if (tokens && !user) {
+    if (tokens && !user && !isUserLoading) {
+      setUserLoading(true)
       fetchCurrentUser()
         .then(setUser)
         .catch(() => {
@@ -20,10 +22,14 @@ function ProtectedRoute({ children }: ProtectedRouteProps): React.JSX.Element {
           navigate('/login', { replace: true })
         })
     }
-  }, [tokens, user, setUser, logout, navigate])
+  }, [tokens, user, isUserLoading, setUser, setUserLoading, logout, navigate])
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />
+  }
+
+  if (tokens && !user) {
+    return <div data-testid="auth-loading" />
   }
 
   return <>{children}</>

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -20,7 +20,7 @@ function ProtectedRoute({ children }: ProtectedRouteProps): React.JSX.Element {
           navigate('/login', { replace: true })
         })
     }
-  }, [tokens, user])
+  }, [tokens, user, setUser, logout, navigate])
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Navigate, useNavigate } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore'
 import { fetchCurrentUser, AuthError } from '../api/auth'
@@ -11,6 +11,7 @@ function ProtectedRoute({ children }: ProtectedRouteProps): React.JSX.Element {
   const { isAuthenticated, tokens, user, setUser, setUserLoading, logout } = useAuthStore()
   const navigate = useNavigate()
   const fetchingRef = useRef(false)
+  const [fetchError, setFetchError] = useState<string | null>(null)
 
   useEffect(() => {
     if (tokens && !user && !fetchingRef.current) {
@@ -20,8 +21,9 @@ function ProtectedRoute({ children }: ProtectedRouteProps): React.JSX.Element {
         .then(setUser)
         .catch((err: unknown) => {
           if (err instanceof AuthError && err.status >= 500) {
-            // Server error — don't destroy the session, just stop loading
+            // Server error — don't destroy the session, show retry message
             setUserLoading(false)
+            setFetchError('Unable to reach the server. Please refresh the page.')
           } else {
             logout()
             navigate('/login', { replace: true })
@@ -41,6 +43,14 @@ function ProtectedRoute({ children }: ProtectedRouteProps): React.JSX.Element {
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />
+  }
+
+  if (fetchError) {
+    return (
+      <main data-testid="auth-error" style={{ padding: '2rem', textAlign: 'center' }}>
+        <p style={{ color: 'var(--text-primary)' }}>{fetchError}</p>
+      </main>
+    )
   }
 
   if (tokens && !user) {

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+import { Navigate, useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../stores/authStore'
+import { fetchCurrentUser } from '../api/auth'
+
+interface ProtectedRouteProps {
+  children: React.ReactNode
+}
+
+function ProtectedRoute({ children }: ProtectedRouteProps): React.JSX.Element {
+  const { isAuthenticated, tokens, user, setUser, logout } = useAuthStore()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (tokens && !user) {
+      fetchCurrentUser()
+        .then(setUser)
+        .catch(() => {
+          logout()
+          navigate('/login', { replace: true })
+        })
+    }
+  }, [tokens, user])
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />
+  }
+
+  return <>{children}</>
+}
+
+export default ProtectedRoute

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,28 +1,40 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Navigate, useNavigate } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore'
-import { fetchCurrentUser } from '../api/auth'
+import { fetchCurrentUser, AuthError } from '../api/auth'
 
 interface ProtectedRouteProps {
   children: React.ReactNode
 }
 
 function ProtectedRoute({ children }: ProtectedRouteProps): React.JSX.Element {
-  const { isAuthenticated, tokens, user, setUser, setUserLoading, isUserLoading, logout } =
-    useAuthStore()
+  const { isAuthenticated, tokens, user, setUser, setUserLoading, logout } = useAuthStore()
   const navigate = useNavigate()
+  const fetchingRef = useRef(false)
 
   useEffect(() => {
-    if (tokens && !user && !isUserLoading) {
+    if (tokens && !user && !fetchingRef.current) {
+      fetchingRef.current = true
       setUserLoading(true)
       fetchCurrentUser()
         .then(setUser)
-        .catch(() => {
-          logout()
-          navigate('/login', { replace: true })
+        .catch((err: unknown) => {
+          if (err instanceof AuthError && (err.status === 401 || err.status === 403)) {
+            logout()
+            navigate('/login', { replace: true })
+          }
+        })
+        .finally(() => {
+          fetchingRef.current = false
         })
     }
-  }, [tokens, user, isUserLoading, setUser, setUserLoading, logout, navigate])
+    return () => {
+      if (fetchingRef.current) {
+        fetchingRef.current = false
+        setUserLoading(false)
+      }
+    }
+  }, [tokens, user, setUser, setUserLoading, logout, navigate])
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,7 +3,10 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from './api/queryClient'
+import { useAuthStore } from './stores/authStore'
 import App from './App'
+
+useAuthStore.getState().hydrate()
 
 const rootEl = document.getElementById('root')
 if (!rootEl) throw new Error('Root element not found')

--- a/frontend/src/pages/LoginPage.css
+++ b/frontend/src/pages/LoginPage.css
@@ -1,0 +1,74 @@
+.login-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background-color: var(--bg);
+}
+
+.login-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 2.5rem 2rem;
+  border: 1px solid #2a2a2e;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 360px;
+}
+
+.login-title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: -0.5px;
+}
+
+.login-subtitle {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  margin-top: -0.75rem;
+}
+
+.login-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.login-btn {
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s;
+  width: 100%;
+}
+
+.login-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.login-btn--google {
+  background-color: #4285f4;
+  color: #fff;
+}
+
+.login-btn--google:hover:not(:disabled) {
+  background-color: #3367d6;
+}
+
+.login-btn--github {
+  background-color: #24292e;
+  color: #fff;
+  border: 1px solid #444;
+}
+
+.login-btn--github:hover:not(:disabled) {
+  background-color: #1b1f23;
+}

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import LoginPage from './LoginPage'
+
+const future = { v7_startTransition: true, v7_relativeSplatPath: true } as const
+
+function renderLogin(): void {
+  render(
+    <MemoryRouter future={future}>
+      <LoginPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('LoginPage', () => {
+  let assignSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    assignSpy = vi.fn()
+    vi.stubGlobal('location', { ...window.location, assign: assignSpy })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders a Google sign-in button', () => {
+    renderLogin()
+    expect(screen.getByTestId('btn-google')).toBeInTheDocument()
+  })
+
+  it('renders a GitHub sign-in button', () => {
+    renderLogin()
+    expect(screen.getByTestId('btn-github')).toBeInTheDocument()
+  })
+
+  it('renders the page container', () => {
+    renderLogin()
+    expect(screen.getByTestId('page-login')).toBeInTheDocument()
+  })
+
+  it('Google button navigates to Google OAuth authorize URL', async () => {
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'google-client-123')
+    renderLogin()
+    await userEvent.click(screen.getByTestId('btn-google'))
+    expect(assignSpy).toHaveBeenCalledOnce()
+    const url = new URL(assignSpy.mock.calls[0][0])
+    expect(url.hostname).toBe('accounts.google.com')
+    expect(url.searchParams.get('client_id')).toBe('google-client-123')
+    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.searchParams.get('redirect_uri')).toContain('/auth/google/callback')
+    expect(url.searchParams.get('scope')).toMatch(/email/)
+  })
+
+  it('GitHub button navigates to GitHub OAuth authorize URL', async () => {
+    vi.stubEnv('VITE_GITHUB_CLIENT_ID', 'gh-client-456')
+    renderLogin()
+    await userEvent.click(screen.getByTestId('btn-github'))
+    expect(assignSpy).toHaveBeenCalledOnce()
+    const url = new URL(assignSpy.mock.calls[0][0])
+    expect(url.hostname).toBe('github.com')
+    expect(url.searchParams.get('client_id')).toBe('gh-client-456')
+    expect(url.searchParams.get('redirect_uri')).toContain('/auth/github/callback')
+  })
+
+  it('Google button is disabled when VITE_GOOGLE_CLIENT_ID is not set', () => {
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', '')
+    renderLogin()
+    expect(screen.getByTestId('btn-google')).toBeDisabled()
+  })
+
+  it('GitHub button is disabled when VITE_GITHUB_CLIENT_ID is not set', () => {
+    vi.stubEnv('VITE_GITHUB_CLIENT_ID', '')
+    renderLogin()
+    expect(screen.getByTestId('btn-github')).toBeDisabled()
+  })
+})

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -65,6 +65,33 @@ describe('LoginPage', () => {
     expect(url.searchParams.get('redirect_uri')).toContain('/auth/github/callback')
   })
 
+  it('stores a state token in sessionStorage when Google button is clicked', async () => {
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'google-client-123')
+    renderLogin()
+    await userEvent.click(screen.getByTestId('btn-google'))
+    expect(sessionStorage.getItem('oauth_state')).not.toBeNull()
+  })
+
+  it('includes the sessionStorage state in the Google OAuth URL', async () => {
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'google-client-123')
+    renderLogin()
+    await userEvent.click(screen.getByTestId('btn-google'))
+    const url = new URL(assignSpy.mock.calls[0][0])
+    const storedState = sessionStorage.getItem('oauth_state')
+    expect(url.searchParams.get('state')).not.toBeNull()
+    expect(url.searchParams.get('state')).toBe(storedState)
+  })
+
+  it('includes the sessionStorage state in the GitHub OAuth URL', async () => {
+    vi.stubEnv('VITE_GITHUB_CLIENT_ID', 'gh-client-456')
+    renderLogin()
+    await userEvent.click(screen.getByTestId('btn-github'))
+    const url = new URL(assignSpy.mock.calls[0][0])
+    const storedState = sessionStorage.getItem('oauth_state')
+    expect(url.searchParams.get('state')).not.toBeNull()
+    expect(url.searchParams.get('state')).toBe(storedState)
+  })
+
   it('Google button is disabled when VITE_GOOGLE_CLIENT_ID is not set', () => {
     vi.stubEnv('VITE_GOOGLE_CLIENT_ID', '')
     renderLogin()

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,44 @@
+import { buildOAuthUrl } from '../utils/oauth'
+import './LoginPage.css'
+
 function LoginPage(): React.JSX.Element {
-  return <main data-testid="page-login">Login</main>
+  const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined
+  const githubClientId = import.meta.env.VITE_GITHUB_CLIENT_ID as string | undefined
+
+  function handleGoogle(): void {
+    window.location.assign(buildOAuthUrl('google'))
+  }
+
+  function handleGitHub(): void {
+    window.location.assign(buildOAuthUrl('github'))
+  }
+
+  return (
+    <main data-testid="page-login" className="login-page">
+      <div className="login-card">
+        <h1 className="login-title">FlowDay</h1>
+        <p className="login-subtitle">Sign in to continue</p>
+        <div className="login-buttons">
+          <button
+            data-testid="btn-google"
+            className="login-btn login-btn--google"
+            onClick={handleGoogle}
+            disabled={!googleClientId}
+          >
+            Sign in with Google
+          </button>
+          <button
+            data-testid="btn-github"
+            className="login-btn login-btn--github"
+            onClick={handleGitHub}
+            disabled={!githubClientId}
+          >
+            Sign in with GitHub
+          </button>
+        </div>
+      </div>
+    </main>
+  )
 }
 
 export default LoginPage

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,16 +1,27 @@
+import { useState } from 'react'
 import { buildOAuthUrl } from '../utils/oauth'
 import './LoginPage.css'
 
 function LoginPage(): React.JSX.Element {
+  const [error, setError] = useState<string | null>(null)
+
   const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined
   const githubClientId = import.meta.env.VITE_GITHUB_CLIENT_ID as string | undefined
 
   function handleGoogle(): void {
-    window.location.assign(buildOAuthUrl('google'))
+    try {
+      window.location.assign(buildOAuthUrl('google'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to build Google OAuth URL.')
+    }
   }
 
   function handleGitHub(): void {
-    window.location.assign(buildOAuthUrl('github'))
+    try {
+      window.location.assign(buildOAuthUrl('github'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to build GitHub OAuth URL.')
+    }
   }
 
   return (
@@ -18,6 +29,11 @@ function LoginPage(): React.JSX.Element {
       <div className="login-card">
         <h1 className="login-title">FlowDay</h1>
         <p className="login-subtitle">Sign in to continue</p>
+        {error && (
+          <p data-testid="login-error" style={{ color: 'var(--text-primary)', marginBottom: '1rem' }}>
+            {error}
+          </p>
+        )}
         <div className="login-buttons">
           <button
             data-testid="btn-google"

--- a/frontend/src/pages/OAuthCallbackPage.test.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.test.tsx
@@ -68,9 +68,9 @@ describe('OAuthCallbackPage', () => {
     await waitFor(() =>
       expect(fetchSpy.mock.calls[0][0]).toContain('/auth/google/callback'),
     )
-    expect(new URL(fetchSpy.mock.calls[0][0] as string, 'http://x').searchParams.get('code')).toBe(
-      'code-abc',
-    )
+    const requestInit = fetchSpy.mock.calls[0][1] as RequestInit
+    expect(requestInit.method).toBe('POST')
+    expect(JSON.parse(requestInit.body as string)).toEqual({ code: 'code-abc' })
   })
 
   it('stores tokens and user in authStore on success', async () => {

--- a/frontend/src/pages/OAuthCallbackPage.test.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.test.tsx
@@ -52,12 +52,14 @@ afterEach(() => {
 
 describe('OAuthCallbackPage', () => {
   it('shows loading state while exchanging code', () => {
+    sessionStorage.setItem('oauth_state', 'state-token')
     vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {})) // never resolves
-    renderCallback('google', 'code-123')
+    renderCallback('google', 'code-123', 'state-token')
     expect(screen.getByTestId('oauth-loading')).toBeInTheDocument()
   })
 
   it('calls the backend callback endpoint with the code for google', async () => {
+    sessionStorage.setItem('oauth_state', 'state-token')
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(
@@ -67,17 +69,16 @@ describe('OAuthCallbackPage', () => {
         new Response(JSON.stringify(mockUser), { status: 200 }),
       )
 
-    renderCallback('google', 'code-abc')
+    renderCallback('google', 'code-abc', 'state-token')
 
     await waitFor(() =>
       expect(fetchSpy.mock.calls[0][0]).toContain('/auth/google/callback'),
     )
-    const requestInit = fetchSpy.mock.calls[0][1] as RequestInit
-    expect(requestInit.method).toBe('POST')
-    expect(JSON.parse(requestInit.body as string)).toEqual({ code: 'code-abc' })
+    expect((fetchSpy.mock.calls[0][0] as string)).toContain('code=code-abc')
   })
 
   it('stores tokens and user in authStore on success', async () => {
+    sessionStorage.setItem('oauth_state', 'state-token')
     vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(
         new Response(JSON.stringify(mockTokens), { status: 200 }),
@@ -86,7 +87,7 @@ describe('OAuthCallbackPage', () => {
         new Response(JSON.stringify(mockUser), { status: 200 }),
       )
 
-    renderCallback('google', 'code-abc')
+    renderCallback('google', 'code-abc', 'state-token')
 
     await waitFor(() => expect(useAuthStore.getState().isAuthenticated).toBe(true))
     expect(useAuthStore.getState().tokens).toEqual(mockTokens)
@@ -94,6 +95,7 @@ describe('OAuthCallbackPage', () => {
   })
 
   it('navigates to /dashboard on success', async () => {
+    sessionStorage.setItem('oauth_state', 'state-token')
     vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(
         new Response(JSON.stringify(mockTokens), { status: 200 }),
@@ -102,7 +104,7 @@ describe('OAuthCallbackPage', () => {
         new Response(JSON.stringify(mockUser), { status: 200 }),
       )
 
-    renderCallback('google', 'code-abc')
+    renderCallback('google', 'code-abc', 'state-token')
 
     await waitFor(() =>
       expect(screen.getByTestId('page-dashboard')).toBeInTheDocument(),
@@ -110,11 +112,12 @@ describe('OAuthCallbackPage', () => {
   })
 
   it('shows an error message when code exchange fails', async () => {
+    sessionStorage.setItem('oauth_state', 'state-token')
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(JSON.stringify({ detail: 'Invalid code' }), { status: 401 }),
     )
 
-    renderCallback('google', 'bad-code')
+    renderCallback('google', 'bad-code', 'state-token')
 
     await waitFor(() =>
       expect(screen.getByTestId('oauth-error')).toBeInTheDocument(),
@@ -122,11 +125,12 @@ describe('OAuthCallbackPage', () => {
   })
 
   it('shows a back-to-login link on error', async () => {
+    sessionStorage.setItem('oauth_state', 'state-token')
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response('{}', { status: 500 }),
     )
 
-    renderCallback('github', 'bad-code')
+    renderCallback('github', 'bad-code', 'state-token')
 
     await waitFor(() =>
       expect(screen.getByTestId('link-back-to-login')).toBeInTheDocument(),

--- a/frontend/src/pages/OAuthCallbackPage.test.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.test.tsx
@@ -21,10 +21,13 @@ const mockUser: User = {
   created_at: '2026-01-01T00:00:00Z',
 }
 
-function renderCallback(provider: string, code: string): void {
+function renderCallback(provider: string, code: string, state?: string): void {
+  const search = state
+    ? `?code=${code}&state=${state}`
+    : `?code=${code}`
   render(
     <MemoryRouter
-      initialEntries={[`/auth/${provider}/callback?code=${code}`]}
+      initialEntries={[`/auth/${provider}/callback${search}`]}
       future={future}
     >
       <Routes>
@@ -38,6 +41,7 @@ function renderCallback(provider: string, code: string): void {
 
 beforeEach(() => {
   localStorage.clear()
+  sessionStorage.clear()
   useAuthStore.setState({ user: null, tokens: null, isAuthenticated: false })
   vi.restoreAllMocks()
 })
@@ -127,5 +131,47 @@ describe('OAuthCallbackPage', () => {
     await waitFor(() =>
       expect(screen.getByTestId('link-back-to-login')).toBeInTheDocument(),
     )
+  })
+
+  it('shows an error when state param is missing from callback URL', async () => {
+    sessionStorage.setItem('oauth_state', 'expected-state')
+    // mock fetch to succeed so the test validates state, not network
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockTokens), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockUser), { status: 200 }))
+    // no state in URL
+    renderCallback('google', 'code-abc')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('oauth-error')).toBeInTheDocument(),
+    )
+  })
+
+  it('shows an error when state param does not match sessionStorage', async () => {
+    sessionStorage.setItem('oauth_state', 'expected-state')
+    // mock fetch to succeed so the test validates state, not network
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockTokens), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockUser), { status: 200 }))
+    renderCallback('google', 'code-abc', 'wrong-state')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('oauth-error')).toBeInTheDocument(),
+    )
+  })
+
+  it('clears oauth_state from sessionStorage after successful validation', async () => {
+    const state = 'valid-state-token'
+    sessionStorage.setItem('oauth_state', state)
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockTokens), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockUser), { status: 200 }))
+
+    renderCallback('google', 'code-abc', state)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('page-dashboard')).toBeInTheDocument(),
+    )
+    expect(sessionStorage.getItem('oauth_state')).toBeNull()
   })
 })

--- a/frontend/src/pages/OAuthCallbackPage.test.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import OAuthCallbackPage from './OAuthCallbackPage'
+import { useAuthStore } from '../stores/authStore'
+import type { TokenPair, User } from '../types/auth'
+
+const future = { v7_startTransition: true, v7_relativeSplatPath: true } as const
+
+const mockTokens: TokenPair = {
+  access_token: 'access-abc',
+  refresh_token: 'refresh-xyz',
+  token_type: 'bearer',
+}
+
+const mockUser: User = {
+  id: 'usr-1',
+  email: 'alice@example.com',
+  name: 'Alice',
+  settings_json: {},
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+function renderCallback(provider: string, code: string): void {
+  render(
+    <MemoryRouter
+      initialEntries={[`/auth/${provider}/callback?code=${code}`]}
+      future={future}
+    >
+      <Routes>
+        <Route path="/auth/:provider/callback" element={<OAuthCallbackPage />} />
+        <Route path="/dashboard" element={<div data-testid="page-dashboard" />} />
+        <Route path="/login" element={<div data-testid="page-login" />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  useAuthStore.setState({ user: null, tokens: null, isAuthenticated: false })
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('OAuthCallbackPage', () => {
+  it('shows loading state while exchanging code', () => {
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {})) // never resolves
+    renderCallback('google', 'code-123')
+    expect(screen.getByTestId('oauth-loading')).toBeInTheDocument()
+  })
+
+  it('calls the backend callback endpoint with the code for google', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockTokens), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockUser), { status: 200 }),
+      )
+
+    renderCallback('google', 'code-abc')
+
+    await waitFor(() =>
+      expect(fetchSpy.mock.calls[0][0]).toContain('/auth/google/callback'),
+    )
+    expect(new URL(fetchSpy.mock.calls[0][0] as string, 'http://x').searchParams.get('code')).toBe(
+      'code-abc',
+    )
+  })
+
+  it('stores tokens and user in authStore on success', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockTokens), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockUser), { status: 200 }),
+      )
+
+    renderCallback('google', 'code-abc')
+
+    await waitFor(() => expect(useAuthStore.getState().isAuthenticated).toBe(true))
+    expect(useAuthStore.getState().tokens).toEqual(mockTokens)
+    expect(useAuthStore.getState().user).toEqual(mockUser)
+  })
+
+  it('navigates to /dashboard on success', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockTokens), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockUser), { status: 200 }),
+      )
+
+    renderCallback('google', 'code-abc')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('page-dashboard')).toBeInTheDocument(),
+    )
+  })
+
+  it('shows an error message when code exchange fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: 'Invalid code' }), { status: 401 }),
+    )
+
+    renderCallback('google', 'bad-code')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('oauth-error')).toBeInTheDocument(),
+    )
+  })
+
+  it('shows a back-to-login link on error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('{}', { status: 500 }),
+    )
+
+    renderCallback('github', 'bad-code')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('link-back-to-login')).toBeInTheDocument(),
+    )
+  })
+})

--- a/frontend/src/pages/OAuthCallbackPage.test.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.test.tsx
@@ -74,7 +74,9 @@ describe('OAuthCallbackPage', () => {
     await waitFor(() =>
       expect(fetchSpy.mock.calls[0][0]).toContain('/auth/google/callback'),
     )
-    expect((fetchSpy.mock.calls[0][0] as string)).toContain('code=code-abc')
+    const requestInit = fetchSpy.mock.calls[0][1] as RequestInit
+    expect(requestInit.method).toBe('POST')
+    expect(JSON.parse(requestInit.body as string)).toEqual({ code: 'code-abc' })
   })
 
   it('stores tokens and user in authStore on success', async () => {

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -35,7 +35,7 @@ function OAuthCallbackPage(): React.JSX.Element {
         const message = err instanceof Error ? err.message : 'Authentication failed.'
         setError(message)
       })
-  }, []) // run once on mount
+  }, [navigate, provider, searchParams, setTokens, setUser])
 
   if (error) {
     return (

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+import { useParams, useSearchParams, useNavigate, Link } from 'react-router-dom'
+import { exchangeOAuthCode, fetchCurrentUser } from '../api/auth'
+import { useAuthStore } from '../stores/authStore'
+
+function OAuthCallbackPage(): React.JSX.Element {
+  const { provider } = useParams<{ provider: string }>()
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const { setTokens, setUser } = useAuthStore()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const code = searchParams.get('code')
+    if (!code || !provider) {
+      setError('Missing OAuth code or provider.')
+      return
+    }
+
+    if (provider !== 'google' && provider !== 'github') {
+      setError(`Unknown provider: ${provider}`)
+      return
+    }
+
+    exchangeOAuthCode(provider, code)
+      .then((tokens) => {
+        setTokens(tokens)
+        return fetchCurrentUser()
+      })
+      .then((user) => {
+        setUser(user)
+        navigate('/dashboard', { replace: true })
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Authentication failed.'
+        setError(message)
+      })
+  }, []) // run once on mount
+
+  if (error) {
+    return (
+      <main data-testid="oauth-error" style={{ padding: '2rem', textAlign: 'center' }}>
+        <p style={{ color: 'var(--text-primary)', marginBottom: '1rem' }}>{error}</p>
+        <Link data-testid="link-back-to-login" to="/login">
+          Back to Login
+        </Link>
+      </main>
+    )
+  }
+
+  return (
+    <main data-testid="oauth-loading" style={{ padding: '2rem', textAlign: 'center' }}>
+      <p style={{ color: 'var(--text-muted)' }}>Signing you in…</p>
+    </main>
+  )
+}
+
+export default OAuthCallbackPage

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -11,6 +11,8 @@ function OAuthCallbackPage(): React.JSX.Element {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    const controller = new AbortController()
+
     const code = searchParams.get('code')
     if (!code || !provider) {
       setError('Missing OAuth code or provider.')
@@ -24,17 +26,24 @@ function OAuthCallbackPage(): React.JSX.Element {
 
     exchangeOAuthCode(provider, code)
       .then((tokens) => {
+        if (controller.signal.aborted) return
         setTokens(tokens)
         return fetchCurrentUser()
       })
       .then((user) => {
+        if (controller.signal.aborted || !user) return
         setUser(user)
         navigate('/dashboard', { replace: true })
       })
       .catch((err: unknown) => {
+        if (controller.signal.aborted) return
         const message = err instanceof Error ? err.message : 'Authentication failed.'
         setError(message)
       })
+
+    return () => {
+      controller.abort()
+    }
   }, [navigate, provider, searchParams, setTokens, setUser])
 
   if (error) {

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -12,6 +12,7 @@ function OAuthCallbackPage(): React.JSX.Element {
 
   useEffect(() => {
     const controller = new AbortController()
+    const { signal } = controller
 
     const code = searchParams.get('code')
     if (!code || !provider) {
@@ -24,19 +25,27 @@ function OAuthCallbackPage(): React.JSX.Element {
       return
     }
 
-    exchangeOAuthCode(provider, code)
+    const urlState = searchParams.get('state')
+    const storedState = sessionStorage.getItem('oauth_state')
+    if (!urlState || !storedState || urlState !== storedState) {
+      setError('Invalid state parameter. Please try signing in again.')
+      return
+    }
+    sessionStorage.removeItem('oauth_state')
+
+    exchangeOAuthCode(provider, code, signal)
       .then((tokens) => {
-        if (controller.signal.aborted) return
+        if (signal.aborted) return
         setTokens(tokens)
-        return fetchCurrentUser()
+        return fetchCurrentUser(signal)
       })
       .then((user) => {
-        if (controller.signal.aborted || !user) return
+        if (signal.aborted || !user) return
         setUser(user)
         navigate('/dashboard', { replace: true })
       })
       .catch((err: unknown) => {
-        if (controller.signal.aborted) return
+        if (signal.aborted) return
         const message = err instanceof Error ? err.message : 'Authentication failed.'
         setError(message)
       })

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -1,33 +1,105 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useAuthStore } from './authStore'
+import type { TokenPair, User } from '../types/auth'
+
+const mockTokens: TokenPair = {
+  access_token: 'access-abc',
+  refresh_token: 'refresh-xyz',
+  token_type: 'bearer',
+}
+
+const mockUser: User = {
+  id: 'usr-1',
+  email: 'alice@example.com',
+  name: 'Alice',
+  settings_json: {},
+  created_at: '2026-01-01T00:00:00Z',
+}
 
 beforeEach(() => {
-  useAuthStore.setState({ user: null, token: null, isAuthenticated: false })
+  localStorage.clear()
+  useAuthStore.setState({ user: null, tokens: null, isAuthenticated: false })
 })
 
-describe('authStore', () => {
+describe('authStore — initial state', () => {
   it('has correct initial state', () => {
     const state = useAuthStore.getState()
     expect(state.user).toBeNull()
-    expect(state.token).toBeNull()
+    expect(state.tokens).toBeNull()
     expect(state.isAuthenticated).toBe(false)
   })
+})
 
-  it('login sets user token and isAuthenticated', () => {
-    const { login } = useAuthStore.getState()
-    login({ id: '1', email: 'a@b.com', name: 'Alice' }, 'tok123')
+describe('authStore — setTokens', () => {
+  it('updates tokens in state and sets isAuthenticated', () => {
+    useAuthStore.getState().setTokens(mockTokens)
     const state = useAuthStore.getState()
-    expect(state.user).toEqual({ id: '1', email: 'a@b.com', name: 'Alice' })
-    expect(state.token).toBe('tok123')
+    expect(state.tokens).toEqual(mockTokens)
     expect(state.isAuthenticated).toBe(true)
   })
 
-  it('logout resets state to initial', () => {
-    useAuthStore.getState().login({ id: '1', email: 'a@b.com', name: 'Alice' }, 'tok123')
+  it('persists tokens to localStorage', () => {
+    useAuthStore.getState().setTokens(mockTokens)
+    const stored = localStorage.getItem('flowday_tokens')
+    expect(stored).not.toBeNull()
+    expect(JSON.parse(stored!)).toEqual(mockTokens)
+  })
+})
+
+describe('authStore — setUser', () => {
+  it('updates user in state', () => {
+    useAuthStore.getState().setUser(mockUser)
+    expect(useAuthStore.getState().user).toEqual(mockUser)
+  })
+})
+
+describe('authStore — logout', () => {
+  it('resets all state to initial values', () => {
+    useAuthStore.getState().setTokens(mockTokens)
+    useAuthStore.getState().setUser(mockUser)
     useAuthStore.getState().logout()
     const state = useAuthStore.getState()
     expect(state.user).toBeNull()
-    expect(state.token).toBeNull()
+    expect(state.tokens).toBeNull()
     expect(state.isAuthenticated).toBe(false)
+  })
+
+  it('removes tokens from localStorage', () => {
+    useAuthStore.getState().setTokens(mockTokens)
+    useAuthStore.getState().logout()
+    expect(localStorage.getItem('flowday_tokens')).toBeNull()
+  })
+})
+
+describe('authStore — hydrate', () => {
+  it('restores tokens from localStorage and sets isAuthenticated', () => {
+    localStorage.setItem('flowday_tokens', JSON.stringify(mockTokens))
+    useAuthStore.getState().hydrate()
+    const state = useAuthStore.getState()
+    expect(state.tokens).toEqual(mockTokens)
+    expect(state.isAuthenticated).toBe(true)
+  })
+
+  it('does nothing when localStorage has no tokens', () => {
+    useAuthStore.getState().hydrate()
+    const state = useAuthStore.getState()
+    expect(state.tokens).toBeNull()
+    expect(state.isAuthenticated).toBe(false)
+  })
+
+  it('does nothing when localStorage has invalid JSON', () => {
+    localStorage.setItem('flowday_tokens', 'not-json')
+    useAuthStore.getState().hydrate()
+    expect(useAuthStore.getState().tokens).toBeNull()
+  })
+})
+
+describe('authStore — login (convenience)', () => {
+  it('sets user, tokens, and isAuthenticated in one call', () => {
+    useAuthStore.getState().login(mockUser, mockTokens)
+    const state = useAuthStore.getState()
+    expect(state.user).toEqual(mockUser)
+    expect(state.tokens).toEqual(mockTokens)
+    expect(state.isAuthenticated).toBe(true)
   })
 })

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -92,6 +92,26 @@ describe('authStore — hydrate', () => {
     useAuthStore.getState().hydrate()
     expect(useAuthStore.getState().tokens).toBeNull()
   })
+
+  it('does not set isAuthenticated when stored object is missing access_token', () => {
+    localStorage.setItem('flowday_tokens', JSON.stringify({ refresh_token: 'r' }))
+    useAuthStore.getState().hydrate()
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+    expect(useAuthStore.getState().tokens).toBeNull()
+  })
+
+  it('does not set isAuthenticated when stored object is missing refresh_token', () => {
+    localStorage.setItem('flowday_tokens', JSON.stringify({ access_token: 'a' }))
+    useAuthStore.getState().hydrate()
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+    expect(useAuthStore.getState().tokens).toBeNull()
+  })
+
+  it('clears malformed token data from localStorage', () => {
+    localStorage.setItem('flowday_tokens', JSON.stringify({ access_token: '' }))
+    useAuthStore.getState().hydrate()
+    expect(localStorage.getItem('flowday_tokens')).toBeNull()
+  })
 })
 
 describe('authStore — login (convenience)', () => {

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { useAuthStore } from './authStore'
 import type { TokenPair, User } from '../types/auth'
 

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -57,7 +57,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       }
       set({ tokens, isAuthenticated: true })
     } catch {
-      // invalid JSON — leave state untouched
+      localStorage.removeItem(STORAGE_KEY)
     }
   },
 }))

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,23 +1,49 @@
 import { create } from 'zustand'
+import type { User, TokenPair } from '../types/auth'
 
-interface User {
-  id: string
-  email: string
-  name: string
-}
+const STORAGE_KEY = 'flowday_tokens'
 
 interface AuthState {
   user: User | null
-  token: string | null
+  tokens: TokenPair | null
   isAuthenticated: boolean
-  login: (user: User, token: string) => void
+  setTokens: (tokens: TokenPair) => void
+  setUser: (user: User) => void
+  login: (user: User, tokens: TokenPair) => void
   logout: () => void
+  hydrate: () => void
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
-  token: null,
+  tokens: null,
   isAuthenticated: false,
-  login: (user, token) => set({ user, token, isAuthenticated: true }),
-  logout: () => set({ user: null, token: null, isAuthenticated: false }),
+
+  setTokens: (tokens) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(tokens))
+    set({ tokens, isAuthenticated: true })
+  },
+
+  setUser: (user) => set({ user }),
+
+  login: (user, tokens) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(tokens))
+    set({ user, tokens, isAuthenticated: true })
+  },
+
+  logout: () => {
+    localStorage.removeItem(STORAGE_KEY)
+    set({ user: null, tokens: null, isAuthenticated: false })
+  },
+
+  hydrate: () => {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return
+    try {
+      const tokens: TokenPair = JSON.parse(raw)
+      set({ tokens, isAuthenticated: true })
+    } catch {
+      // invalid JSON — leave state untouched
+    }
+  },
 }))

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -7,33 +7,38 @@ interface AuthState {
   user: User | null
   tokens: TokenPair | null
   isAuthenticated: boolean
+  isUserLoading: boolean
   setTokens: (tokens: TokenPair) => void
   setUser: (user: User) => void
   login: (user: User, tokens: TokenPair) => void
   logout: () => void
   hydrate: () => void
+  setUserLoading: (loading: boolean) => void
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   tokens: null,
   isAuthenticated: false,
+  isUserLoading: false,
 
   setTokens: (tokens) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(tokens))
     set({ tokens, isAuthenticated: true })
   },
 
-  setUser: (user) => set({ user }),
+  setUser: (user) => set({ user, isUserLoading: false }),
+
+  setUserLoading: (loading) => set({ isUserLoading: loading }),
 
   login: (user, tokens) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(tokens))
-    set({ user, tokens, isAuthenticated: true })
+    set({ user, tokens, isAuthenticated: true, isUserLoading: false })
   },
 
   logout: () => {
     localStorage.removeItem(STORAGE_KEY)
-    set({ user: null, tokens: null, isAuthenticated: false })
+    set({ user: null, tokens: null, isAuthenticated: false, isUserLoading: false })
   },
 
   hydrate: () => {
@@ -41,6 +46,15 @@ export const useAuthStore = create<AuthState>((set) => ({
     if (!raw) return
     try {
       const tokens: TokenPair = JSON.parse(raw)
+      if (
+        typeof tokens.access_token !== 'string' ||
+        !tokens.access_token ||
+        typeof tokens.refresh_token !== 'string' ||
+        !tokens.refresh_token
+      ) {
+        localStorage.removeItem(STORAGE_KEY)
+        return
+      }
       set({ tokens, isAuthenticated: true })
     } catch {
       // invalid JSON — leave state untouched

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,13 @@
+export interface User {
+  id: string
+  email: string
+  name: string
+  settings_json: Record<string, unknown>
+  created_at: string
+}
+
+export interface TokenPair {
+  access_token: string
+  refresh_token: string
+  token_type: string
+}

--- a/frontend/src/utils/oauth.ts
+++ b/frontend/src/utils/oauth.ts
@@ -1,0 +1,23 @@
+export function buildOAuthUrl(provider: 'google' | 'github'): string {
+  const origin = window.location.origin
+  const redirectUri = `${origin}/auth/${provider}/callback`
+
+  if (provider === 'google') {
+    const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      scope: 'email profile',
+    })
+    return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`
+  }
+
+  const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID as string
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: 'user:email',
+  })
+  return `https://github.com/login/oauth/authorize?${params.toString()}`
+}

--- a/frontend/src/utils/oauth.ts
+++ b/frontend/src/utils/oauth.ts
@@ -2,6 +2,9 @@ export function buildOAuthUrl(provider: 'google' | 'github'): string {
   const origin = window.location.origin
   const redirectUri = `${origin}/auth/${provider}/callback`
 
+  const state = crypto.randomUUID()
+  sessionStorage.setItem('oauth_state', state)
+
   if (provider === 'google') {
     const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID
     if (!clientId) throw new Error('VITE_GOOGLE_CLIENT_ID is not set')
@@ -10,6 +13,7 @@ export function buildOAuthUrl(provider: 'google' | 'github'): string {
       redirect_uri: redirectUri,
       response_type: 'code',
       scope: 'email profile',
+      state,
     })
     return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`
   }
@@ -20,6 +24,7 @@ export function buildOAuthUrl(provider: 'google' | 'github'): string {
     client_id: clientId,
     redirect_uri: redirectUri,
     scope: 'user:email',
+    state,
   })
   return `https://github.com/login/oauth/authorize?${params.toString()}`
 }

--- a/frontend/src/utils/oauth.ts
+++ b/frontend/src/utils/oauth.ts
@@ -3,7 +3,8 @@ export function buildOAuthUrl(provider: 'google' | 'github'): string {
   const redirectUri = `${origin}/auth/${provider}/callback`
 
   if (provider === 'google') {
-    const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string
+    const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID
+    if (!clientId) throw new Error('VITE_GOOGLE_CLIENT_ID is not set')
     const params = new URLSearchParams({
       client_id: clientId,
       redirect_uri: redirectUri,
@@ -13,7 +14,8 @@ export function buildOAuthUrl(provider: 'google' | 'github'): string {
     return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`
   }
 
-  const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID as string
+  const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID
+  if (!clientId) throw new Error('VITE_GITHUB_CLIENT_ID is not set')
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
         target: 'http://localhost:5060',
         changeOrigin: true,
       },
+      '/auth': {
+        target: 'http://localhost:5060',
+        changeOrigin: true,
+      },
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- Implements full frontend OAuth 2.0 login flow for Google and GitHub providers
- `LoginPage` builds OAuth URLs with CSRF state, handles env-missing errors
- `OAuthCallbackPage` validates CSRF state, POSTs code to backend, stores tokens/user, redirects to dashboard
- `ProtectedRoute` guards authenticated routes, auto-fetches `/auth/me` when tokens exist but user is null
- `authStore` extended with `isUserLoading` flag and `hydrate()` with token shape validation

## Test plan
- [x] All 55 frontend tests pass (`npx vitest run`)
- [x] 6 backend integration tests for POST `/auth/{provider}/callback` (405 on GET, 501 when unconfigured, 401 on bad code)
- [x] CSRF state stored in `sessionStorage` and validated on callback
- [x] AbortController signal threaded through fetch chain for proper cancellation
- [x] LoginPage shows error UI when OAuth URL build fails (env var missing)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)