### PR TITLE
[#40] feat: build planned vs actual review page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.27.0",
+        "recharts": "^3.8.1",
         "zustand": "^5.0.1"
       },
       "devDependencies": {
@@ -1256,6 +1257,42 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1622,6 +1659,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.99.1",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.1.tgz",
@@ -1791,6 +1840,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1832,6 +1944,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.2",
@@ -2680,6 +2798,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2777,6 +2904,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -2868,6 +3116,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -3182,6 +3436,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -3572,6 +3836,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -4053,6 +4323,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4103,6 +4383,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5300,9 +5589,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5346,6 +5657,36 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -5358,6 +5699,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5403,6 +5759,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -5937,6 +6299,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6250,6 +6618,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",
+    "recharts": "^3.8.1",
     "zustand": "^5.0.1"
   },
   "devDependencies": {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -35,6 +35,11 @@ vi.mock('./api/scheduleBlocks', () => ({
   SCHEDULE_BLOCK_KEYS: { byDate: (d: string) => ['schedule-blocks', d] },
 }))
 
+vi.mock('./api/analytics', () => ({
+  usePlannedVsActual: () => ({ data: undefined, isLoading: false }),
+  useWeeklyStats: () => ({ data: undefined, isLoading: false }),
+}))
+
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-query')>()
   return {

--- a/frontend/src/api/analytics.test.ts
+++ b/frontend/src/api/analytics.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+vi.mock('./client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}))
+
+import { apiClient } from './client'
+import type { PlannedVsActualResponse, WeeklyStatsResponse } from '../types/analytics'
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+const mockDailyResponse: PlannedVsActualResponse = {
+  date: '2025-01-15',
+  tasks: [
+    {
+      task_id: 'task-1',
+      task_title: 'Write tests',
+      planned_hours: 1,
+      actual_hours: 0.5,
+      status: 'partial',
+    },
+  ],
+  summary: {
+    total_planned_hours: 1,
+    total_actual_hours: 0.5,
+    done_count: 0,
+    partial_count: 1,
+    skipped_count: 0,
+    unplanned_count: 0,
+  },
+}
+
+const mockWeeklyResponse: WeeklyStatsResponse = {
+  week_start: '2025-01-13',
+  week_end: '2025-01-19',
+  projects: [
+    {
+      project_id: 'proj-1',
+      project_name: 'FlowDay',
+      project_color: '#f59e0b',
+      planned_hours: 10,
+      actual_hours: 8,
+      accuracy_pct: 80,
+    },
+  ],
+  summary: {
+    total_planned_hours: 10,
+    total_actual_hours: 8,
+    average_accuracy_pct: 80,
+  },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('usePlannedVsActual', () => {
+  it('calls the correct endpoint with date query param', async () => {
+    const { usePlannedVsActual } = await import('./analytics')
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockDailyResponse,
+    } as Response)
+
+    const { result } = renderHook(() => usePlannedVsActual('2025-01-15'), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(vi.mocked(apiClient.get).mock.calls[0][0]).toBe(
+      '/analytics/planned-vs-actual?date=2025-01-15',
+    )
+    expect(result.current.data?.tasks).toHaveLength(1)
+    expect(result.current.data?.tasks[0].task_title).toBe('Write tests')
+  })
+
+  it('is disabled when date is empty', async () => {
+    const { usePlannedVsActual } = await import('./analytics')
+
+    const { result } = renderHook(() => usePlannedVsActual(''), { wrapper })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(vi.mocked(apiClient.get)).not.toHaveBeenCalled()
+  })
+})
+
+describe('useWeeklyStats', () => {
+  it('calls the correct endpoint with week_start query param', async () => {
+    const { useWeeklyStats } = await import('./analytics')
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockWeeklyResponse,
+    } as Response)
+
+    const { result } = renderHook(() => useWeeklyStats('2025-01-13'), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(vi.mocked(apiClient.get).mock.calls[0][0]).toBe(
+      '/analytics/weekly-stats?week_start=2025-01-13',
+    )
+    expect(result.current.data?.projects).toHaveLength(1)
+    expect(result.current.data?.projects[0].project_name).toBe('FlowDay')
+  })
+
+  it('is disabled when weekStart is empty', async () => {
+    const { useWeeklyStats } = await import('./analytics')
+
+    const { result } = renderHook(() => useWeeklyStats(''), { wrapper })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(vi.mocked(apiClient.get)).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/api/analytics.ts
+++ b/frontend/src/api/analytics.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiClient } from './client'
+import type { PlannedVsActualResponse, WeeklyStatsResponse } from '../types/analytics'
+
+export const ANALYTICS_KEYS = {
+  plannedVsActual: (date: string) => ['analytics', 'planned-vs-actual', date] as const,
+  weeklyStats: (weekStart: string) => ['analytics', 'weekly-stats', weekStart] as const,
+}
+
+async function fetchPlannedVsActual(date: string): Promise<PlannedVsActualResponse> {
+  const res = await apiClient.get(`/analytics/planned-vs-actual?date=${date}`)
+  if (!res.ok) throw new Error('Failed to fetch planned vs actual')
+  return res.json() as Promise<PlannedVsActualResponse>
+}
+
+async function fetchWeeklyStats(weekStart: string): Promise<WeeklyStatsResponse> {
+  const res = await apiClient.get(`/analytics/weekly-stats?week_start=${weekStart}`)
+  if (!res.ok) throw new Error('Failed to fetch weekly stats')
+  return res.json() as Promise<WeeklyStatsResponse>
+}
+
+export function usePlannedVsActual(date: string) {
+  return useQuery({
+    queryKey: ANALYTICS_KEYS.plannedVsActual(date),
+    queryFn: () => fetchPlannedVsActual(date),
+    enabled: Boolean(date),
+  })
+}
+
+export function useWeeklyStats(weekStart: string) {
+  return useQuery({
+    queryKey: ANALYTICS_KEYS.weeklyStats(weekStart),
+    queryFn: () => fetchWeeklyStats(weekStart),
+    enabled: Boolean(weekStart),
+  })
+}

--- a/frontend/src/components/DailyComparisonView.test.tsx
+++ b/frontend/src/components/DailyComparisonView.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import React from 'react'
 import DailyComparisonView from './DailyComparisonView'
 import type { TaskComparison } from '../types/analytics'
 

--- a/frontend/src/components/DailyComparisonView.test.tsx
+++ b/frontend/src/components/DailyComparisonView.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import DailyComparisonView from './DailyComparisonView'
+import type { TaskComparison } from '../types/analytics'
+
+const tasks: TaskComparison[] = [
+  { task_id: 'task-1', task_title: 'Write tests', planned_hours: 1, actual_hours: 0.5, status: 'partial' },
+  { task_id: 'task-2', task_title: 'Deploy feature', planned_hours: 2, actual_hours: 2.1, status: 'done' },
+  { task_id: 'task-3', task_title: 'Review PR', planned_hours: 0.5, actual_hours: 0, status: 'skipped' },
+  { task_id: 'task-4', task_title: 'Hotfix', planned_hours: 0, actual_hours: 1, status: 'unplanned' },
+]
+
+describe('DailyComparisonView', () => {
+  it('renders a row for each task', () => {
+    render(<DailyComparisonView tasks={tasks} />)
+    expect(screen.getByText('Write tests')).toBeInTheDocument()
+    expect(screen.getByText('Deploy feature')).toBeInTheDocument()
+    expect(screen.getByText('Review PR')).toBeInTheDocument()
+    expect(screen.getByText('Hotfix')).toBeInTheDocument()
+  })
+
+  it('renders planned hours for each task', () => {
+    render(<DailyComparisonView tasks={tasks} />)
+    expect(screen.getByTestId('planned-task-1')).toHaveTextContent('1.00h')
+    expect(screen.getByTestId('planned-task-2')).toHaveTextContent('2.00h')
+  })
+
+  it('renders actual hours for each task', () => {
+    render(<DailyComparisonView tasks={tasks} />)
+    expect(screen.getByTestId('actual-task-1')).toHaveTextContent('0.50h')
+    expect(screen.getByTestId('actual-task-2')).toHaveTextContent('2.10h')
+  })
+
+  it('renders status badge with correct color for done', () => {
+    render(<DailyComparisonView tasks={[tasks[1]]} />)
+    const badge = screen.getByTestId('status-badge-task-2')
+    expect(badge).toHaveStyle({ backgroundColor: '#22c55e' })
+  })
+
+  it('renders status badge with correct color for partial', () => {
+    render(<DailyComparisonView tasks={[tasks[0]]} />)
+    const badge = screen.getByTestId('status-badge-task-1')
+    expect(badge).toHaveStyle({ backgroundColor: '#eab308' })
+  })
+
+  it('renders status badge with correct color for skipped', () => {
+    render(<DailyComparisonView tasks={[tasks[2]]} />)
+    const badge = screen.getByTestId('status-badge-task-3')
+    expect(badge).toHaveStyle({ backgroundColor: '#ef4444' })
+  })
+
+  it('renders status badge with correct color for unplanned', () => {
+    render(<DailyComparisonView tasks={[tasks[3]]} />)
+    const badge = screen.getByTestId('status-badge-task-4')
+    expect(badge).toHaveStyle({ backgroundColor: '#3b82f6' })
+  })
+
+  it('renders empty message when tasks list is empty', () => {
+    render(<DailyComparisonView tasks={[]} />)
+    expect(screen.getByText('No tasks scheduled')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/DailyComparisonView.tsx
+++ b/frontend/src/components/DailyComparisonView.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import type { TaskComparison } from '../types/analytics'
+import { statusTagColor } from '../utils/reviewUtils'
+
+interface DailyComparisonViewProps {
+  tasks: TaskComparison[]
+}
+
+function DailyComparisonView({ tasks }: DailyComparisonViewProps): React.JSX.Element {
+  if (tasks.length === 0) {
+    return <p>No tasks scheduled</p>
+  }
+
+  return (
+    <ul>
+      {tasks.map((task) => (
+        <li key={task.task_id}>
+          <span>{task.task_title}</span>
+          <span data-testid={`planned-${task.task_id}`}>{task.planned_hours.toFixed(2)}h</span>
+          <span data-testid={`actual-${task.task_id}`}>{task.actual_hours.toFixed(2)}h</span>
+          <span
+            data-testid={`status-badge-${task.task_id}`}
+            style={{ backgroundColor: statusTagColor(task.status) }}
+          >
+            {task.status}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default DailyComparisonView

--- a/frontend/src/components/WeeklyBarChart.test.tsx
+++ b/frontend/src/components/WeeklyBarChart.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import React from 'react'
 import WeeklyBarChart from './WeeklyBarChart'
 import type { WeeklyChartEntry } from '../types/analytics'
 

--- a/frontend/src/components/WeeklyBarChart.test.tsx
+++ b/frontend/src/components/WeeklyBarChart.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import WeeklyBarChart from './WeeklyBarChart'
+import type { WeeklyChartEntry } from '../types/analytics'
+
+// recharts uses ResizeObserver — stub it for jsdom
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+})
+
+const chartData: WeeklyChartEntry[] = [
+  { name: 'FlowDay', planned: 10, actual: 8, color: '#f59e0b' },
+  { name: 'Backend', planned: 5, actual: 6, color: '#3b82f6' },
+]
+
+describe('WeeklyBarChart', () => {
+  it('renders the chart wrapper', () => {
+    render(<WeeklyBarChart data={chartData} />)
+    expect(screen.getByTestId('weekly-bar-chart')).toBeInTheDocument()
+  })
+
+  it('renders project names as Y-axis labels', () => {
+    render(<WeeklyBarChart data={chartData} />)
+    expect(screen.getByText('FlowDay')).toBeInTheDocument()
+    expect(screen.getByText('Backend')).toBeInTheDocument()
+  })
+
+  it('renders empty state when data is empty', () => {
+    render(<WeeklyBarChart data={[]} />)
+    expect(screen.getByText('No project data for this week')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/WeeklyBarChart.tsx
+++ b/frontend/src/components/WeeklyBarChart.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import type { WeeklyChartEntry } from '../types/analytics'
+
+interface WeeklyBarChartProps {
+  data: WeeklyChartEntry[]
+}
+
+function WeeklyBarChart({ data }: WeeklyBarChartProps): React.JSX.Element {
+  if (data.length === 0) {
+    return <p>No project data for this week</p>
+  }
+
+  return (
+    <div data-testid="weekly-bar-chart">
+      <ul aria-label="project list" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {data.map((entry) => (
+          <li key={entry.name}>{entry.name}</li>
+        ))}
+      </ul>
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart layout="vertical" data={data}>
+            <XAxis type="number" unit="h" />
+            <YAxis type="category" dataKey="name" width={100} />
+            <Tooltip formatter={(value: number) => `${value}h`} />
+            <Bar dataKey="planned" name="Planned" fill="#f59e0b" />
+            <Bar dataKey="actual" name="Actual" fill="#22c55e" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}
+
+export default WeeklyBarChart

--- a/frontend/src/components/WeeklyBarChart.tsx
+++ b/frontend/src/components/WeeklyBarChart.tsx
@@ -13,7 +13,17 @@ function WeeklyBarChart({ data }: WeeklyBarChartProps): React.JSX.Element {
 
   return (
     <div data-testid="weekly-bar-chart">
-      <ul aria-label="project list" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+      <ul
+        aria-label="project list"
+        style={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          overflow: 'hidden',
+          clip: 'rect(0,0,0,0)',
+          whiteSpace: 'nowrap',
+        }}
+      >
         {data.map((entry) => (
           <li key={entry.name}>{entry.name}</li>
         ))}

--- a/frontend/src/components/WeeklyBarChart.tsx
+++ b/frontend/src/components/WeeklyBarChart.tsx
@@ -23,7 +23,7 @@ function WeeklyBarChart({ data }: WeeklyBarChartProps): React.JSX.Element {
           <BarChart layout="vertical" data={data}>
             <XAxis type="number" unit="h" />
             <YAxis type="category" dataKey="name" width={100} />
-            <Tooltip formatter={(value: number) => `${value}h`} />
+            <Tooltip formatter={(value) => (typeof value === 'number' ? `${value}h` : value)} />
             <Bar dataKey="planned" name="Planned" fill="#f59e0b" />
             <Bar dataKey="actual" name="Actual" fill="#22c55e" />
           </BarChart>

--- a/frontend/src/components/WeeklyBarChart.tsx
+++ b/frontend/src/components/WeeklyBarChart.tsx
@@ -28,7 +28,7 @@ function WeeklyBarChart({ data }: WeeklyBarChartProps): React.JSX.Element {
           <li key={entry.name}>{entry.name}</li>
         ))}
       </ul>
-      <div style={{ width: '100%', height: 300 }}>
+      <div aria-hidden="true" style={{ width: '100%', height: 300 }}>
         <ResponsiveContainer width="100%" height="100%">
           <BarChart layout="vertical" data={data}>
             <XAxis type="number" unit="h" />

--- a/frontend/src/pages/ReviewPage.test.tsx
+++ b/frontend/src/pages/ReviewPage.test.tsx
@@ -72,6 +72,14 @@ describe('ReviewPage', () => {
     expect(screen.getByTestId('review-empty')).toBeInTheDocument()
   })
 
+  it('shows error state when a query fails', () => {
+    vi.mocked(usePlannedVsActual).mockReturnValue({ data: undefined, isLoading: false, isError: true } as ReturnType<typeof usePlannedVsActual>)
+    vi.mocked(useWeeklyStats).mockReturnValue({ data: undefined, isLoading: false, isError: false } as ReturnType<typeof useWeeklyStats>)
+    render(<ReviewPage />, { wrapper })
+    expect(screen.getByTestId('review-error')).toBeInTheDocument()
+    expect(screen.queryByTestId('review-empty')).not.toBeInTheDocument()
+  })
+
   it('navigates to the next day when next-day button is clicked', async () => {
     const user = userEvent.setup()
     render(<ReviewPage />, { wrapper })

--- a/frontend/src/pages/ReviewPage.test.tsx
+++ b/frontend/src/pages/ReviewPage.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+})
+
+vi.mock('../api/analytics', () => ({
+  usePlannedVsActual: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useWeeklyStats: vi.fn(() => ({ data: undefined, isLoading: false })),
+}))
+
+import { usePlannedVsActual, useWeeklyStats } from '../api/analytics'
+import ReviewPage from './ReviewPage'
+import type { PlannedVsActualResponse, WeeklyStatsResponse } from '../types/analytics'
+
+const mockDaily: PlannedVsActualResponse = {
+  date: '2026-04-19',
+  tasks: [],
+  summary: { total_planned_hours: 0, total_actual_hours: 0, done_count: 0, partial_count: 0, skipped_count: 0, unplanned_count: 0 },
+}
+
+const mockWeekly: WeeklyStatsResponse = {
+  week_start: '2026-04-13',
+  week_end: '2026-04-19',
+  projects: [],
+  summary: { total_planned_hours: 0, total_actual_hours: 0, average_accuracy_pct: 0 },
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+beforeEach(() => {
+  vi.mocked(usePlannedVsActual).mockReturnValue({ data: mockDaily, isLoading: false } as ReturnType<typeof usePlannedVsActual>)
+  vi.mocked(useWeeklyStats).mockReturnValue({ data: mockWeekly, isLoading: false } as ReturnType<typeof useWeeklyStats>)
+})
+
+describe('ReviewPage', () => {
+  it('renders the page with testid', () => {
+    render(<ReviewPage />, { wrapper })
+    expect(screen.getByTestId('page-review')).toBeInTheDocument()
+  })
+
+  it('renders prev and next day navigation buttons', () => {
+    render(<ReviewPage />, { wrapper })
+    expect(screen.getByTestId('prev-day')).toBeInTheDocument()
+    expect(screen.getByTestId('next-day')).toBeInTheDocument()
+  })
+
+  it('renders prev and next week navigation buttons', () => {
+    render(<ReviewPage />, { wrapper })
+    expect(screen.getByTestId('prev-week')).toBeInTheDocument()
+    expect(screen.getByTestId('next-week')).toBeInTheDocument()
+  })
+
+  it('shows loading state while data is loading', () => {
+    vi.mocked(usePlannedVsActual).mockReturnValue({ data: undefined, isLoading: true } as ReturnType<typeof usePlannedVsActual>)
+    vi.mocked(useWeeklyStats).mockReturnValue({ data: undefined, isLoading: true } as ReturnType<typeof useWeeklyStats>)
+    render(<ReviewPage />, { wrapper })
+    expect(screen.getByTestId('review-loading')).toBeInTheDocument()
+  })
+
+  it('shows empty state when both queries return empty lists', () => {
+    render(<ReviewPage />, { wrapper })
+    expect(screen.getByTestId('review-empty')).toBeInTheDocument()
+  })
+
+  it('navigates to the next day when next-day button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<ReviewPage />, { wrapper })
+    const nextBtn = screen.getByTestId('next-day')
+    const initialDate = screen.getByTestId('selected-date').textContent
+    await user.click(nextBtn)
+    expect(screen.getByTestId('selected-date').textContent).not.toBe(initialDate)
+  })
+
+  it('navigates to the previous week when prev-week button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<ReviewPage />, { wrapper })
+    const prevWeekBtn = screen.getByTestId('prev-week')
+    const initialWeek = screen.getByTestId('selected-week').textContent
+    await user.click(prevWeekBtn)
+    expect(screen.getByTestId('selected-week').textContent).not.toBe(initialWeek)
+  })
+})

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -2,14 +2,7 @@ import React, { useState } from 'react'
 import { usePlannedVsActual, useWeeklyStats } from '../api/analytics'
 import DailyComparisonView from '../components/DailyComparisonView'
 import WeeklyBarChart from '../components/WeeklyBarChart'
-import { getWeekStart, toWeeklyChartData } from '../utils/reviewUtils'
-
-function formatLocalDate(d: Date): string {
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
-}
+import { getWeekStart, toWeeklyChartData, formatLocalDate } from '../utils/reviewUtils'
 
 function addDays(date: string, days: number): string {
   const d = new Date(date + 'T00:00:00')

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -4,14 +4,21 @@ import DailyComparisonView from '../components/DailyComparisonView'
 import WeeklyBarChart from '../components/WeeklyBarChart'
 import { getWeekStart, toWeeklyChartData } from '../utils/reviewUtils'
 
+function formatLocalDate(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
 function addDays(date: string, days: number): string {
   const d = new Date(date + 'T00:00:00')
   d.setDate(d.getDate() + days)
-  return d.toISOString().slice(0, 10)
+  return formatLocalDate(d)
 }
 
 function today(): string {
-  return new Date().toISOString().slice(0, 10)
+  return formatLocalDate(new Date())
 }
 
 function ReviewPage(): React.JSX.Element {
@@ -22,10 +29,11 @@ function ReviewPage(): React.JSX.Element {
   const weeklyQuery = useWeeklyStats(weekStart)
 
   const isLoading = dailyQuery.isLoading || weeklyQuery.isLoading
+  const hasError = dailyQuery.isError || weeklyQuery.isError
 
   const tasks = dailyQuery.data?.tasks ?? []
   const projects = weeklyQuery.data?.projects ?? []
-  const isEmpty = !isLoading && tasks.length === 0 && projects.length === 0
+  const isEmpty = !isLoading && !hasError && tasks.length === 0 && projects.length === 0
 
   return (
     <main data-testid="page-review">
@@ -52,11 +60,15 @@ function ReviewPage(): React.JSX.Element {
 
       {isLoading && <div data-testid="review-loading">Loading...</div>}
 
+      {hasError && (
+        <div data-testid="review-error">Failed to load data. Please try again.</div>
+      )}
+
       {isEmpty && (
         <div data-testid="review-empty">No data for this period</div>
       )}
 
-      {!isLoading && !isEmpty && (
+      {!isLoading && !hasError && !isEmpty && (
         <>
           <DailyComparisonView tasks={tasks} />
           <WeeklyBarChart data={toWeeklyChartData(projects)} />

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1,5 +1,69 @@
+import React, { useState } from 'react'
+import { usePlannedVsActual, useWeeklyStats } from '../api/analytics'
+import DailyComparisonView from '../components/DailyComparisonView'
+import WeeklyBarChart from '../components/WeeklyBarChart'
+import { getWeekStart, toWeeklyChartData } from '../utils/reviewUtils'
+
+function addDays(date: string, days: number): string {
+  const d = new Date(date + 'T00:00:00')
+  d.setDate(d.getDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
 function ReviewPage(): React.JSX.Element {
-  return <main data-testid="page-review">Review</main>
+  const [selectedDate, setSelectedDate] = useState<string>(today)
+  const [weekStart, setWeekStart] = useState<string>(() => getWeekStart(today()))
+
+  const dailyQuery = usePlannedVsActual(selectedDate)
+  const weeklyQuery = useWeeklyStats(weekStart)
+
+  const isLoading = dailyQuery.isLoading || weeklyQuery.isLoading
+
+  const tasks = dailyQuery.data?.tasks ?? []
+  const projects = weeklyQuery.data?.projects ?? []
+  const isEmpty = !isLoading && tasks.length === 0 && projects.length === 0
+
+  return (
+    <main data-testid="page-review">
+      <section>
+        <div>
+          <button data-testid="prev-day" onClick={() => setSelectedDate((d) => addDays(d, -1))}>
+            &lt;
+          </button>
+          <span data-testid="selected-date">{selectedDate}</span>
+          <button data-testid="next-day" onClick={() => setSelectedDate((d) => addDays(d, 1))}>
+            &gt;
+          </button>
+        </div>
+        <div>
+          <button data-testid="prev-week" onClick={() => setWeekStart((w) => addDays(w, -7))}>
+            &lt;&lt;
+          </button>
+          <span data-testid="selected-week">{weekStart}</span>
+          <button data-testid="next-week" onClick={() => setWeekStart((w) => addDays(w, 7))}>
+            &gt;&gt;
+          </button>
+        </div>
+      </section>
+
+      {isLoading && <div data-testid="review-loading">Loading...</div>}
+
+      {isEmpty && (
+        <div data-testid="review-empty">No data for this period</div>
+      )}
+
+      {!isLoading && !isEmpty && (
+        <>
+          <DailyComparisonView tasks={tasks} />
+          <WeeklyBarChart data={toWeeklyChartData(projects)} />
+        </>
+      )}
+    </main>
+  )
 }
 
 export default ReviewPage

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -1,0 +1,53 @@
+export type StatusTag = 'done' | 'partial' | 'skipped' | 'unplanned'
+
+export interface TaskComparison {
+  task_id: string
+  task_title: string
+  planned_hours: number
+  actual_hours: number
+  status: StatusTag
+}
+
+export interface PlannedVsActualSummary {
+  total_planned_hours: number
+  total_actual_hours: number
+  done_count: number
+  partial_count: number
+  skipped_count: number
+  unplanned_count: number
+}
+
+export interface PlannedVsActualResponse {
+  date: string
+  tasks: TaskComparison[]
+  summary: PlannedVsActualSummary
+}
+
+export interface ProjectWeeklyStats {
+  project_id: string
+  project_name: string
+  project_color: string
+  planned_hours: number
+  actual_hours: number
+  accuracy_pct: number
+}
+
+export interface WeeklyStatsSummary {
+  total_planned_hours: number
+  total_actual_hours: number
+  average_accuracy_pct: number
+}
+
+export interface WeeklyStatsResponse {
+  week_start: string
+  week_end: string
+  projects: ProjectWeeklyStats[]
+  summary: WeeklyStatsSummary
+}
+
+export interface WeeklyChartEntry {
+  name: string
+  planned: number
+  actual: number
+  color: string
+}

--- a/frontend/src/utils/reviewUtils.test.ts
+++ b/frontend/src/utils/reviewUtils.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  statusTagColor,
+  formatAccuracy,
+  toWeeklyChartData,
+  getWeekStart,
+} from './reviewUtils'
+import type { ProjectWeeklyStats } from '../types/analytics'
+
+function makeProjectStats(overrides: Partial<ProjectWeeklyStats>): ProjectWeeklyStats {
+  return {
+    project_id: 'proj-1',
+    project_name: 'FlowDay',
+    project_color: '#f59e0b',
+    planned_hours: 8,
+    actual_hours: 6,
+    accuracy_pct: 75,
+    ...overrides,
+  }
+}
+
+describe('statusTagColor', () => {
+  it('returns green for done', () => {
+    expect(statusTagColor('done')).toBe('#22c55e')
+  })
+
+  it('returns yellow for partial', () => {
+    expect(statusTagColor('partial')).toBe('#eab308')
+  })
+
+  it('returns red for skipped', () => {
+    expect(statusTagColor('skipped')).toBe('#ef4444')
+  })
+
+  it('returns blue for unplanned', () => {
+    expect(statusTagColor('unplanned')).toBe('#3b82f6')
+  })
+})
+
+describe('formatAccuracy', () => {
+  it('rounds to one decimal place', () => {
+    expect(formatAccuracy(87.567)).toBe('87.6%')
+  })
+
+  it('returns 0.0% for zero', () => {
+    expect(formatAccuracy(0)).toBe('0.0%')
+  })
+
+  it('returns 100.0% for perfect accuracy', () => {
+    expect(formatAccuracy(100)).toBe('100.0%')
+  })
+})
+
+describe('toWeeklyChartData', () => {
+  it('maps projects to chart entries with name, planned, actual, color', () => {
+    const stats = [
+      makeProjectStats({ project_name: 'Alpha', planned_hours: 4, actual_hours: 3, project_color: '#ff0000' }),
+      makeProjectStats({ project_id: 'proj-2', project_name: 'Beta', planned_hours: 2, actual_hours: 2, project_color: '#00ff00' }),
+    ]
+    const result = toWeeklyChartData(stats)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({ name: 'Alpha', planned: 4, actual: 3, color: '#ff0000' })
+    expect(result[1]).toEqual({ name: 'Beta', planned: 2, actual: 2, color: '#00ff00' })
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(toWeeklyChartData([])).toEqual([])
+  })
+
+  it('rounds hours to two decimal places', () => {
+    const stats = [makeProjectStats({ planned_hours: 1.3333, actual_hours: 0.6667 })]
+    const result = toWeeklyChartData(stats)
+    expect(result[0].planned).toBe(1.33)
+    expect(result[0].actual).toBe(0.67)
+  })
+})
+
+describe('getWeekStart', () => {
+  it('returns Monday for a Wednesday input', () => {
+    expect(getWeekStart('2026-04-22')).toBe('2026-04-20')
+  })
+
+  it('returns the same day for a Monday input', () => {
+    expect(getWeekStart('2026-04-20')).toBe('2026-04-20')
+  })
+
+  it('returns the previous Monday for a Sunday input', () => {
+    expect(getWeekStart('2026-04-19')).toBe('2026-04-13')
+  })
+})

--- a/frontend/src/utils/reviewUtils.ts
+++ b/frontend/src/utils/reviewUtils.ts
@@ -1,0 +1,35 @@
+import type { StatusTag, ProjectWeeklyStats, WeeklyChartEntry } from '../types/analytics'
+
+export function statusTagColor(status: StatusTag): string {
+  switch (status) {
+    case 'done':
+      return '#22c55e'
+    case 'partial':
+      return '#eab308'
+    case 'skipped':
+      return '#ef4444'
+    case 'unplanned':
+      return '#3b82f6'
+  }
+}
+
+export function formatAccuracy(pct: number): string {
+  return pct.toFixed(1) + '%'
+}
+
+export function toWeeklyChartData(projects: ProjectWeeklyStats[]): WeeklyChartEntry[] {
+  return projects.map((p) => ({
+    name: p.project_name,
+    planned: Math.round(p.planned_hours * 100) / 100,
+    actual: Math.round(p.actual_hours * 100) / 100,
+    color: p.project_color,
+  }))
+}
+
+export function getWeekStart(date: string): string {
+  const d = new Date(date + 'T00:00:00')
+  const day = d.getDay()
+  const diff = day === 0 ? -6 : 1 - day
+  d.setDate(d.getDate() + diff)
+  return d.toISOString().slice(0, 10)
+}

--- a/frontend/src/utils/reviewUtils.ts
+++ b/frontend/src/utils/reviewUtils.ts
@@ -26,7 +26,7 @@ export function toWeeklyChartData(projects: ProjectWeeklyStats[]): WeeklyChartEn
   }))
 }
 
-function formatLocalDate(d: Date): string {
+export function formatLocalDate(d: Date): string {
   const y = d.getFullYear()
   const m = String(d.getMonth() + 1).padStart(2, '0')
   const day = String(d.getDate()).padStart(2, '0')

--- a/frontend/src/utils/reviewUtils.ts
+++ b/frontend/src/utils/reviewUtils.ts
@@ -26,10 +26,17 @@ export function toWeeklyChartData(projects: ProjectWeeklyStats[]): WeeklyChartEn
   }))
 }
 
+function formatLocalDate(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
 export function getWeekStart(date: string): string {
   const d = new Date(date + 'T00:00:00')
-  const day = d.getDay()
-  const diff = day === 0 ? -6 : 1 - day
+  const dow = d.getDay()
+  const diff = dow === 0 ? -6 : 1 - dow
   d.setDate(d.getDate() + diff)
-  return d.toISOString().slice(0, 10)
+  return formatLocalDate(d)
 }


### PR DESCRIPTION
## Summary

- Implements `ReviewPage` with daily planned vs actual task comparison and weekly bar chart by project
- Adds `usePlannedVsActual` / `useWeeklyStats` React Query hooks against existing backend analytics API
- Color-coded status badges (done=green, partial=yellow, skipped=red, unplanned=blue), date/week navigation, loading/error/empty states
- Installs `recharts` for the horizontal grouped bar chart

## Files added
- `src/types/analytics.ts` — TypeScript interfaces mirroring backend schemas
- `src/api/analytics.ts` — React Query hooks for both analytics endpoints
- `src/utils/reviewUtils.ts` — pure helpers: `statusTagColor`, `formatAccuracy`, `toWeeklyChartData`, `getWeekStart`, `formatLocalDate`
- `src/components/DailyComparisonView.tsx` — task row list with status badges
- `src/components/WeeklyBarChart.tsx` — accessible horizontal bar chart (sr-only project list + aria-hidden SVG)
- `src/pages/ReviewPage.tsx` — replaced stub, composes all views

## Test plan
- [x] 237 tests passing (`npx vitest run` from `frontend/`)
- [x] `npm run build` clean (no TypeScript errors)
- [x] `npm run lint` clean (0 warnings)
- [x] 3 TDD cycles with RED/GREEN/REFACTOR commits
- [x] Timezone-safe date helpers (`formatLocalDate` uses local components, not `toISOString`)
- [x] Error state surfaced to user (not silently swallowed as empty state)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)