### PR TITLE
[#41] feat: build weekly review display page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import LoginPage from './pages/LoginPage'
 import DashboardPage from './pages/DashboardPage'
 import PlannerPage from './pages/PlannerPage'
 import ReviewPage from './pages/ReviewPage'
+import WeeklyReviewPage from './pages/WeeklyReviewPage'
 import OAuthCallbackPage from './pages/OAuthCallbackPage'
 import ProtectedRoute from './components/ProtectedRoute'
 import { useTimerBootstrap } from './hooks/useTimerBootstrap'
@@ -37,6 +38,14 @@ function App(): React.JSX.Element {
           element={
             <ProtectedRoute>
               <ReviewPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/weekly-review"
+          element={
+            <ProtectedRoute>
+              <WeeklyReviewPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/api/weeklyReviews.ts
+++ b/frontend/src/api/weeklyReviews.ts
@@ -1,0 +1,55 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from './client'
+import type { WeeklyReview } from '../types/weeklyReview'
+
+export const WEEKLY_REVIEW_KEYS = {
+  list: () => ['weekly-reviews'] as const,
+  current: (weekStart: string) => ['weekly-reviews', 'current', weekStart] as const,
+}
+
+async function fetchWeeklyReview(weekStart: string): Promise<WeeklyReview | undefined> {
+  const res = await apiClient.get(`/weekly-reviews/current?week_start=${weekStart}`)
+  if (res.status === 404) return undefined
+  if (!res.ok) throw new Error('Failed to fetch weekly review')
+  return res.json() as Promise<WeeklyReview>
+}
+
+async function fetchWeeklyReviewHistory(limit: number): Promise<WeeklyReview[]> {
+  const res = await apiClient.get(`/weekly-reviews?limit=${limit}`)
+  if (!res.ok) throw new Error('Failed to fetch weekly review history')
+  return res.json() as Promise<WeeklyReview[]>
+}
+
+async function generateWeeklyReview(weekStart: string): Promise<WeeklyReview> {
+  const res = await apiClient.post('/weekly-reviews/generate', { week_start: weekStart })
+  if (!res.ok) throw new Error('Failed to generate weekly review')
+  return res.json() as Promise<WeeklyReview>
+}
+
+export function useWeeklyReview(weekStart: string) {
+  return useQuery({
+    queryKey: WEEKLY_REVIEW_KEYS.current(weekStart),
+    queryFn: () => fetchWeeklyReview(weekStart),
+    enabled: Boolean(weekStart),
+    refetchInterval: (query) =>
+      query.state.data?.status === 'generating' ? 4000 : false,
+  })
+}
+
+export function useWeeklyReviewHistory(limit = 10) {
+  return useQuery({
+    queryKey: WEEKLY_REVIEW_KEYS.list(),
+    queryFn: () => fetchWeeklyReviewHistory(limit),
+  })
+}
+
+export function useGenerateWeeklyReview() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (weekStart: string) => generateWeeklyReview(weekStart),
+    onSuccess: (_result, weekStart) => {
+      queryClient.invalidateQueries({ queryKey: WEEKLY_REVIEW_KEYS.list() })
+      queryClient.invalidateQueries({ queryKey: WEEKLY_REVIEW_KEYS.current(weekStart) })
+    },
+  })
+}

--- a/frontend/src/api/weeklyReviews.ts
+++ b/frontend/src/api/weeklyReviews.ts
@@ -31,6 +31,7 @@ export function useWeeklyReview(weekStart: string) {
     queryKey: WEEKLY_REVIEW_KEYS.current(weekStart),
     queryFn: () => fetchWeeklyReview(weekStart),
     enabled: Boolean(weekStart),
+    staleTime: 0,
     refetchInterval: (query) =>
       query.state.data?.status === 'generating' ? 4000 : false,
   })

--- a/frontend/src/components/JudgeScoreCard.test.tsx
+++ b/frontend/src/components/JudgeScoreCard.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import React from 'react'
 import JudgeScoreCard from './JudgeScoreCard'
 import type { JudgeScores } from '../types/weeklyReview'
 

--- a/frontend/src/components/JudgeScoreCard.test.tsx
+++ b/frontend/src/components/JudgeScoreCard.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import JudgeScoreCard from './JudgeScoreCard'
+import type { JudgeScores } from '../types/weeklyReview'
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+})
+
+const mockScores: JudgeScores = {
+  actionability: 85,
+  accuracy: 72,
+  coherence: 91,
+}
+
+describe('JudgeScoreCard', () => {
+  it('shows nothing when scores are null', () => {
+    const { container } = render(<JudgeScoreCard scores={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders actionability score', () => {
+    render(<JudgeScoreCard scores={mockScores} />)
+    expect(screen.getByTestId('score-actionability')).toHaveTextContent('85')
+  })
+
+  it('renders accuracy score', () => {
+    render(<JudgeScoreCard scores={mockScores} />)
+    expect(screen.getByTestId('score-accuracy')).toHaveTextContent('72')
+  })
+
+  it('renders coherence score', () => {
+    render(<JudgeScoreCard scores={mockScores} />)
+    expect(screen.getByTestId('score-coherence')).toHaveTextContent('91')
+  })
+
+  it('renders the score card container', () => {
+    render(<JudgeScoreCard scores={mockScores} />)
+    expect(screen.getByTestId('judge-score-card')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/JudgeScoreCard.tsx
+++ b/frontend/src/components/JudgeScoreCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import {
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  ResponsiveContainer,
+} from 'recharts'
+import type { JudgeScores } from '../types/weeklyReview'
+
+interface JudgeScoreCardProps {
+  scores: JudgeScores | null
+}
+
+function JudgeScoreCard({ scores }: JudgeScoreCardProps): React.JSX.Element | null {
+  if (!scores) return null
+
+  const data = [
+    { dimension: 'Actionability', value: scores.actionability },
+    { dimension: 'Accuracy', value: scores.accuracy },
+    { dimension: 'Coherence', value: scores.coherence },
+  ]
+
+  return (
+    <div data-testid="judge-score-card">
+      <div>
+        <span>Actionability: </span>
+        <span data-testid="score-actionability">{scores.actionability}</span>
+        <span> | Accuracy: </span>
+        <span data-testid="score-accuracy">{scores.accuracy}</span>
+        <span> | Coherence: </span>
+        <span data-testid="score-coherence">{scores.coherence}</span>
+      </div>
+      <ResponsiveContainer width="100%" height={250}>
+        <RadarChart data={data}>
+          <PolarGrid />
+          <PolarAngleAxis dataKey="dimension" />
+          <PolarRadiusAxis domain={[0, 100]} />
+          <Radar dataKey="value" fill="#f59e0b" fillOpacity={0.6} />
+        </RadarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+export default JudgeScoreCard

--- a/frontend/src/components/NarrativeSection.test.tsx
+++ b/frontend/src/components/NarrativeSection.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import React from 'react'
 import NarrativeSection from './NarrativeSection'
 import type { ReviewStatus } from '../types/weeklyReview'
 

--- a/frontend/src/components/NarrativeSection.test.tsx
+++ b/frontend/src/components/NarrativeSection.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import NarrativeSection from './NarrativeSection'
+import type { ReviewStatus } from '../types/weeklyReview'
+
+describe('NarrativeSection', () => {
+  it('shows generating state', () => {
+    render(<NarrativeSection narrative={null} status="generating" />)
+    expect(screen.getByTestId('narrative-generating')).toBeInTheDocument()
+  })
+
+  it('shows pending state', () => {
+    render(<NarrativeSection narrative={null} status="pending" />)
+    expect(screen.getByTestId('narrative-pending')).toBeInTheDocument()
+  })
+
+  it('shows failed state', () => {
+    render(<NarrativeSection narrative={null} status="failed" />)
+    expect(screen.getByTestId('narrative-error')).toBeInTheDocument()
+  })
+
+  it('shows narrative content when complete', () => {
+    render(<NarrativeSection narrative="Great week of productivity!" status="complete" />)
+    expect(screen.getByTestId('narrative-content')).toHaveTextContent('Great week of productivity!')
+  })
+
+  it('shows empty state when complete but narrative is null', () => {
+    render(<NarrativeSection narrative={null} status={'complete' as ReviewStatus} />)
+    expect(screen.getByTestId('narrative-empty')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/NarrativeSection.tsx
+++ b/frontend/src/components/NarrativeSection.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import type { ReviewStatus } from '../types/weeklyReview'
+
+interface NarrativeSectionProps {
+  narrative: string | null
+  status: ReviewStatus
+}
+
+function NarrativeSection({ narrative, status }: NarrativeSectionProps): React.JSX.Element {
+  if (status === 'generating') {
+    return <div data-testid="narrative-generating">Generating your weekly review...</div>
+  }
+
+  if (status === 'failed') {
+    return <div data-testid="narrative-error">Review generation failed. Try regenerating.</div>
+  }
+
+  if (status === 'pending') {
+    return <div data-testid="narrative-pending">No review yet. Generate one to get started.</div>
+  }
+
+  if (!narrative) {
+    return <div data-testid="narrative-empty">Review complete but no narrative available.</div>
+  }
+
+  return (
+    <article data-testid="narrative-content" style={{ whiteSpace: 'pre-wrap' }}>
+      {narrative}
+    </article>
+  )
+}
+
+export default NarrativeSection

--- a/frontend/src/components/ReviewHistoryList.test.tsx
+++ b/frontend/src/components/ReviewHistoryList.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import ReviewHistoryList from './ReviewHistoryList'
+import type { WeeklyReview } from '../types/weeklyReview'
+
+const mockReviews: WeeklyReview[] = [
+  {
+    id: '1',
+    user_id: 'u1',
+    week_start: '2026-04-06',
+    narrative: 'Week 1 was productive',
+    insights_json: null,
+    scores_json: { actionability: 80, accuracy: 70, coherence: 90 },
+    status: 'complete',
+    created_at: '2026-04-12T10:00:00Z',
+  },
+  {
+    id: '2',
+    user_id: 'u1',
+    week_start: '2026-04-13',
+    narrative: null,
+    insights_json: null,
+    scores_json: null,
+    status: 'generating',
+    created_at: '2026-04-19T10:00:00Z',
+  },
+]
+
+describe('ReviewHistoryList', () => {
+  it('renders the history list', () => {
+    render(
+      <ReviewHistoryList
+        reviews={mockReviews}
+        selectedWeekStart="2026-04-06"
+        onSelectWeek={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('review-history-list')).toBeInTheDocument()
+  })
+
+  it('renders an item for each review', () => {
+    render(
+      <ReviewHistoryList
+        reviews={mockReviews}
+        selectedWeekStart="2026-04-06"
+        onSelectWeek={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('review-history-item-2026-04-06')).toBeInTheDocument()
+    expect(screen.getByTestId('review-history-item-2026-04-13')).toBeInTheDocument()
+  })
+
+  it('calls onSelectWeek when an item is clicked', async () => {
+    const user = userEvent.setup()
+    const onSelectWeek = vi.fn()
+    render(
+      <ReviewHistoryList
+        reviews={mockReviews}
+        selectedWeekStart="2026-04-06"
+        onSelectWeek={onSelectWeek}
+      />
+    )
+    await user.click(screen.getByTestId('review-history-item-2026-04-13'))
+    expect(onSelectWeek).toHaveBeenCalledWith('2026-04-13')
+  })
+
+  it('shows empty state when no reviews', () => {
+    render(
+      <ReviewHistoryList reviews={[]} selectedWeekStart="" onSelectWeek={vi.fn()} />
+    )
+    expect(screen.getByTestId('review-history-empty')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ReviewHistoryList.test.tsx
+++ b/frontend/src/components/ReviewHistoryList.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import React from 'react'
 import ReviewHistoryList from './ReviewHistoryList'
 import type { WeeklyReview } from '../types/weeklyReview'
 

--- a/frontend/src/components/ReviewHistoryList.tsx
+++ b/frontend/src/components/ReviewHistoryList.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import type { WeeklyReview, ReviewStatus } from '../types/weeklyReview'
+
+const STATUS_COLORS: Record<ReviewStatus, string> = {
+  complete: '#22c55e',
+  generating: '#f59e0b',
+  failed: '#ef4444',
+  pending: '#6b7280',
+}
+
+interface ReviewHistoryListProps {
+  reviews: WeeklyReview[]
+  selectedWeekStart: string
+  onSelectWeek: (weekStart: string) => void
+}
+
+function ReviewHistoryList({
+  reviews,
+  selectedWeekStart,
+  onSelectWeek,
+}: ReviewHistoryListProps): React.JSX.Element {
+  if (reviews.length === 0) {
+    return <div data-testid="review-history-empty">No review history yet.</div>
+  }
+
+  return (
+    <ul data-testid="review-history-list">
+      {reviews.map((review) => (
+        <li
+          key={review.week_start}
+          data-testid={`review-history-item-${review.week_start}`}
+          onClick={() => onSelectWeek(review.week_start)}
+          style={{
+            cursor: 'pointer',
+            fontWeight: review.week_start === selectedWeekStart ? 'bold' : 'normal',
+          }}
+        >
+          <span
+            style={{
+              display: 'inline-block',
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              backgroundColor: STATUS_COLORS[review.status],
+              marginRight: 6,
+            }}
+          />
+          {review.week_start} — {review.status}
+          {review.narrative && (
+            <span> — {review.narrative.slice(0, 60)}</span>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default ReviewHistoryList

--- a/frontend/src/components/ReviewHistoryList.tsx
+++ b/frontend/src/components/ReviewHistoryList.tsx
@@ -29,7 +29,12 @@ function ReviewHistoryList({
         <li
           key={review.week_start}
           data-testid={`review-history-item-${review.week_start}`}
+          role="button"
+          tabIndex={0}
           onClick={() => onSelectWeek(review.week_start)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') onSelectWeek(review.week_start)
+          }}
           style={{
             cursor: 'pointer',
             fontWeight: review.week_start === selectedWeekStart ? 'bold' : 'normal',

--- a/frontend/src/components/ScoreTrendChart.test.tsx
+++ b/frontend/src/components/ScoreTrendChart.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import React from 'react'
 import ScoreTrendChart from './ScoreTrendChart'
 import type { WeeklyReview } from '../types/weeklyReview'
 

--- a/frontend/src/components/ScoreTrendChart.test.tsx
+++ b/frontend/src/components/ScoreTrendChart.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import ScoreTrendChart from './ScoreTrendChart'
+import type { WeeklyReview } from '../types/weeklyReview'
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+})
+
+const mockReviews: WeeklyReview[] = [
+  {
+    id: '1',
+    user_id: 'u1',
+    week_start: '2026-04-06',
+    narrative: 'Week 1',
+    insights_json: null,
+    scores_json: { actionability: 80, accuracy: 70, coherence: 90 },
+    status: 'complete',
+    created_at: '2026-04-12T10:00:00Z',
+  },
+  {
+    id: '2',
+    user_id: 'u1',
+    week_start: '2026-04-13',
+    narrative: 'Week 2',
+    insights_json: null,
+    scores_json: { actionability: 85, accuracy: 75, coherence: 88 },
+    status: 'complete',
+    created_at: '2026-04-19T10:00:00Z',
+  },
+]
+
+describe('ScoreTrendChart', () => {
+  it('shows empty state when no complete reviews', () => {
+    render(<ScoreTrendChart reviews={[]} />)
+    expect(screen.getByTestId('score-trend-empty')).toBeInTheDocument()
+  })
+
+  it('renders the chart when reviews with scores exist', () => {
+    render(<ScoreTrendChart reviews={mockReviews} />)
+    expect(screen.getByTestId('score-trend-chart')).toBeInTheDocument()
+  })
+
+  it('filters out reviews without scores', () => {
+    const reviewWithoutScores: WeeklyReview = {
+      ...mockReviews[0],
+      id: '3',
+      scores_json: null,
+      status: 'pending',
+    }
+    render(<ScoreTrendChart reviews={[reviewWithoutScores]} />)
+    expect(screen.getByTestId('score-trend-empty')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ScoreTrendChart.tsx
+++ b/frontend/src/components/ScoreTrendChart.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+import type { WeeklyReview } from '../types/weeklyReview'
+
+interface ScoreTrendChartProps {
+  reviews: WeeklyReview[]
+}
+
+function ScoreTrendChart({ reviews }: ScoreTrendChartProps): React.JSX.Element {
+  const chartData = reviews
+    .filter((r) => r.scores_json !== null)
+    .map((r) => ({
+      week: r.week_start,
+      actionability: r.scores_json!.actionability,
+      accuracy: r.scores_json!.accuracy,
+      coherence: r.scores_json!.coherence,
+    }))
+
+  if (chartData.length === 0) {
+    return <div data-testid="score-trend-empty">No score history available yet.</div>
+  }
+
+  return (
+    <div data-testid="score-trend-chart">
+      <ResponsiveContainer width="100%" height={250}>
+        <LineChart data={chartData}>
+          <XAxis dataKey="week" />
+          <YAxis domain={[0, 100]} />
+          <Tooltip />
+          <Legend />
+          <Line type="monotone" dataKey="actionability" stroke="#f59e0b" />
+          <Line type="monotone" dataKey="accuracy" stroke="#22c55e" />
+          <Line type="monotone" dataKey="coherence" stroke="#60a5fa" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+export default ScoreTrendChart

--- a/frontend/src/components/ScoreTrendChart.tsx
+++ b/frontend/src/components/ScoreTrendChart.tsx
@@ -8,7 +8,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts'
-import type { WeeklyReview } from '../types/weeklyReview'
+import type { WeeklyReview, JudgeScores } from '../types/weeklyReview'
 
 interface ScoreTrendChartProps {
   reviews: WeeklyReview[]
@@ -16,12 +16,12 @@ interface ScoreTrendChartProps {
 
 function ScoreTrendChart({ reviews }: ScoreTrendChartProps): React.JSX.Element {
   const chartData = reviews
-    .filter((r) => r.scores_json !== null)
+    .filter((r): r is WeeklyReview & { scores_json: JudgeScores } => r.scores_json !== null)
     .map((r) => ({
       week: r.week_start,
-      actionability: r.scores_json!.actionability,
-      accuracy: r.scores_json!.accuracy,
-      coherence: r.scores_json!.coherence,
+      actionability: r.scores_json.actionability,
+      accuracy: r.scores_json.accuracy,
+      coherence: r.scores_json.coherence,
     }))
 
   if (chartData.length === 0) {

--- a/frontend/src/pages/WeeklyReviewPage.test.tsx
+++ b/frontend/src/pages/WeeklyReviewPage.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+})
+
+vi.mock('../api/weeklyReviews', () => ({
+  useWeeklyReview: vi.fn(() => ({ data: undefined, isLoading: false, isError: false })),
+  useWeeklyReviewHistory: vi.fn(() => ({ data: [], isLoading: false })),
+  useGenerateWeeklyReview: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}))
+
+import {
+  useWeeklyReview,
+  useWeeklyReviewHistory,
+  useGenerateWeeklyReview,
+} from '../api/weeklyReviews'
+import WeeklyReviewPage from './WeeklyReviewPage'
+import type { WeeklyReview } from '../types/weeklyReview'
+
+const mockReview: WeeklyReview = {
+  id: '1',
+  user_id: 'u1',
+  week_start: '2026-04-13',
+  narrative: 'This was a productive week.',
+  insights_json: null,
+  scores_json: { actionability: 85, accuracy: 72, coherence: 91 },
+  status: 'complete',
+  created_at: '2026-04-19T10:00:00Z',
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+beforeEach(() => {
+  vi.mocked(useWeeklyReview).mockReturnValue({
+    data: mockReview,
+    isLoading: false,
+    isError: false,
+  } as ReturnType<typeof useWeeklyReview>)
+  vi.mocked(useWeeklyReviewHistory).mockReturnValue({
+    data: [mockReview],
+    isLoading: false,
+  } as ReturnType<typeof useWeeklyReviewHistory>)
+  vi.mocked(useGenerateWeeklyReview).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useGenerateWeeklyReview>)
+})
+
+describe('WeeklyReviewPage', () => {
+  it('renders the page', () => {
+    render(<WeeklyReviewPage />, { wrapper })
+    expect(screen.getByTestId('page-weekly-review')).toBeInTheDocument()
+  })
+
+  it('shows loading state', () => {
+    vi.mocked(useWeeklyReview).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as ReturnType<typeof useWeeklyReview>)
+    render(<WeeklyReviewPage />, { wrapper })
+    expect(screen.getByTestId('weekly-review-loading')).toBeInTheDocument()
+  })
+
+  it('shows error state', () => {
+    vi.mocked(useWeeklyReview).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as ReturnType<typeof useWeeklyReview>)
+    render(<WeeklyReviewPage />, { wrapper })
+    expect(screen.getByTestId('weekly-review-error')).toBeInTheDocument()
+  })
+
+  it('renders narrative when review is complete', () => {
+    render(<WeeklyReviewPage />, { wrapper })
+    expect(screen.getByTestId('narrative-content')).toBeInTheDocument()
+  })
+
+  it('renders judge scores when review is complete', () => {
+    render(<WeeklyReviewPage />, { wrapper })
+    expect(screen.getByTestId('judge-score-card')).toBeInTheDocument()
+  })
+
+  it('renders review history list', () => {
+    render(<WeeklyReviewPage />, { wrapper })
+    expect(screen.getByTestId('review-history-list')).toBeInTheDocument()
+  })
+
+  it('shows generate button when no review exists', () => {
+    vi.mocked(useWeeklyReview).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useWeeklyReview>)
+    render(<WeeklyReviewPage />, { wrapper })
+    expect(screen.getByTestId('generate-review-btn')).toBeInTheDocument()
+  })
+
+  it('calls mutate when generate button is clicked', async () => {
+    const user = userEvent.setup()
+    const mutateFn = vi.fn()
+    vi.mocked(useWeeklyReview).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useWeeklyReview>)
+    vi.mocked(useGenerateWeeklyReview).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof useGenerateWeeklyReview>)
+    render(<WeeklyReviewPage />, { wrapper })
+    await user.click(screen.getByTestId('generate-review-btn'))
+    expect(mutateFn).toHaveBeenCalled()
+  })
+
+  it('disables generate button when generating', () => {
+    vi.mocked(useWeeklyReview).mockReturnValue({
+      data: { ...mockReview, status: 'generating', narrative: null, scores_json: null },
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useWeeklyReview>)
+    vi.mocked(useGenerateWeeklyReview).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+    } as unknown as ReturnType<typeof useGenerateWeeklyReview>)
+    render(<WeeklyReviewPage />, { wrapper })
+    expect(screen.getByTestId('generate-review-btn')).toBeDisabled()
+  })
+
+  it('navigates to the previous week', async () => {
+    const user = userEvent.setup()
+    render(<WeeklyReviewPage />, { wrapper })
+    const initialWeek = screen.getByTestId('selected-week').textContent
+    await user.click(screen.getByTestId('prev-week'))
+    expect(screen.getByTestId('selected-week').textContent).not.toBe(initialWeek)
+  })
+
+  it('navigates to the next week', async () => {
+    const user = userEvent.setup()
+    render(<WeeklyReviewPage />, { wrapper })
+    const initialWeek = screen.getByTestId('selected-week').textContent
+    await user.click(screen.getByTestId('next-week'))
+    expect(screen.getByTestId('selected-week').textContent).not.toBe(initialWeek)
+  })
+})

--- a/frontend/src/pages/WeeklyReviewPage.test.tsx
+++ b/frontend/src/pages/WeeklyReviewPage.test.tsx
@@ -97,6 +97,26 @@ describe('WeeklyReviewPage', () => {
     expect(screen.getByTestId('review-history-list')).toBeInTheDocument()
   })
 
+  it('hides generate button during loading', () => {
+    vi.mocked(useWeeklyReview).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as ReturnType<typeof useWeeklyReview>)
+    render(<WeeklyReviewPage />, { wrapper })
+    expect(screen.queryByTestId('generate-review-btn')).not.toBeInTheDocument()
+  })
+
+  it('hides generate button during error', () => {
+    vi.mocked(useWeeklyReview).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as ReturnType<typeof useWeeklyReview>)
+    render(<WeeklyReviewPage />, { wrapper })
+    expect(screen.queryByTestId('generate-review-btn')).not.toBeInTheDocument()
+  })
+
   it('shows generate button when no review exists', () => {
     vi.mocked(useWeeklyReview).mockReturnValue({
       data: undefined,

--- a/frontend/src/pages/WeeklyReviewPage.tsx
+++ b/frontend/src/pages/WeeklyReviewPage.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react'
+import { useWeeklyReview, useWeeklyReviewHistory, useGenerateWeeklyReview } from '../api/weeklyReviews'
+import NarrativeSection from '../components/NarrativeSection'
+import JudgeScoreCard from '../components/JudgeScoreCard'
+import ScoreTrendChart from '../components/ScoreTrendChart'
+import ReviewHistoryList from '../components/ReviewHistoryList'
+import { getWeekStart, formatLocalDate } from '../utils/reviewUtils'
+
+function addWeeks(weekStart: string, weeks: number): string {
+  const d = new Date(weekStart + 'T00:00:00')
+  d.setDate(d.getDate() + weeks * 7)
+  return formatLocalDate(d)
+}
+
+function WeeklyReviewPage(): React.JSX.Element {
+  const [selectedWeekStart, setSelectedWeekStart] = useState<string>(() =>
+    getWeekStart(formatLocalDate(new Date()))
+  )
+
+  const reviewQuery = useWeeklyReview(selectedWeekStart)
+  const historyQuery = useWeeklyReviewHistory(10)
+  const generateMutation = useGenerateWeeklyReview()
+
+  const review = reviewQuery.data
+  const history = historyQuery.data ?? []
+
+  const isGenerating = review?.status === 'generating' || generateMutation.isPending
+  const buttonLabel =
+    !review || review.status === 'pending' ? 'Generate Review' : 'Regenerate'
+
+  return (
+    <main data-testid="page-weekly-review">
+      <section>
+        <button
+          data-testid="prev-week"
+          onClick={() => setSelectedWeekStart((w) => addWeeks(w, -1))}
+        >
+          {'<<'}
+        </button>
+        <span data-testid="selected-week">{selectedWeekStart}</span>
+        <button
+          data-testid="next-week"
+          onClick={() => setSelectedWeekStart((w) => addWeeks(w, 1))}
+        >
+          {'>>'}
+        </button>
+      </section>
+
+      <button
+        data-testid="generate-review-btn"
+        disabled={isGenerating}
+        onClick={() => generateMutation.mutate(selectedWeekStart)}
+      >
+        {buttonLabel}
+      </button>
+
+      {reviewQuery.isLoading && (
+        <div data-testid="weekly-review-loading">Loading...</div>
+      )}
+
+      {reviewQuery.isError && (
+        <div data-testid="weekly-review-error">Failed to load review. Please try again.</div>
+      )}
+
+      {!reviewQuery.isLoading && !reviewQuery.isError && (
+        <>
+          <NarrativeSection
+            narrative={review?.narrative ?? null}
+            status={review?.status ?? 'pending'}
+          />
+          <JudgeScoreCard scores={review?.scores_json ?? null} />
+        </>
+      )}
+
+      <ScoreTrendChart reviews={history} />
+      <ReviewHistoryList
+        reviews={history}
+        selectedWeekStart={selectedWeekStart}
+        onSelectWeek={setSelectedWeekStart}
+      />
+    </main>
+  )
+}
+
+export default WeeklyReviewPage

--- a/frontend/src/pages/WeeklyReviewPage.tsx
+++ b/frontend/src/pages/WeeklyReviewPage.tsx
@@ -4,13 +4,7 @@ import NarrativeSection from '../components/NarrativeSection'
 import JudgeScoreCard from '../components/JudgeScoreCard'
 import ScoreTrendChart from '../components/ScoreTrendChart'
 import ReviewHistoryList from '../components/ReviewHistoryList'
-import { getWeekStart, formatLocalDate } from '../utils/reviewUtils'
-
-function addWeeks(weekStart: string, weeks: number): string {
-  const d = new Date(weekStart + 'T00:00:00')
-  d.setDate(d.getDate() + weeks * 7)
-  return formatLocalDate(d)
-}
+import { getWeekStart, formatLocalDate, addWeeks } from '../utils/reviewUtils'
 
 function WeeklyReviewPage(): React.JSX.Element {
   const [selectedWeekStart, setSelectedWeekStart] = useState<string>(() =>

--- a/frontend/src/pages/WeeklyReviewPage.tsx
+++ b/frontend/src/pages/WeeklyReviewPage.tsx
@@ -46,14 +46,6 @@ function WeeklyReviewPage(): React.JSX.Element {
         </button>
       </section>
 
-      <button
-        data-testid="generate-review-btn"
-        disabled={isGenerating}
-        onClick={() => generateMutation.mutate(selectedWeekStart)}
-      >
-        {buttonLabel}
-      </button>
-
       {reviewQuery.isLoading && (
         <div data-testid="weekly-review-loading">Loading...</div>
       )}
@@ -64,6 +56,13 @@ function WeeklyReviewPage(): React.JSX.Element {
 
       {!reviewQuery.isLoading && !reviewQuery.isError && (
         <>
+          <button
+            data-testid="generate-review-btn"
+            disabled={isGenerating}
+            onClick={() => generateMutation.mutate(selectedWeekStart)}
+          >
+            {buttonLabel}
+          </button>
           <NarrativeSection
             narrative={review?.narrative ?? null}
             status={review?.status ?? 'pending'}

--- a/frontend/src/types/weeklyReview.ts
+++ b/frontend/src/types/weeklyReview.ts
@@ -1,0 +1,18 @@
+export type ReviewStatus = 'pending' | 'generating' | 'complete' | 'failed'
+
+export interface JudgeScores {
+  actionability: number
+  accuracy: number
+  coherence: number
+}
+
+export interface WeeklyReview {
+  id: string
+  user_id: string
+  week_start: string
+  narrative: string | null
+  insights_json: Record<string, unknown> | null
+  scores_json: JudgeScores | null
+  status: ReviewStatus
+  created_at: string
+}

--- a/frontend/src/utils/reviewUtils.ts
+++ b/frontend/src/utils/reviewUtils.ts
@@ -33,6 +33,12 @@ export function formatLocalDate(d: Date): string {
   return `${y}-${m}-${day}`
 }
 
+export function addWeeks(weekStart: string, weeks: number): string {
+  const d = new Date(weekStart + 'T00:00:00')
+  d.setDate(d.getDate() + weeks * 7)
+  return formatLocalDate(d)
+}
+
 export function getWeekStart(date: string): string {
   const d = new Date(date + 'T00:00:00')
   const dow = d.getDay()


### PR DESCRIPTION
## Summary
- Adds \`/weekly-review\` route with \`WeeklyReviewPage\` showing AI-generated narrative, judge scores (radar chart), score trends (line chart), and review history list
- Implements \`useWeeklyReview\` (4s polling during generation), \`useWeeklyReviewHistory\`, and \`useGenerateWeeklyReview\` API hooks wired to future backend endpoints
- Generate/Regenerate button guarded behind non-loading/non-error state; keyboard-accessible history list items

## Test plan
- [ ] 267 tests passing, 0 regressions
- [ ] Production build succeeds
- [ ] Navigate to \`/weekly-review\` — page renders with week navigation
- [ ] Click \"Generate Review\" — button disables while generating, re-enables on completion
- [ ] Week navigation switches selected week and re-fetches

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)