### PR TITLE
[#39] feat: inline timer component on task cards

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -5,6 +5,12 @@ import App from './App'
 import { useAuthStore } from './stores/authStore'
 import type { TokenPair, User } from './types/auth'
 
+vi.mock('./api/timeEntries', () => ({
+  useActiveTimer: () => ({ data: null }),
+  useStartTimer: () => ({ mutate: vi.fn() }),
+  useStopTimer: () => ({ mutate: vi.fn() }),
+}))
+
 vi.mock('./api/projects', () => ({
   useProjects: () => ({ data: [], isLoading: false, isError: false }),
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false }),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,9 +5,12 @@ import PlannerPage from './pages/PlannerPage'
 import ReviewPage from './pages/ReviewPage'
 import OAuthCallbackPage from './pages/OAuthCallbackPage'
 import ProtectedRoute from './components/ProtectedRoute'
+import { useTimerBootstrap } from './hooks/useTimerBootstrap'
 import './index.css'
 
 function App(): React.JSX.Element {
+  useTimerBootstrap()
+
   return (
     <div className="dark-bg">
       <Routes>

--- a/frontend/src/api/timeEntries.test.ts
+++ b/frontend/src/api/timeEntries.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { useActiveTimer } from './timeEntries'
+import type { TimeEntry } from '../types/timeEntry'
+
+// Mock apiClient
+vi.mock('./client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+import { apiClient } from './client'
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+const stoppedEntry: TimeEntry = {
+  id: 'entry-stopped',
+  task_id: 'task-1',
+  started_at: '2026-04-19T10:00:00Z',
+  ended_at: '2026-04-19T10:30:00Z',
+  duration_seconds: 1800,
+  created_at: '2026-04-19T10:00:00Z',
+}
+
+const activeEntry: TimeEntry = {
+  id: 'entry-active',
+  task_id: 'task-2',
+  started_at: '2026-04-19T11:00:00Z',
+  ended_at: null,
+  duration_seconds: null,
+  created_at: '2026-04-19T11:00:00Z',
+}
+
+describe('useActiveTimer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the entry with ended_at === null from GET /time-entries', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [stoppedEntry, activeEntry],
+    } as Response)
+
+    const { result } = renderHook(() => useActiveTimer(), { wrapper })
+
+    await waitFor(() => expect(result.current.data).toBeDefined())
+
+    expect(result.current.data).toEqual(activeEntry)
+  })
+
+  it('returns undefined when all entries are stopped', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [stoppedEntry],
+    } as Response)
+
+    const { result } = renderHook(() => useActiveTimer(), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toBeUndefined()
+  })
+})

--- a/frontend/src/api/timeEntries.test.ts
+++ b/frontend/src/api/timeEntries.test.ts
@@ -68,6 +68,6 @@ describe('useActiveTimer', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-    expect(result.current.data).toBeUndefined()
+    expect(result.current.data).toBeNull()
   })
 })

--- a/frontend/src/api/timeEntries.ts
+++ b/frontend/src/api/timeEntries.ts
@@ -1,0 +1,52 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from './client'
+import type { TimeEntry, TimeEntryStart } from '../types/timeEntry'
+
+export const TIME_ENTRY_KEYS = {
+  all: ['time-entries'] as const,
+  active: ['time-entries', 'active'] as const,
+}
+
+async function fetchTimeEntries(): Promise<TimeEntry[]> {
+  const res = await apiClient.get('/time-entries')
+  if (!res.ok) throw new Error('Failed to fetch time entries')
+  return res.json() as Promise<TimeEntry[]>
+}
+
+async function startTimer(data: TimeEntryStart): Promise<TimeEntry> {
+  const res = await apiClient.post('/time-entries/start', data)
+  if (!res.ok) throw new Error('Failed to start timer')
+  return res.json() as Promise<TimeEntry>
+}
+
+async function stopTimer(entryId: string): Promise<TimeEntry> {
+  const res = await apiClient.post(`/time-entries/${entryId}/stop`)
+  if (!res.ok) throw new Error('Failed to stop timer')
+  return res.json() as Promise<TimeEntry>
+}
+
+export function useActiveTimer() {
+  return useQuery({
+    queryKey: TIME_ENTRY_KEYS.active,
+    queryFn: async () => {
+      const entries = await fetchTimeEntries()
+      return entries.find((e) => e.ended_at === null) ?? null
+    },
+  })
+}
+
+export function useStartTimer() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: TimeEntryStart) => startTimer(data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: TIME_ENTRY_KEYS.active }),
+  })
+}
+
+export function useStopTimer() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (entryId: string) => stopTimer(entryId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: TIME_ENTRY_KEYS.active }),
+  })
+}

--- a/frontend/src/components/TaskCard.test.tsx
+++ b/frontend/src/components/TaskCard.test.tsx
@@ -1,7 +1,25 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
 import TaskCard from './TaskCard'
 import type { Task } from '../types/task'
+
+// Stub out the timer API so TaskCard tests stay focused on card rendering
+vi.mock('../api/timeEntries', () => ({
+  useActiveTimer: () => ({ data: null }),
+  useStartTimer: () => ({ mutate: vi.fn() }),
+  useStopTimer: () => ({ mutate: vi.fn() }),
+}))
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function renderCard(task: Task) {
+  return render(<TaskCard task={task} />, { wrapper })
+}
 
 const baseTask: Task = {
   id: 'task-1',
@@ -18,12 +36,12 @@ const baseTask: Task = {
 
 describe('TaskCard', () => {
   it('renders task title', () => {
-    render(<TaskCard task={baseTask} />)
+    renderCard(baseTask)
     expect(screen.getByText('Write unit tests')).toBeInTheDocument()
   })
 
   it('renders priority indicator with correct class', () => {
-    render(<TaskCard task={baseTask} />)
+    renderCard(baseTask)
     const indicator = screen.getByTestId('task-priority-indicator')
     expect(indicator).toHaveClass('priority-high')
   })
@@ -31,7 +49,7 @@ describe('TaskCard', () => {
   it('renders priority indicator for each priority level', () => {
     const priorities = ['low', 'medium', 'high', 'urgent'] as const
     for (const priority of priorities) {
-      const { unmount } = render(<TaskCard task={{ ...baseTask, priority }} />)
+      const { unmount } = renderCard({ ...baseTask, priority })
       const indicator = screen.getByTestId('task-priority-indicator')
       expect(indicator).toHaveClass(`priority-${priority}`)
       unmount()
@@ -39,38 +57,43 @@ describe('TaskCard', () => {
   })
 
   it('renders status badge with correct text', () => {
-    render(<TaskCard task={baseTask} />)
+    renderCard(baseTask)
     expect(screen.getByTestId('task-status-badge')).toHaveTextContent('Todo')
   })
 
   it('renders status badge for in_progress', () => {
-    render(<TaskCard task={{ ...baseTask, status: 'in_progress' }} />)
+    renderCard({ ...baseTask, status: 'in_progress' })
     expect(screen.getByTestId('task-status-badge')).toHaveTextContent('In Progress')
   })
 
   it('renders status badge for done', () => {
-    render(<TaskCard task={{ ...baseTask, status: 'done' }} />)
+    renderCard({ ...baseTask, status: 'done' })
     expect(screen.getByTestId('task-status-badge')).toHaveTextContent('Done')
   })
 
   it('renders due date when present', () => {
-    render(<TaskCard task={{ ...baseTask, due_date: '2026-04-30' }} />)
+    renderCard({ ...baseTask, due_date: '2026-04-30' })
     expect(screen.getByTestId('task-due-date')).toBeInTheDocument()
     expect(screen.getByTestId('task-due-date').textContent).toContain('2026-04-30')
   })
 
   it('does not render due date when absent', () => {
-    render(<TaskCard task={baseTask} />)
+    renderCard(baseTask)
     expect(screen.queryByTestId('task-due-date')).not.toBeInTheDocument()
   })
 
   it('adds overdue class when due date is in the past', () => {
-    render(<TaskCard task={{ ...baseTask, due_date: '2020-01-01' }} />)
+    renderCard({ ...baseTask, due_date: '2020-01-01' })
     expect(screen.getByTestId('task-due-date')).toHaveClass('overdue')
   })
 
   it('does not add overdue class when due date is in the future', () => {
-    render(<TaskCard task={{ ...baseTask, due_date: '2099-12-31' }} />)
+    renderCard({ ...baseTask, due_date: '2099-12-31' })
     expect(screen.getByTestId('task-due-date')).not.toHaveClass('overdue')
+  })
+
+  it('renders timer start button when no active timer for this task', () => {
+    renderCard(baseTask)
+    expect(screen.getByTestId('timer-start-btn')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -34,7 +34,7 @@ function TaskCard({ task, onClick }: TaskCardProps): React.JSX.Element {
       { task_id: task.id },
       {
         onSuccess: (entry) => {
-          startTick(entry.id, entry.started_at, entry.task_id)
+          startTick(entry.id, entry.task_id)
         },
       },
     )

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import './TaskCard.css'
 import type { Task, TaskStatus } from '../types/task'
+import TimerButton from './TimerButton'
+import { useTimerStore } from '../stores/timerStore'
+import { useActiveTimer, useStartTimer, useStopTimer } from '../api/timeEntries'
 
 const STATUS_LABELS: Record<TaskStatus, string> = {
   todo: 'Todo',
@@ -18,6 +21,31 @@ function TaskCard({ task, onClick }: TaskCardProps): React.JSX.Element {
   // Parse due_date as local midnight so comparison is timezone-consistent
   const isOverdue = task.due_date !== null && new Date(task.due_date + 'T00:00:00') < today
 
+  const { data: activeEntry } = useActiveTimer()
+  const startTimer = useStartTimer()
+  const stopTimer = useStopTimer()
+  const startTick = useTimerStore((s) => s.startTick)
+  const stopTick = useTimerStore((s) => s.stopTick)
+
+  const taskActiveEntry = activeEntry?.task_id === task.id ? activeEntry : null
+
+  function handleStart() {
+    startTimer.mutate(
+      { task_id: task.id },
+      {
+        onSuccess: (entry) => {
+          startTick(entry.id, entry.started_at, entry.task_id)
+        },
+      },
+    )
+  }
+
+  function handleStop(entryId: string) {
+    stopTimer.mutate(entryId, {
+      onSuccess: () => stopTick(),
+    })
+  }
+
   return (
     <div className="task-card" data-testid="task-card" onClick={onClick}>
       <span
@@ -34,6 +62,13 @@ function TaskCard({ task, onClick }: TaskCardProps): React.JSX.Element {
             {task.due_date}
           </span>
         )}
+      </div>
+      <div className="task-card-actions" data-testid="task-card-actions">
+        <TimerButton
+          activeEntry={taskActiveEntry ?? null}
+          onStart={handleStart}
+          onStop={handleStop}
+        />
       </div>
       <span
         className={`task-status-badge status-${task.status}`}

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -65,7 +65,7 @@ function TaskCard({ task, onClick }: TaskCardProps): React.JSX.Element {
       </div>
       <div className="task-card-actions" data-testid="task-card-actions">
         <TimerButton
-          activeEntry={taskActiveEntry ?? null}
+          activeEntry={taskActiveEntry}
           onStart={handleStart}
           onStop={handleStop}
         />

--- a/frontend/src/components/TimerButton.css
+++ b/frontend/src/components/TimerButton.css
@@ -1,0 +1,42 @@
+.timer-btn {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.timer-btn--start {
+  background: #2a2a2d;
+  color: var(--text-muted, #9ca3af);
+}
+
+.timer-btn--start:hover {
+  background: #3a3a3e;
+  color: var(--text-primary, #f5f5f5);
+}
+
+.timer-btn--stop {
+  background: #f59e0b;
+  color: #111113;
+}
+
+.timer-btn--stop:hover {
+  background: #d97706;
+}
+
+.timer-active {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.timer-elapsed {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #f59e0b;
+  font-variant-numeric: tabular-nums;
+  min-width: 36px;
+}

--- a/frontend/src/components/TimerButton.test.tsx
+++ b/frontend/src/components/TimerButton.test.tsx
@@ -63,4 +63,17 @@ describe('TimerButton', () => {
     expect(mm).toBe(1)
     expect(ss).toBeGreaterThanOrEqual(5)
   })
+
+  it('resumes elapsed from started_at on mount (persistence after refresh)', () => {
+    // started_at 30 seconds in the past
+    const entry: TimeEntry = {
+      ...activeEntry,
+      started_at: new Date(Date.now() - 30_000).toISOString(),
+    }
+    render(<TimerButton activeEntry={entry} onStart={vi.fn()} onStop={vi.fn()} />)
+    const elapsed = screen.getByTestId('timer-elapsed').textContent ?? ''
+    expect(elapsed).toMatch(/^\d{2}:\d{2}$/)
+    const totalSeconds = parseInt(elapsed.split(':')[0]) * 60 + parseInt(elapsed.split(':')[1])
+    expect(totalSeconds).toBeGreaterThanOrEqual(30)
+  })
 })

--- a/frontend/src/components/TimerButton.test.tsx
+++ b/frontend/src/components/TimerButton.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import TimerButton from './TimerButton'
+import type { TimeEntry } from '../types/timeEntry'
+
+const activeEntry: TimeEntry = {
+  id: 'entry-1',
+  task_id: 'task-1',
+  started_at: new Date(Date.now() - 65_000).toISOString(), // 65 seconds ago
+  ended_at: null,
+  duration_seconds: null,
+  created_at: new Date().toISOString(),
+}
+
+describe('TimerButton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders start button when no active entry', () => {
+    render(<TimerButton activeEntry={null} onStart={vi.fn()} onStop={vi.fn()} />)
+    expect(screen.getByTestId('timer-start-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('timer-start-btn')).toHaveTextContent('Start')
+  })
+
+  it('calls onStart when start button is clicked', () => {
+    const onStart = vi.fn()
+    render(<TimerButton activeEntry={null} onStart={onStart} onStop={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('timer-start-btn'))
+    expect(onStart).toHaveBeenCalledOnce()
+  })
+
+  it('renders stop button and elapsed display when active entry present', () => {
+    render(<TimerButton activeEntry={activeEntry} onStart={vi.fn()} onStop={vi.fn()} />)
+    expect(screen.getByTestId('timer-stop-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('timer-elapsed')).toBeInTheDocument()
+  })
+
+  it('calls onStop with entry id when stop button is clicked', () => {
+    const onStop = vi.fn()
+    render(<TimerButton activeEntry={activeEntry} onStart={vi.fn()} onStop={onStop} />)
+    fireEvent.click(screen.getByTestId('timer-stop-btn'))
+    expect(onStop).toHaveBeenCalledWith('entry-1')
+  })
+
+  it('elapsed display formats seconds as MM:SS', () => {
+    // started_at = exactly 65 seconds ago so elapsed starts at 65s → "01:05"
+    const entry: TimeEntry = {
+      ...activeEntry,
+      started_at: new Date(Date.now() - 65_000).toISOString(),
+    }
+    render(<TimerButton activeEntry={entry} onStart={vi.fn()} onStop={vi.fn()} />)
+    // tick one interval so the display renders
+    act(() => { vi.advanceTimersByTime(1000) })
+    const elapsed = screen.getByTestId('timer-elapsed').textContent ?? ''
+    // Should be "01:05" or "01:06" depending on rounding — at minimum contains ":"
+    expect(elapsed).toMatch(/^\d{2}:\d{2}$/)
+    const [mm, ss] = elapsed.split(':').map(Number)
+    expect(mm).toBe(1)
+    expect(ss).toBeGreaterThanOrEqual(5)
+  })
+})

--- a/frontend/src/components/TimerButton.tsx
+++ b/frontend/src/components/TimerButton.tsx
@@ -1,17 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import './TimerButton.css'
 import type { TimeEntry } from '../types/timeEntry'
+import { formatElapsed } from '../utils/formatElapsed'
 
 interface TimerButtonProps {
   activeEntry: TimeEntry | null
   onStart: () => void
   onStop: (entryId: string) => void
-}
-
-function formatElapsed(seconds: number): string {
-  const mm = Math.floor(seconds / 60).toString().padStart(2, '0')
-  const ss = (seconds % 60).toString().padStart(2, '0')
-  return `${mm}:${ss}`
 }
 
 function TimerButton({ activeEntry, onStart, onStop }: TimerButtonProps): React.JSX.Element {

--- a/frontend/src/components/TimerButton.tsx
+++ b/frontend/src/components/TimerButton.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react'
+import './TimerButton.css'
+import type { TimeEntry } from '../types/timeEntry'
+
+interface TimerButtonProps {
+  activeEntry: TimeEntry | null
+  onStart: () => void
+  onStop: (entryId: string) => void
+}
+
+function formatElapsed(seconds: number): string {
+  const mm = Math.floor(seconds / 60).toString().padStart(2, '0')
+  const ss = (seconds % 60).toString().padStart(2, '0')
+  return `${mm}:${ss}`
+}
+
+function TimerButton({ activeEntry, onStart, onStop }: TimerButtonProps): React.JSX.Element {
+  const [elapsed, setElapsed] = useState<number>(0)
+
+  useEffect(() => {
+    if (!activeEntry) {
+      setElapsed(0)
+      return
+    }
+    // Compute initial elapsed from wall clock
+    const initial = Math.floor((Date.now() - Date.parse(activeEntry.started_at)) / 1000)
+    setElapsed(initial)
+
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - Date.parse(activeEntry.started_at)) / 1000))
+    }, 1000)
+    return () => clearInterval(id)
+  }, [activeEntry])
+
+  if (!activeEntry) {
+    return (
+      <button className="timer-btn timer-btn--start" data-testid="timer-start-btn" onClick={onStart}>
+        Start
+      </button>
+    )
+  }
+
+  return (
+    <div className="timer-active">
+      <span className="timer-elapsed" data-testid="timer-elapsed">{formatElapsed(elapsed)}</span>
+      <button
+        className="timer-btn timer-btn--stop"
+        data-testid="timer-stop-btn"
+        onClick={() => onStop(activeEntry.id)}
+      >
+        Stop
+      </button>
+    </div>
+  )
+}
+
+export default TimerButton

--- a/frontend/src/hooks/useTimerBootstrap.ts
+++ b/frontend/src/hooks/useTimerBootstrap.ts
@@ -9,7 +9,7 @@ export function useTimerBootstrap(): void {
 
   useEffect(() => {
     if (activeEntry) {
-      startTick(activeEntry.id, activeEntry.started_at, activeEntry.task_id)
+      startTick(activeEntry.id, activeEntry.task_id)
     } else if (activeEntry === null) {
       stopTick()
     }

--- a/frontend/src/hooks/useTimerBootstrap.ts
+++ b/frontend/src/hooks/useTimerBootstrap.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+import { useActiveTimer } from '../api/timeEntries'
+import { useTimerStore } from '../stores/timerStore'
+
+export function useTimerBootstrap(): void {
+  const { data: activeEntry } = useActiveTimer()
+  const startTick = useTimerStore((s) => s.startTick)
+  const stopTick = useTimerStore((s) => s.stopTick)
+
+  useEffect(() => {
+    if (activeEntry) {
+      startTick(activeEntry.id, activeEntry.started_at, activeEntry.task_id)
+    } else if (activeEntry === null) {
+      stopTick()
+    }
+  }, [activeEntry, startTick, stopTick])
+}

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -55,6 +55,12 @@ const mockTasks: Task[] = [
   },
 ]
 
+vi.mock('../api/timeEntries', () => ({
+  useActiveTimer: () => ({ data: null }),
+  useStartTimer: () => ({ mutate: vi.fn() }),
+  useStopTimer: () => ({ mutate: vi.fn() }),
+}))
+
 vi.mock('../api/projects', () => ({
   useProjects: vi.fn(),
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false }),

--- a/frontend/src/stores/timerStore.test.ts
+++ b/frontend/src/stores/timerStore.test.ts
@@ -29,11 +29,13 @@ describe('timerStore', () => {
     expect(useTimerStore.getState().activeEntryId).toBe('entry-2')
   })
 
-  it('useIsTaskTimerActive returns true for active task', () => {
-    useTimerStore.getState().startTick('entry-99', undefined)
-    const active = useTimerStore.getState().isTaskTimerActive('task-with-entry-99')
-    // Can't know task_id here — test the selector with the activeEntryId directly
-    expect(useTimerStore.getState().activeEntryId).toBe('entry-99')
-    expect(active).toBe(false) // different task
+  it('isTaskTimerActive returns true for the active task', () => {
+    useTimerStore.getState().startTick('entry-1', 'task-abc')
+    expect(useTimerStore.getState().isTaskTimerActive('task-abc')).toBe(true)
+  })
+
+  it('isTaskTimerActive returns false for a different task', () => {
+    useTimerStore.getState().startTick('entry-1', 'task-abc')
+    expect(useTimerStore.getState().isTaskTimerActive('task-xyz')).toBe(false)
   })
 })

--- a/frontend/src/stores/timerStore.test.ts
+++ b/frontend/src/stores/timerStore.test.ts
@@ -13,24 +13,24 @@ describe('timerStore', () => {
   })
 
   it('startTick sets activeEntryId', () => {
-    useTimerStore.getState().startTick('entry-1', new Date().toISOString())
+    useTimerStore.getState().startTick('entry-1', undefined)
     expect(useTimerStore.getState().activeEntryId).toBe('entry-1')
   })
 
   it('stopTick clears activeEntryId', () => {
-    useTimerStore.getState().startTick('entry-1', new Date().toISOString())
+    useTimerStore.getState().startTick('entry-1', undefined)
     useTimerStore.getState().stopTick()
     expect(useTimerStore.getState().activeEntryId).toBeNull()
   })
 
   it('startTick replaces previous activeEntryId (single-active constraint)', () => {
-    useTimerStore.getState().startTick('entry-1', new Date().toISOString())
-    useTimerStore.getState().startTick('entry-2', new Date().toISOString())
+    useTimerStore.getState().startTick('entry-1', undefined)
+    useTimerStore.getState().startTick('entry-2', undefined)
     expect(useTimerStore.getState().activeEntryId).toBe('entry-2')
   })
 
   it('useIsTaskTimerActive returns true for active task', () => {
-    useTimerStore.getState().startTick('entry-99', new Date().toISOString())
+    useTimerStore.getState().startTick('entry-99', undefined)
     const active = useTimerStore.getState().isTaskTimerActive('task-with-entry-99')
     // Can't know task_id here — test the selector with the activeEntryId directly
     expect(useTimerStore.getState().activeEntryId).toBe('entry-99')

--- a/frontend/src/stores/timerStore.test.ts
+++ b/frontend/src/stores/timerStore.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { useTimerStore } from './timerStore'
+
+describe('timerStore', () => {
+  beforeEach(() => {
+    useTimerStore.setState({ activeEntryId: null })
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    useTimerStore.getState().stopTick()
+    vi.useRealTimers()
+  })
+
+  it('startTick sets activeEntryId', () => {
+    useTimerStore.getState().startTick('entry-1', new Date().toISOString())
+    expect(useTimerStore.getState().activeEntryId).toBe('entry-1')
+  })
+
+  it('stopTick clears activeEntryId', () => {
+    useTimerStore.getState().startTick('entry-1', new Date().toISOString())
+    useTimerStore.getState().stopTick()
+    expect(useTimerStore.getState().activeEntryId).toBeNull()
+  })
+
+  it('startTick replaces previous activeEntryId (single-active constraint)', () => {
+    useTimerStore.getState().startTick('entry-1', new Date().toISOString())
+    useTimerStore.getState().startTick('entry-2', new Date().toISOString())
+    expect(useTimerStore.getState().activeEntryId).toBe('entry-2')
+  })
+
+  it('useIsTaskTimerActive returns true for active task', () => {
+    useTimerStore.getState().startTick('entry-99', new Date().toISOString())
+    const active = useTimerStore.getState().isTaskTimerActive('task-with-entry-99')
+    // Can't know task_id here — test the selector with the activeEntryId directly
+    expect(useTimerStore.getState().activeEntryId).toBe('entry-99')
+    expect(active).toBe(false) // different task
+  })
+})

--- a/frontend/src/stores/timerStore.ts
+++ b/frontend/src/stores/timerStore.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand'
+
+interface TimerState {
+  activeEntryId: string | null
+  activeTaskId: string | null
+  startTick: (entryId: string, startedAt: string) => void
+  stopTick: () => void
+  isTaskTimerActive: (taskId: string) => boolean
+}
+
+let _tickInterval: ReturnType<typeof setInterval> | null = null
+
+export const useTimerStore = create<TimerState>((set, get) => ({
+  activeEntryId: null,
+  activeTaskId: null,
+
+  startTick: (entryId, _startedAt) => {
+    // Clear any existing interval before starting a new one
+    if (_tickInterval !== null) {
+      clearInterval(_tickInterval)
+      _tickInterval = null
+    }
+    set({ activeEntryId: entryId })
+  },
+
+  stopTick: () => {
+    if (_tickInterval !== null) {
+      clearInterval(_tickInterval)
+      _tickInterval = null
+    }
+    set({ activeEntryId: null, activeTaskId: null })
+  },
+
+  isTaskTimerActive: (taskId) => {
+    return get().activeTaskId === taskId
+  },
+}))

--- a/frontend/src/stores/timerStore.ts
+++ b/frontend/src/stores/timerStore.ts
@@ -3,30 +3,20 @@ import { create } from 'zustand'
 interface TimerState {
   activeEntryId: string | null
   activeTaskId: string | null
-  startTick: (entryId: string, startedAt: string, taskId?: string) => void
+  startTick: (entryId: string, taskId?: string) => void
   stopTick: () => void
   isTaskTimerActive: (taskId: string) => boolean
 }
-
-let _tickInterval: ReturnType<typeof setInterval> | null = null
 
 export const useTimerStore = create<TimerState>((set, get) => ({
   activeEntryId: null,
   activeTaskId: null,
 
-  startTick: (entryId, _startedAt, taskId) => {
-    if (_tickInterval !== null) {
-      clearInterval(_tickInterval)
-      _tickInterval = null
-    }
+  startTick: (entryId, taskId) => {
     set({ activeEntryId: entryId, activeTaskId: taskId ?? null })
   },
 
   stopTick: () => {
-    if (_tickInterval !== null) {
-      clearInterval(_tickInterval)
-      _tickInterval = null
-    }
     set({ activeEntryId: null, activeTaskId: null })
   },
 

--- a/frontend/src/stores/timerStore.ts
+++ b/frontend/src/stores/timerStore.ts
@@ -3,7 +3,7 @@ import { create } from 'zustand'
 interface TimerState {
   activeEntryId: string | null
   activeTaskId: string | null
-  startTick: (entryId: string, startedAt: string) => void
+  startTick: (entryId: string, startedAt: string, taskId?: string) => void
   stopTick: () => void
   isTaskTimerActive: (taskId: string) => boolean
 }
@@ -14,13 +14,12 @@ export const useTimerStore = create<TimerState>((set, get) => ({
   activeEntryId: null,
   activeTaskId: null,
 
-  startTick: (entryId, _startedAt) => {
-    // Clear any existing interval before starting a new one
+  startTick: (entryId, _startedAt, taskId) => {
     if (_tickInterval !== null) {
       clearInterval(_tickInterval)
       _tickInterval = null
     }
-    set({ activeEntryId: entryId })
+    set({ activeEntryId: entryId, activeTaskId: taskId ?? null })
   },
 
   stopTick: () => {

--- a/frontend/src/types/timeEntry.ts
+++ b/frontend/src/types/timeEntry.ts
@@ -1,0 +1,13 @@
+export interface TimeEntry {
+  id: string
+  task_id: string
+  started_at: string
+  ended_at: string | null
+  duration_seconds: number | null
+  created_at: string
+}
+
+export interface TimeEntryStart {
+  task_id: string
+  started_at?: string
+}

--- a/frontend/src/utils/formatElapsed.ts
+++ b/frontend/src/utils/formatElapsed.ts
@@ -1,0 +1,5 @@
+export function formatElapsed(seconds: number): string {
+  const mm = Math.floor(seconds / 60).toString().padStart(2, '0')
+  const ss = (seconds % 60).toString().padStart(2, '0')
+  return `${mm}:${ss}`
+}

--- a/frontend/src/utils/formatElapsed.ts
+++ b/frontend/src/utils/formatElapsed.ts
@@ -1,5 +1,6 @@
 export function formatElapsed(seconds: number): string {
-  const mm = Math.floor(seconds / 60).toString().padStart(2, '0')
-  const ss = (seconds % 60).toString().padStart(2, '0')
+  const s = Math.max(0, seconds)
+  const mm = Math.floor(s / 60).toString().padStart(2, '0')
+  const ss = (s % 60).toString().padStart(2, '0')
   return `${mm}:${ss}`
 }


### PR DESCRIPTION
## Summary
- Adds Start/Stop timer button to each task card, showing elapsed time while running
- Enforces single-active-timer constraint (starting a new timer auto-stops the previous)
- Persists active timer across page refresh via `useTimerBootstrap` rehydration on app mount

## Files added
- `types/timeEntry.ts` — TypeScript interfaces matching backend schema
- `api/timeEntries.ts` — `useActiveTimer`, `useStartTimer`, `useStopTimer` React Query hooks
- `stores/timerStore.ts` — Zustand store tracking active entry/task IDs
- `components/TimerButton.tsx` + `.css` — presentational timer button with elapsed display
- `utils/formatElapsed.ts` — MM:SS formatter with negative-input guard
- `hooks/useTimerBootstrap.ts` — wired into `App.tsx` for persistence on reload

## Test plan
- [x] `npx vitest run` — 201 tests, all passing
- [x] `npm run lint` — clean
- [ ] Manual: start timer on a task, refresh page, confirm timer resumes
- [ ] Manual: start timer on task A, start on task B — confirm task A shows Start again

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)