### PR TITLE
[#31] feat: AI Agent Group D — Judge (LLM-as-Judge)

### DIFF
--- a/backend/alembic/versions/0008_add_agent_score_history_table.py
+++ b/backend/alembic/versions/0008_add_agent_score_history_table.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 from alembic import op
 

--- a/backend/alembic/versions/0008_add_agent_score_history_table.py
+++ b/backend/alembic/versions/0008_add_agent_score_history_table.py
@@ -44,6 +44,22 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("now()"),
         ),
+        sa.CheckConstraint(
+            "actionability_score BETWEEN 1 AND 10",
+            name="ck_agent_score_history_actionability",
+        ),
+        sa.CheckConstraint(
+            "accuracy_score BETWEEN 1 AND 10",
+            name="ck_agent_score_history_accuracy",
+        ),
+        sa.CheckConstraint(
+            "coherence_score BETWEEN 1 AND 10",
+            name="ck_agent_score_history_coherence",
+        ),
+        sa.CheckConstraint(
+            "overall_score BETWEEN 1 AND 10",
+            name="ck_agent_score_history_overall",
+        ),
     )
     op.create_index(
         "idx_agent_score_history_user_date",

--- a/backend/alembic/versions/0008_add_agent_score_history_table.py
+++ b/backend/alembic/versions/0008_add_agent_score_history_table.py
@@ -1,0 +1,61 @@
+"""add agent_score_history table
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-04-19
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0008"
+down_revision: str = "0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_score_history",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("analysis_date", sa.Date(), nullable=False),
+        sa.Column("actionability_score", sa.Integer(), nullable=False),
+        sa.Column("accuracy_score", sa.Integer(), nullable=False),
+        sa.Column("coherence_score", sa.Integer(), nullable=False),
+        sa.Column("overall_score", sa.Integer(), nullable=False),
+        sa.Column("feedback", sa.Text(), nullable=False),
+        sa.Column("retry_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "idx_agent_score_history_user_date",
+        "agent_score_history",
+        ["user_id", "analysis_date"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_agent_score_history_user_date",
+        table_name="agent_score_history",
+    )
+    op.drop_table("agent_score_history")

--- a/backend/app/agents/judge.py
+++ b/backend/app/agents/judge.py
@@ -19,11 +19,13 @@ judge: Agent[JudgeDeps, JudgeResult] = Agent(
     retries=2,
     system_prompt=(
         "You are an impartial evaluator of weekly productivity review narratives. "
-        "Given a narrative produced by an AI writer and the underlying data it was based on, "
-        "score the narrative on three dimensions (each from 1 to 10): "
-        "1) actionability_score: Are the observations specific and grounded enough to act on? "
-        "2) accuracy_score: Does the narrative accurately reflect the underlying data? "
-        "3) coherence_score: Is the narrative internally consistent and logically structured? "
+        "Given a narrative produced by an AI writer and the underlying data "
+        "it was based on, score the narrative on three dimensions (1–10 each): "
+        "1) actionability_score: Are observations specific and grounded enough "
+        "to act on? "
+        "2) accuracy_score: Does the narrative accurately reflect the data? "
+        "3) coherence_score: Is the narrative internally consistent and "
+        "logically structured? "
         "Then provide an overall_score (1–10) as a holistic assessment. "
         "Finally, provide a brief feedback string explaining the scores. "
         "Be critical but fair. Base scores solely on the data and narrative provided."
@@ -105,7 +107,9 @@ async def add_evaluation_context(ctx: RunContext[JudgeDeps]) -> str:
 
 
 @judge.output_validator
-async def validate_scores(ctx: RunContext[JudgeDeps], result: JudgeResult) -> JudgeResult:
+async def validate_scores(
+    ctx: RunContext[JudgeDeps], result: JudgeResult
+) -> JudgeResult:
     """Raise ModelRetry if any dimension score is below the configured threshold.
 
     The agent is configured with retries=2, so the LLM will re-evaluate the
@@ -113,7 +117,10 @@ async def validate_scores(ctx: RunContext[JudgeDeps], result: JudgeResult) -> Ju
     This avoids self-bias by using a different provider (Gemini vs OpenAI).
     """
     threshold = settings.JUDGE_SCORE_THRESHOLD
-    if min(result.actionability_score, result.accuracy_score, result.coherence_score) < threshold:
+    min_dim = min(
+        result.actionability_score, result.accuracy_score, result.coherence_score
+    )
+    if min_dim < threshold:
         judge_retry_count.labels(agent_name="judge").inc()
         raise ModelRetry(
             f"One or more dimension scores are below the threshold of {threshold}. "

--- a/backend/app/agents/judge.py
+++ b/backend/app/agents/judge.py
@@ -29,13 +29,64 @@ judge: Agent[JudgeDeps, JudgeResult] = Agent(
 )
 
 
+def _serialize_group_a_summary(deps: JudgeDeps) -> list[str]:
+    """Return concise data-summary lines from Group A results for the prompt."""
+    ga = deps.group_a_result
+    lines: list[str] = []
+
+    if ga.time_analysis:
+        t = ga.time_analysis
+        lines.append(
+            f"TIME: tracked={t.total_tracked_hours:.2f}h, "
+            f"planned={t.total_planned_hours:.2f}h, "
+            f"utilization={t.utilization_pct:.1f}%"
+        )
+    else:
+        lines.append("TIME: unavailable")
+
+    if ga.meeting_analysis:
+        m = ga.meeting_analysis
+        lines.append(
+            f"MEETINGS: {m.meeting_count} meetings, "
+            f"{m.total_meeting_hours:.2f}h total, "
+            f"focus={m.focus_time_hours:.2f}h"
+        )
+    else:
+        lines.append("MEETINGS: unavailable")
+
+    if ga.code_analysis:
+        c = ga.code_analysis
+        lines.append(f"CODE: commits={c.commits_count}, prs={c.pull_requests_count}")
+    else:
+        lines.append("CODE: unavailable")
+
+    if ga.task_analysis:
+        tk = ga.task_analysis
+        lines.append(
+            f"TASKS: {tk.completed_tasks}/{tk.total_tasks} completed "
+            f"({tk.completion_rate_pct:.1f}%), overdue={tk.overdue_tasks}"
+        )
+    else:
+        lines.append("TASKS: unavailable")
+
+    pd = deps.pattern_result
+    if pd.patterns:
+        pattern_lines = [
+            f"  - [{p.category}] {p.pattern} (confidence={p.confidence:.2f})"
+            for p in pd.patterns
+        ]
+        lines.append("PATTERNS:\n" + "\n".join(pattern_lines))
+    else:
+        lines.append("PATTERNS: none detected")
+
+    return lines
+
+
 @judge.instructions
 async def add_evaluation_context(ctx: RunContext[JudgeDeps]) -> str:
     """Serialize the narrative and underlying pipeline data into the prompt."""
     deps = ctx.deps
     nw = deps.narrative_result
-    ga = deps.group_a_result
-    pd = deps.pattern_result
 
     sections = [
         f"Analysis date: {deps.analysis_date}",
@@ -45,52 +96,7 @@ async def add_evaluation_context(ctx: RunContext[JudgeDeps]) -> str:
         f"Productivity Patterns:\n{nw.productivity_patterns}",
         f"Areas of Concern:\n{nw.areas_of_concern}",
         "--- UNDERLYING DATA ---",
+        *_serialize_group_a_summary(deps),
     ]
-
-    if ga.time_analysis:
-        t = ga.time_analysis
-        sections.append(
-            f"TIME: tracked={t.total_tracked_hours:.2f}h, "
-            f"planned={t.total_planned_hours:.2f}h, "
-            f"utilization={t.utilization_pct:.1f}%"
-        )
-    else:
-        sections.append("TIME: unavailable")
-
-    if ga.meeting_analysis:
-        m = ga.meeting_analysis
-        sections.append(
-            f"MEETINGS: {m.meeting_count} meetings, "
-            f"{m.total_meeting_hours:.2f}h total, "
-            f"focus={m.focus_time_hours:.2f}h"
-        )
-    else:
-        sections.append("MEETINGS: unavailable")
-
-    if ga.code_analysis:
-        c = ga.code_analysis
-        sections.append(
-            f"CODE: commits={c.commits_count}, prs={c.pull_requests_count}"
-        )
-    else:
-        sections.append("CODE: unavailable")
-
-    if ga.task_analysis:
-        tk = ga.task_analysis
-        sections.append(
-            f"TASKS: {tk.completed_tasks}/{tk.total_tasks} completed "
-            f"({tk.completion_rate_pct:.1f}%), overdue={tk.overdue_tasks}"
-        )
-    else:
-        sections.append("TASKS: unavailable")
-
-    if pd.patterns:
-        pattern_lines = [
-            f"  - [{p.category}] {p.pattern} (confidence={p.confidence:.2f})"
-            for p in pd.patterns
-        ]
-        sections.append("PATTERNS:\n" + "\n".join(pattern_lines))
-    else:
-        sections.append("PATTERNS: none detected")
 
     return "\n\n".join(sections)

--- a/backend/app/agents/judge.py
+++ b/backend/app/agents/judge.py
@@ -9,6 +9,7 @@ from pydantic_ai import Agent, ModelRetry, RunContext
 
 from app.agents.schemas import JudgeDeps, JudgeResult
 from app.core.config import settings
+from app.core.metrics import judge_retry_count
 
 judge: Agent[JudgeDeps, JudgeResult] = Agent(
     model=settings.LLM_JUDGE_MODEL,
@@ -113,6 +114,7 @@ async def validate_scores(ctx: RunContext[JudgeDeps], result: JudgeResult) -> Ju
     """
     threshold = settings.JUDGE_SCORE_THRESHOLD
     if min(result.actionability_score, result.accuracy_score, result.coherence_score) < threshold:
+        judge_retry_count.labels(agent_name="judge").inc()
         raise ModelRetry(
             f"One or more dimension scores are below the threshold of {threshold}. "
             "Please re-evaluate and provide higher-quality scores."

--- a/backend/app/agents/judge.py
+++ b/backend/app/agents/judge.py
@@ -5,7 +5,7 @@ Uses a different LLM provider than the Narrative Writer to avoid self-bias.
 
 from __future__ import annotations
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, ModelRetry, RunContext
 
 from app.agents.schemas import JudgeDeps, JudgeResult
 from app.core.config import settings
@@ -15,6 +15,7 @@ judge: Agent[JudgeDeps, JudgeResult] = Agent(
     output_type=JudgeResult,
     deps_type=JudgeDeps,
     defer_model_check=True,
+    retries=2,
     system_prompt=(
         "You are an impartial evaluator of weekly productivity review narratives. "
         "Given a narrative produced by an AI writer and the underlying data it was based on, "
@@ -100,3 +101,15 @@ async def add_evaluation_context(ctx: RunContext[JudgeDeps]) -> str:
     ]
 
     return "\n\n".join(sections)
+
+
+@judge.output_validator
+async def validate_scores(ctx: RunContext[JudgeDeps], result: JudgeResult) -> JudgeResult:
+    """Raise ModelRetry if any dimension score is below the configured threshold."""
+    threshold = settings.JUDGE_SCORE_THRESHOLD
+    if min(result.actionability_score, result.accuracy_score, result.coherence_score) < threshold:
+        raise ModelRetry(
+            f"One or more dimension scores are below the threshold of {threshold}. "
+            "Please re-evaluate and provide higher-quality scores."
+        )
+    return result

--- a/backend/app/agents/judge.py
+++ b/backend/app/agents/judge.py
@@ -1,0 +1,96 @@
+"""Judge agent — LLM-as-Judge scoring of weekly review narratives (Group D).
+
+Uses a different LLM provider than the Narrative Writer to avoid self-bias.
+"""
+
+from __future__ import annotations
+
+from pydantic_ai import Agent, RunContext
+
+from app.agents.schemas import JudgeDeps, JudgeResult
+from app.core.config import settings
+
+judge: Agent[JudgeDeps, JudgeResult] = Agent(
+    model=settings.LLM_JUDGE_MODEL,
+    output_type=JudgeResult,
+    deps_type=JudgeDeps,
+    defer_model_check=True,
+    system_prompt=(
+        "You are an impartial evaluator of weekly productivity review narratives. "
+        "Given a narrative produced by an AI writer and the underlying data it was based on, "
+        "score the narrative on three dimensions (each from 1 to 10): "
+        "1) actionability_score: Are the observations specific and grounded enough to act on? "
+        "2) accuracy_score: Does the narrative accurately reflect the underlying data? "
+        "3) coherence_score: Is the narrative internally consistent and logically structured? "
+        "Then provide an overall_score (1–10) as a holistic assessment. "
+        "Finally, provide a brief feedback string explaining the scores. "
+        "Be critical but fair. Base scores solely on the data and narrative provided."
+    ),
+)
+
+
+@judge.instructions
+async def add_evaluation_context(ctx: RunContext[JudgeDeps]) -> str:
+    """Serialize the narrative and underlying pipeline data into the prompt."""
+    deps = ctx.deps
+    nw = deps.narrative_result
+    ga = deps.group_a_result
+    pd = deps.pattern_result
+
+    sections = [
+        f"Analysis date: {deps.analysis_date}",
+        "--- NARRATIVE TO EVALUATE ---",
+        f"Executive Summary:\n{nw.executive_summary}",
+        f"Time Analysis:\n{nw.time_analysis}",
+        f"Productivity Patterns:\n{nw.productivity_patterns}",
+        f"Areas of Concern:\n{nw.areas_of_concern}",
+        "--- UNDERLYING DATA ---",
+    ]
+
+    if ga.time_analysis:
+        t = ga.time_analysis
+        sections.append(
+            f"TIME: tracked={t.total_tracked_hours:.2f}h, "
+            f"planned={t.total_planned_hours:.2f}h, "
+            f"utilization={t.utilization_pct:.1f}%"
+        )
+    else:
+        sections.append("TIME: unavailable")
+
+    if ga.meeting_analysis:
+        m = ga.meeting_analysis
+        sections.append(
+            f"MEETINGS: {m.meeting_count} meetings, "
+            f"{m.total_meeting_hours:.2f}h total, "
+            f"focus={m.focus_time_hours:.2f}h"
+        )
+    else:
+        sections.append("MEETINGS: unavailable")
+
+    if ga.code_analysis:
+        c = ga.code_analysis
+        sections.append(
+            f"CODE: commits={c.commits_count}, prs={c.pull_requests_count}"
+        )
+    else:
+        sections.append("CODE: unavailable")
+
+    if ga.task_analysis:
+        tk = ga.task_analysis
+        sections.append(
+            f"TASKS: {tk.completed_tasks}/{tk.total_tasks} completed "
+            f"({tk.completion_rate_pct:.1f}%), overdue={tk.overdue_tasks}"
+        )
+    else:
+        sections.append("TASKS: unavailable")
+
+    if pd.patterns:
+        pattern_lines = [
+            f"  - [{p.category}] {p.pattern} (confidence={p.confidence:.2f})"
+            for p in pd.patterns
+        ]
+        sections.append("PATTERNS:\n" + "\n".join(pattern_lines))
+    else:
+        sections.append("PATTERNS: none detected")
+
+    return "\n\n".join(sections)

--- a/backend/app/agents/judge.py
+++ b/backend/app/agents/judge.py
@@ -105,7 +105,12 @@ async def add_evaluation_context(ctx: RunContext[JudgeDeps]) -> str:
 
 @judge.output_validator
 async def validate_scores(ctx: RunContext[JudgeDeps], result: JudgeResult) -> JudgeResult:
-    """Raise ModelRetry if any dimension score is below the configured threshold."""
+    """Raise ModelRetry if any dimension score is below the configured threshold.
+
+    The agent is configured with retries=2, so the LLM will re-evaluate the
+    narrative at most twice before the caller receives UnexpectedModelBehavior.
+    This avoids self-bias by using a different provider (Gemini vs OpenAI).
+    """
     threshold = settings.JUDGE_SCORE_THRESHOLD
     if min(result.actionability_score, result.accuracy_score, result.coherence_score) < threshold:
         raise ModelRetry(

--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -9,6 +9,7 @@ from datetime import date
 from typing import Any
 
 from pydantic_ai import Agent
+from pydantic_ai.exceptions import UnexpectedModelBehavior
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.base import (
@@ -39,6 +40,7 @@ from app.agents.schemas import (
 from app.agents.task_analyst import task_analyst
 from app.agents.time_analyst import time_analyst
 from app.core.metrics import judge_score
+from app.models.agent_score_history import AgentScoreHistory
 
 log = logging.getLogger(__name__)
 
@@ -172,15 +174,20 @@ async def run_group_c(
 
 
 async def run_group_d(
+    db: AsyncSession,
     group_a_result: GroupAResult,
     pattern_result: PatternDetectorResult,
     narrative_result: NarrativeWriterResult,
     user_id: uuid.UUID,
     analysis_date: date,
-) -> JudgeResult:
+) -> JudgeResult | None:
     """Run the Judge agent (Group D) to score the Narrative Writer's output.
 
+    Persists the score to agent_score_history and records Prometheus metrics.
+    Returns None if the judge fails after all retries (logged, not raised).
+
     Args:
+        db: Async database session for persisting score history.
         group_a_result: Aggregated output from all Group A analysts.
         pattern_result: Output from the Pattern Detector (Group B).
         narrative_result: Output from the Narrative Writer (Group C).
@@ -188,7 +195,7 @@ async def run_group_d(
         analysis_date: The reference date for the analysis.
 
     Returns:
-        JudgeResult with dimension scores and feedback.
+        JudgeResult with dimension scores and feedback, or None on failure.
     """
     deps = JudgeDeps(
         user_id=user_id,
@@ -197,6 +204,26 @@ async def run_group_d(
         pattern_result=pattern_result,
         narrative_result=narrative_result,
     )
-    result = await run_with_metrics(judge, "judge", deps)
+    retry_count = 0
+    try:
+        result = await run_with_metrics(judge, "judge", deps)
+    except UnexpectedModelBehavior as exc:
+        log.error("Judge agent failed after retries: %s", exc)
+        return None
+
     judge_score.labels(agent_name="judge").observe(result.overall_score)
+
+    record = AgentScoreHistory(
+        user_id=user_id,
+        analysis_date=analysis_date,
+        actionability_score=result.actionability_score,
+        accuracy_score=result.accuracy_score,
+        coherence_score=result.coherence_score,
+        overall_score=result.overall_score,
+        feedback=result.feedback,
+        retry_count=retry_count,
+    )
+    db.add(record)
+    await db.flush()
+
     return result

--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -19,12 +19,15 @@ from app.agents.base import (
     run_with_metrics,
 )
 from app.agents.code_analyst import code_analyst
+from app.agents.judge import judge
 from app.agents.meeting_analyst import meeting_analyst
 from app.agents.narrative_writer import narrative_writer
 from app.agents.pattern_detector import pattern_detector
 from app.agents.schemas import (
     CodeAnalystDeps,
     GroupAResult,
+    JudgeDeps,
+    JudgeResult,
     MeetingAnalystDeps,
     NarrativeWriterDeps,
     NarrativeWriterResult,
@@ -35,6 +38,7 @@ from app.agents.schemas import (
 )
 from app.agents.task_analyst import task_analyst
 from app.agents.time_analyst import time_analyst
+from app.core.metrics import judge_score
 
 log = logging.getLogger(__name__)
 
@@ -165,3 +169,34 @@ async def run_group_c(
         pattern_result=pattern_result,
     )
     return await run_with_metrics(narrative_writer, "narrative_writer", deps)
+
+
+async def run_group_d(
+    group_a_result: GroupAResult,
+    pattern_result: PatternDetectorResult,
+    narrative_result: NarrativeWriterResult,
+    user_id: uuid.UUID,
+    analysis_date: date,
+) -> JudgeResult:
+    """Run the Judge agent (Group D) to score the Narrative Writer's output.
+
+    Args:
+        group_a_result: Aggregated output from all Group A analysts.
+        pattern_result: Output from the Pattern Detector (Group B).
+        narrative_result: Output from the Narrative Writer (Group C).
+        user_id: The user whose data was analyzed.
+        analysis_date: The reference date for the analysis.
+
+    Returns:
+        JudgeResult with dimension scores and feedback.
+    """
+    deps = JudgeDeps(
+        user_id=user_id,
+        analysis_date=analysis_date,
+        group_a_result=group_a_result,
+        pattern_result=pattern_result,
+        narrative_result=narrative_result,
+    )
+    result = await run_with_metrics(judge, "judge", deps)
+    judge_score.labels(agent_name="judge").observe(result.overall_score)
+    return result

--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -210,8 +210,6 @@ async def run_group_d(
         log.error("Judge agent failed after retries: %s", exc)
         return None
 
-    judge_score.labels(agent_name="judge").observe(result.overall_score)
-
     # retry_count defaults to 0; pydantic-ai does not expose per-run retry count
     # on the result object — retries are tracked via judge_retry_count metric
     record = AgentScoreHistory(
@@ -225,5 +223,8 @@ async def run_group_d(
     )
     db.add(record)
     await db.flush()
+
+    # Observe metric only after the row is confirmed persisted.
+    judge_score.labels(agent_name="judge").observe(result.overall_score)
 
     return result

--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -204,7 +204,6 @@ async def run_group_d(
         pattern_result=pattern_result,
         narrative_result=narrative_result,
     )
-    retry_count = 0
     try:
         result = await run_with_metrics(judge, "judge", deps)
     except UnexpectedModelBehavior as exc:
@@ -213,6 +212,8 @@ async def run_group_d(
 
     judge_score.labels(agent_name="judge").observe(result.overall_score)
 
+    # retry_count defaults to 0; pydantic-ai does not expose per-run retry count
+    # on the result object — retries are tracked via judge_retry_count metric
     record = AgentScoreHistory(
         user_id=user_id,
         analysis_date=analysis_date,
@@ -221,7 +222,6 @@ async def run_group_d(
         coherence_score=result.coherence_score,
         overall_score=result.overall_score,
         feedback=result.feedback,
-        retry_count=retry_count,
     )
     db.add(record)
     await db.flush()

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -226,3 +226,29 @@ class NarrativeWriterResult(BaseModel):
     time_analysis: str = Field(min_length=1)
     productivity_patterns: str = Field(min_length=1)
     areas_of_concern: str = Field(min_length=1)
+
+
+# ---------------------------------------------------------------------------
+# Judge (Group D)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class JudgeDeps:
+    """Dependencies injected into the Judge agent via RunContext."""
+
+    user_id: uuid.UUID
+    analysis_date: date
+    group_a_result: GroupAResult
+    pattern_result: PatternDetectorResult
+    narrative_result: NarrativeWriterResult
+
+
+class JudgeResult(BaseModel):
+    """Structured output produced by the Judge agent."""
+
+    actionability_score: int = Field(ge=1, le=10)
+    accuracy_score: int = Field(ge=1, le=10)
+    coherence_score: int = Field(ge=1, le=10)
+    overall_score: int = Field(ge=1, le=10)
+    feedback: str = Field(min_length=1)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -44,6 +44,9 @@ class Settings(BaseSettings):
     LLM_MODEL: str = "openai:gpt-4o-mini"
     LLM_JUDGE_MODEL: str = "google-gla:gemini-1.5-flash"
 
+    # Judge agent — minimum acceptable score per dimension (1–10); triggers retry below
+    JUDGE_SCORE_THRESHOLD: int = 6
+
     # Monitoring (optional — silently disabled when absent)
     SENTRY_DSN: str | None = None
     PROMETHEUS_ENABLED: bool = True

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -25,6 +25,12 @@ judge_score: Histogram = Histogram(
     buckets=(10, 20, 30, 40, 50, 60, 70, 80, 90, 100),
 )
 
+judge_retry_count: Counter = Counter(
+    "judge_retry_count",
+    "Number of ModelRetry events triggered by the judge agent",
+    labelnames=["agent_name"],
+)
+
 
 def configure_metrics(
     app: FastAPI,

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -20,9 +20,9 @@ token_cost_total: Counter = Counter(
 
 judge_score: Histogram = Histogram(
     "judge_score",
-    "Score assigned by the judge agent",
+    "Score assigned by the judge agent (1–10 scale)",
     labelnames=["agent_name"],
-    buckets=(10, 20, 30, 40, 50, 60, 70, 80, 90, 100),
+    buckets=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
 )
 
 judge_retry_count: Counter = Counter(

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.agent_score_history import AgentScoreHistory
 from app.models.external_sync import ExternalSync
 from app.models.project import Project
 from app.models.schedule_block import ScheduleBlock
@@ -5,4 +6,12 @@ from app.models.task import Task
 from app.models.time_entry import TimeEntry
 from app.models.user import User
 
-__all__ = ["ExternalSync", "Project", "ScheduleBlock", "Task", "TimeEntry", "User"]
+__all__ = [
+    "AgentScoreHistory",
+    "ExternalSync",
+    "Project",
+    "ScheduleBlock",
+    "Task",
+    "TimeEntry",
+    "User",
+]

--- a/backend/app/models/agent_score_history.py
+++ b/backend/app/models/agent_score_history.py
@@ -1,0 +1,48 @@
+"""AgentScoreHistory model — stores Judge agent scores for trend analysis."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime
+
+from sqlalchemy import Date, DateTime, ForeignKey, Index, Integer, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class AgentScoreHistory(Base):
+    """Persisted Judge scores per user per analysis date."""
+
+    __tablename__ = "agent_score_history"
+    __table_args__ = (
+        Index("idx_agent_score_history_user_date", "user_id", "analysis_date"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    analysis_date: Mapped[date] = mapped_column(Date, nullable=False)
+    actionability_score: Mapped[int] = mapped_column(Integer, nullable=False)
+    accuracy_score: Mapped[int] = mapped_column(Integer, nullable=False)
+    coherence_score: Mapped[int] = mapped_column(Integer, nullable=False)
+    overall_score: Mapped[int] = mapped_column(Integer, nullable=False)
+    feedback: Mapped[str] = mapped_column(Text, nullable=False)
+    retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<AgentScoreHistory(user_id={self.user_id}, "
+            f"date={self.analysis_date}, overall={self.overall_score})>"
+        )

--- a/backend/app/models/agent_score_history.py
+++ b/backend/app/models/agent_score_history.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, date, datetime
 
-from sqlalchemy import Date, DateTime, ForeignKey, Index, Integer, Text
+from sqlalchemy import CheckConstraint, Date, DateTime, ForeignKey, Index, Integer, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
+
+_SCORE_RANGE = "BETWEEN 1 AND 10"
 
 
 class AgentScoreHistory(Base):
@@ -18,6 +20,22 @@ class AgentScoreHistory(Base):
     __tablename__ = "agent_score_history"
     __table_args__ = (
         Index("idx_agent_score_history_user_date", "user_id", "analysis_date"),
+        CheckConstraint(
+            f"actionability_score {_SCORE_RANGE}",
+            name="ck_agent_score_history_actionability",
+        ),
+        CheckConstraint(
+            f"accuracy_score {_SCORE_RANGE}",
+            name="ck_agent_score_history_accuracy",
+        ),
+        CheckConstraint(
+            f"coherence_score {_SCORE_RANGE}",
+            name="ck_agent_score_history_coherence",
+        ),
+        CheckConstraint(
+            f"overall_score {_SCORE_RANGE}",
+            name="ck_agent_score_history_overall",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "prometheus-fastapi-instrumentator>=7.0.0",
     "prometheus-client>=0.20.0",
     "pydantic-ai>=0.0.20",
+    "google-genai>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/unit/agents/conftest.py
+++ b/backend/tests/unit/agents/conftest.py
@@ -86,10 +86,10 @@ def partial_group_a_result() -> GroupAResult:
 @pytest.fixture
 def sample_narrative_result() -> NarrativeWriterResult:
     return NarrativeWriterResult(
-        executive_summary="A productive week with steady progress across all tracked areas.",
+        executive_summary="A productive week with steady progress across all tracked areas.",  # noqa: E501
         time_analysis="6.5 hours tracked against 8 planned, yielding 81% utilization.",
-        productivity_patterns="Commit activity aligns with high-priority task completion.",
-        areas_of_concern="2 overdue tasks and moderate meeting load may impact next sprint.",
+        productivity_patterns="Commit activity aligns with high-priority task completion.",  # noqa: E501
+        areas_of_concern="2 overdue tasks and moderate meeting load may impact next sprint.",  # noqa: E501
     )
 
 

--- a/backend/tests/unit/agents/conftest.py
+++ b/backend/tests/unit/agents/conftest.py
@@ -9,6 +9,7 @@ from app.agents.schemas import (
     CrossPattern,
     GroupAResult,
     MeetingAnalystResult,
+    NarrativeWriterResult,
     PatternDetectorResult,
     TaskAnalystResult,
     TimeAnalystResult,
@@ -79,6 +80,16 @@ def partial_group_a_result() -> GroupAResult:
             insights=["Low completion rate", "3 overdue tasks"],
         ),
         errors={"time_analyst": "timeout", "code_analyst": "no github"},
+    )
+
+
+@pytest.fixture
+def sample_narrative_result() -> NarrativeWriterResult:
+    return NarrativeWriterResult(
+        executive_summary="A productive week with steady progress across all tracked areas.",
+        time_analysis="6.5 hours tracked against 8 planned, yielding 81% utilization.",
+        productivity_patterns="Commit activity aligns with high-priority task completion.",
+        areas_of_concern="2 overdue tasks and moderate meeting load may impact next sprint.",
     )
 
 

--- a/backend/tests/unit/agents/test_judge.py
+++ b/backend/tests/unit/agents/test_judge.py
@@ -138,8 +138,7 @@ async def test_judge_raises_model_retry_when_score_below_threshold(
     sample_pattern_result: PatternDetectorResult,
     sample_narrative_result: NarrativeWriterResult,
 ) -> None:
-    """Result validator raises ModelRetry when any dimension score is below threshold."""
-    from pydantic_ai import ModelRetry
+    """Result validator raises ModelRetry when any dimension score is below threshold."""  # noqa: E501
     from pydantic_ai.models.function import AgentInfo, FunctionModel
 
     from app.agents.judge import judge
@@ -344,8 +343,9 @@ async def test_run_group_d_records_judge_score_metric(
 
 def test_judge_retry_count_metric_exists() -> None:
     """judge_retry_count Counter is defined in metrics module."""
-    from app.core.metrics import judge_retry_count
     from prometheus_client import Counter
+
+    from app.core.metrics import judge_retry_count
 
     assert isinstance(judge_retry_count, Counter)
 

--- a/backend/tests/unit/agents/test_judge.py
+++ b/backend/tests/unit/agents/test_judge.py
@@ -282,6 +282,73 @@ def test_agent_score_history_table_name() -> None:
     assert AgentScoreHistory.__tablename__ == "agent_score_history"
 
 
+# ---------------------------------------------------------------------------
+# Cycle 5 — Orchestrator integration and Prometheus metrics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_group_d_returns_judge_result(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """run_group_d returns a valid JudgeResult."""
+    import app.agents.judge as judge_mod
+    from app.agents.orchestrator import run_group_d
+    from app.agents.schemas import JudgeResult
+
+    with judge_mod.judge.override(model=_make_passing_model()):
+        result = await run_group_d(
+            group_a_result=full_group_a_result,
+            pattern_result=sample_pattern_result,
+            narrative_result=sample_narrative_result,
+            user_id=uuid.uuid4(),
+            analysis_date=date(2026, 4, 14),
+        )
+
+    assert isinstance(result, JudgeResult)
+    assert isinstance(result.feedback, str)
+    assert len(result.feedback) > 0
+
+
+@pytest.mark.asyncio
+async def test_run_group_d_records_judge_score_metric(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """run_group_d observes the overall_score in the judge_score histogram."""
+    from unittest.mock import patch
+
+    import app.agents.judge as judge_mod
+    from app.agents.orchestrator import run_group_d
+    from app.core.metrics import judge_score
+
+    with (
+        judge_mod.judge.override(model=_make_passing_model()),
+        patch.object(judge_score, "labels", wraps=judge_score.labels) as mock_labels,
+    ):
+        result = await run_group_d(
+            group_a_result=full_group_a_result,
+            pattern_result=sample_pattern_result,
+            narrative_result=sample_narrative_result,
+            user_id=uuid.uuid4(),
+            analysis_date=date(2026, 4, 14),
+        )
+
+    mock_labels.assert_called_once_with(agent_name="judge")
+    mock_labels.return_value.observe.assert_called_once_with(result.overall_score)
+
+
+def test_judge_retry_count_metric_exists() -> None:
+    """judge_retry_count Counter is defined in metrics module."""
+    from app.core.metrics import judge_retry_count
+    from prometheus_client import Counter
+
+    assert isinstance(judge_retry_count, Counter)
+
+
 def test_judge_deps_accepts_full_pipeline_inputs(
     full_group_a_result: GroupAResult,
     sample_pattern_result: PatternDetectorResult,

--- a/backend/tests/unit/agents/test_judge.py
+++ b/backend/tests/unit/agents/test_judge.py
@@ -211,6 +211,40 @@ async def test_judge_no_retry_when_all_scores_above_threshold(
     assert result.output.coherence_score >= 6
 
 
+# ---------------------------------------------------------------------------
+# Cycle 3 — Provider isolation
+# ---------------------------------------------------------------------------
+
+
+def test_judge_uses_different_model_than_narrative_writer() -> None:
+    """Judge agent's configured model differs from the Narrative Writer's model."""
+    from app.agents.judge import judge
+    from app.agents.narrative_writer import narrative_writer
+
+    judge_model = str(judge.model)
+    writer_model = str(narrative_writer.model)
+    assert judge_model != writer_model, (
+        f"Judge and Narrative Writer must use different providers, "
+        f"but both use: {judge_model}"
+    )
+
+
+def test_judge_model_is_llm_judge_model_setting() -> None:
+    """Judge agent is configured with settings.LLM_JUDGE_MODEL."""
+    from app.agents.judge import judge
+    from app.core.config import settings
+
+    assert settings.LLM_JUDGE_MODEL in str(judge.model)
+
+
+def test_narrative_writer_model_is_llm_model_setting() -> None:
+    """Narrative Writer is configured with settings.LLM_MODEL (not the judge model)."""
+    from app.agents.narrative_writer import narrative_writer
+    from app.core.config import settings
+
+    assert settings.LLM_MODEL in str(narrative_writer.model)
+
+
 def test_judge_deps_accepts_full_pipeline_inputs(
     full_group_a_result: GroupAResult,
     sample_pattern_result: PatternDetectorResult,

--- a/backend/tests/unit/agents/test_judge.py
+++ b/backend/tests/unit/agents/test_judge.py
@@ -6,13 +6,34 @@ import uuid
 from datetime import date
 
 import pytest
-from pydantic_ai.models.test import TestModel
 
 from app.agents.schemas import (
     GroupAResult,
     NarrativeWriterResult,
     PatternDetectorResult,
 )
+
+
+def _make_passing_model():  # type: ignore[return]
+    """Return a FunctionModel that always emits scores above the retry threshold."""
+    from pydantic_ai.models.function import FunctionModel
+
+    from app.agents.schemas import JudgeResult
+
+    def _model(messages, info):  # type: ignore[return, type-arg]
+        from pydantic_ai.models.function import ModelResponse, TextPart
+
+        result = JudgeResult(
+            actionability_score=8,
+            accuracy_score=9,
+            coherence_score=7,
+            overall_score=8,
+            feedback="Well-grounded narrative with actionable observations.",
+        )
+        return ModelResponse(parts=[TextPart(result.model_dump_json())])
+
+    return FunctionModel(_model)
+
 
 # ---------------------------------------------------------------------------
 # Cycle 1 — Schema + basic agent output
@@ -25,7 +46,7 @@ async def test_judge_result_conforms_to_schema(
     sample_pattern_result: PatternDetectorResult,
     sample_narrative_result: NarrativeWriterResult,
 ) -> None:
-    """Agent with TestModel returns a valid JudgeResult schema."""
+    """Agent returns a valid JudgeResult schema."""
     from app.agents.judge import judge
     from app.agents.schemas import JudgeDeps, JudgeResult
 
@@ -37,7 +58,7 @@ async def test_judge_result_conforms_to_schema(
         narrative_result=sample_narrative_result,
     )
 
-    with judge.override(model=TestModel()):
+    with judge.override(model=_make_passing_model()):
         result = await judge.run("Analyze and produce structured insights.", deps=deps)
 
     output = result.output
@@ -67,7 +88,7 @@ async def test_judge_all_scores_within_range(
         narrative_result=sample_narrative_result,
     )
 
-    with judge.override(model=TestModel()):
+    with judge.override(model=_make_passing_model()):
         result = await judge.run("Analyze and produce structured insights.", deps=deps)
 
     output = result.output
@@ -99,7 +120,7 @@ async def test_judge_feedback_is_non_empty_string(
         narrative_result=sample_narrative_result,
     )
 
-    with judge.override(model=TestModel()):
+    with judge.override(model=_make_passing_model()):
         result = await judge.run("Analyze and produce structured insights.", deps=deps)
 
     assert isinstance(result.output.feedback, str)

--- a/backend/tests/unit/agents/test_judge.py
+++ b/backend/tests/unit/agents/test_judge.py
@@ -245,6 +245,43 @@ def test_narrative_writer_model_is_llm_model_setting() -> None:
     assert settings.LLM_MODEL in str(narrative_writer.model)
 
 
+# ---------------------------------------------------------------------------
+# Cycle 4 — Score history DB model
+# ---------------------------------------------------------------------------
+
+
+def test_agent_score_history_model_has_required_fields() -> None:
+    """AgentScoreHistory ORM model exposes all required columns."""
+    from app.models.agent_score_history import AgentScoreHistory
+
+    record = AgentScoreHistory(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        actionability_score=8,
+        accuracy_score=9,
+        coherence_score=7,
+        overall_score=8,
+        feedback="Good narrative.",
+        retry_count=0,
+    )
+
+    assert record.user_id is not None
+    assert record.analysis_date == date(2026, 4, 14)
+    assert record.actionability_score == 8
+    assert record.accuracy_score == 9
+    assert record.coherence_score == 7
+    assert record.overall_score == 8
+    assert record.feedback == "Good narrative."
+    assert record.retry_count == 0
+
+
+def test_agent_score_history_table_name() -> None:
+    """AgentScoreHistory maps to the agent_score_history table."""
+    from app.models.agent_score_history import AgentScoreHistory
+
+    assert AgentScoreHistory.__tablename__ == "agent_score_history"
+
+
 def test_judge_deps_accepts_full_pipeline_inputs(
     full_group_a_result: GroupAResult,
     sample_pattern_result: PatternDetectorResult,

--- a/backend/tests/unit/agents/test_judge.py
+++ b/backend/tests/unit/agents/test_judge.py
@@ -293,12 +293,18 @@ async def test_run_group_d_returns_judge_result(
     sample_narrative_result: NarrativeWriterResult,
 ) -> None:
     """run_group_d returns a valid JudgeResult."""
+    from unittest.mock import AsyncMock, MagicMock
+
     import app.agents.judge as judge_mod
     from app.agents.orchestrator import run_group_d
     from app.agents.schemas import JudgeResult
 
+    mock_db = MagicMock()
+    mock_db.flush = AsyncMock()
+
     with judge_mod.judge.override(model=_make_passing_model()):
         result = await run_group_d(
+            db=mock_db,
             group_a_result=full_group_a_result,
             pattern_result=sample_pattern_result,
             narrative_result=sample_narrative_result,
@@ -309,6 +315,8 @@ async def test_run_group_d_returns_judge_result(
     assert isinstance(result, JudgeResult)
     assert isinstance(result.feedback, str)
     assert len(result.feedback) > 0
+    mock_db.add.assert_called_once()
+    mock_db.flush.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -318,18 +326,21 @@ async def test_run_group_d_records_judge_score_metric(
     sample_narrative_result: NarrativeWriterResult,
 ) -> None:
     """run_group_d observes the overall_score in the judge_score histogram."""
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     import app.agents.judge as judge_mod
     from app.agents.orchestrator import run_group_d
     from app.core.metrics import judge_score
 
+    mock_db = MagicMock()
+    mock_db.flush = AsyncMock()
     mock_histogram = MagicMock()
     with (
         judge_mod.judge.override(model=_make_passing_model()),
         patch.object(judge_score, "labels", return_value=mock_histogram) as mock_labels,
     ):
         result = await run_group_d(
+            db=mock_db,
             group_a_result=full_group_a_result,
             pattern_result=sample_pattern_result,
             narrative_result=sample_narrative_result,
@@ -339,6 +350,43 @@ async def test_run_group_d_records_judge_score_metric(
 
     mock_labels.assert_called_once_with(agent_name="judge")
     mock_histogram.observe.assert_called_once_with(result.overall_score)
+
+
+@pytest.mark.asyncio
+async def test_run_group_d_returns_none_on_exhausted_retries(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """run_group_d returns None (does not raise) when all retries are exhausted."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+    import app.agents.judge as judge_mod
+    from app.agents.orchestrator import run_group_d
+
+    mock_db = MagicMock()
+    mock_db.flush = AsyncMock()
+
+    with (
+        judge_mod.judge.override(model=_make_passing_model()),
+        patch(
+            "app.agents.orchestrator.run_with_metrics",
+            side_effect=UnexpectedModelBehavior("Exceeded maximum retries (2)"),
+        ),
+    ):
+        result = await run_group_d(
+            db=mock_db,
+            group_a_result=full_group_a_result,
+            pattern_result=sample_pattern_result,
+            narrative_result=sample_narrative_result,
+            user_id=uuid.uuid4(),
+            analysis_date=date(2026, 4, 14),
+        )
+
+    assert result is None
+    mock_db.add.assert_not_called()
 
 
 def test_judge_retry_count_metric_exists() -> None:

--- a/backend/tests/unit/agents/test_judge.py
+++ b/backend/tests/unit/agents/test_judge.py
@@ -1,0 +1,129 @@
+"""Unit tests for the Judge agent (Group D)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+from pydantic_ai.models.test import TestModel
+
+from app.agents.schemas import (
+    GroupAResult,
+    NarrativeWriterResult,
+    PatternDetectorResult,
+)
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — Schema + basic agent output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_judge_result_conforms_to_schema(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """Agent with TestModel returns a valid JudgeResult schema."""
+    from app.agents.judge import judge
+    from app.agents.schemas import JudgeDeps, JudgeResult
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+
+    with judge.override(model=TestModel()):
+        result = await judge.run("Analyze and produce structured insights.", deps=deps)
+
+    output = result.output
+    assert isinstance(output, JudgeResult)
+    assert hasattr(output, "actionability_score")
+    assert hasattr(output, "accuracy_score")
+    assert hasattr(output, "coherence_score")
+    assert hasattr(output, "overall_score")
+    assert hasattr(output, "feedback")
+
+
+@pytest.mark.asyncio
+async def test_judge_all_scores_within_range(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """All four scores are integers in the range [1, 10]."""
+    from app.agents.judge import judge
+    from app.agents.schemas import JudgeDeps
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+
+    with judge.override(model=TestModel()):
+        result = await judge.run("Analyze and produce structured insights.", deps=deps)
+
+    output = result.output
+    for score in (
+        output.actionability_score,
+        output.accuracy_score,
+        output.coherence_score,
+        output.overall_score,
+    ):
+        assert isinstance(score, int)
+        assert 1 <= score <= 10
+
+
+@pytest.mark.asyncio
+async def test_judge_feedback_is_non_empty_string(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """Feedback field is a non-empty string."""
+    from app.agents.judge import judge
+    from app.agents.schemas import JudgeDeps
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+
+    with judge.override(model=TestModel()):
+        result = await judge.run("Analyze and produce structured insights.", deps=deps)
+
+    assert isinstance(result.output.feedback, str)
+    assert len(result.output.feedback) > 0
+
+
+def test_judge_deps_accepts_full_pipeline_inputs(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """JudgeDeps can be constructed without errors from full pipeline outputs."""
+    from app.agents.schemas import JudgeDeps
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+
+    assert deps.user_id is not None
+    assert deps.analysis_date == date(2026, 4, 14)
+    assert deps.group_a_result is full_group_a_result
+    assert deps.pattern_result is sample_pattern_result
+    assert deps.narrative_result is sample_narrative_result

--- a/backend/tests/unit/agents/test_judge.py
+++ b/backend/tests/unit/agents/test_judge.py
@@ -350,6 +350,260 @@ def test_judge_retry_count_metric_exists() -> None:
     assert isinstance(judge_retry_count, Counter)
 
 
+# ---------------------------------------------------------------------------
+# Mutation killers — prompt content and agent configuration
+# ---------------------------------------------------------------------------
+
+
+def test_judge_max_retries_is_two() -> None:
+    """Judge agent is configured with exactly 2 retries (max_result_retries)."""
+    from app.agents.judge import judge
+
+    assert judge._max_result_retries == 2
+
+
+def test_judge_system_prompt_covers_all_dimensions() -> None:
+    """System prompt references all three scoring dimensions and overall score."""
+    from app.agents.judge import judge
+
+    prompt = " ".join(judge._system_prompts)
+    assert "actionability_score" in prompt
+    assert "accuracy_score" in prompt
+    assert "coherence_score" in prompt
+    assert "overall_score" in prompt
+    assert "You are an impartial evaluator" in prompt
+    assert "1\u201310" in prompt or "1-10" in prompt  # en-dash or hyphen variant
+    assert "XX" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_serialize_group_a_summary_includes_time_data(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """_serialize_group_a_summary includes tracked hours and utilization."""
+    from app.agents.judge import _serialize_group_a_summary
+    from app.agents.schemas import JudgeDeps
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+
+    lines = _serialize_group_a_summary(deps)
+    combined = "\n".join(lines)
+
+    assert any(line.startswith("TIME: tracked") for line in lines)
+    assert "6.50h" in combined
+    assert "81.2%" in combined
+    assert "XX" not in combined
+
+
+@pytest.mark.asyncio
+async def test_serialize_group_a_summary_includes_meeting_data(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """_serialize_group_a_summary includes meeting count and focus hours."""
+    from app.agents.judge import _serialize_group_a_summary
+    from app.agents.schemas import JudgeDeps
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+
+    lines = _serialize_group_a_summary(deps)
+    combined = "\n".join(lines)
+
+    assert any(line.startswith("MEETINGS: 3 meetings") for line in lines)
+    assert "focus=5.50h" in combined
+    assert "XX" not in combined
+
+
+@pytest.mark.asyncio
+async def test_serialize_group_a_summary_pattern_line_format(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """Pattern lines include category, pattern text, and confidence value."""
+    from app.agents.judge import _serialize_group_a_summary
+    from app.agents.schemas import JudgeDeps
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+
+    lines = _serialize_group_a_summary(deps)
+    combined = "\n".join(lines)
+
+    assert "  - [time-meeting]" in combined
+    assert "confidence=0.85" in combined
+    assert "PATTERNS:\n  - [time-meeting]" in combined
+    assert "XX" not in combined
+
+
+@pytest.mark.asyncio
+async def test_serialize_group_a_summary_includes_code_and_task_data(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """_serialize_group_a_summary includes commit/PR counts and task completion."""
+    from app.agents.judge import _serialize_group_a_summary
+    from app.agents.schemas import JudgeDeps
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+
+    lines = _serialize_group_a_summary(deps)
+    combined = "\n".join(lines)
+
+    assert any(line.startswith("CODE: commits=5") for line in lines)
+    assert "prs=2" in combined
+    assert "4/12" in combined
+    assert any(line.startswith("PATTERNS:") for line in lines)
+    assert "XX" not in combined
+
+
+@pytest.mark.asyncio
+async def test_serialize_group_a_summary_unavailable_sections(
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """_serialize_group_a_summary marks missing sections as unavailable."""
+    from app.agents.judge import _serialize_group_a_summary
+    from app.agents.schemas import JudgeDeps
+
+    empty_ga = GroupAResult(
+        time_analysis=None,
+        meeting_analysis=None,
+        code_analysis=None,
+        task_analysis=None,
+        errors={},
+    )
+    empty_pattern = PatternDetectorResult(patterns=[], summary="No patterns.")
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=empty_ga,
+        pattern_result=empty_pattern,
+        narrative_result=sample_narrative_result,
+    )
+
+    lines = _serialize_group_a_summary(deps)
+    combined = "\n".join(lines)
+
+    assert any(line == "TIME: unavailable" for line in lines)
+    assert any(line == "MEETINGS: unavailable" for line in lines)
+    assert any(line == "CODE: unavailable" for line in lines)
+    assert any(line == "TASKS: unavailable" for line in lines)
+    assert any(line == "PATTERNS: none detected" for line in lines)
+    assert "XX" not in combined
+
+
+@pytest.mark.asyncio
+async def test_add_evaluation_context_contains_narrative_sections(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """add_evaluation_context output contains analysis_date and narrative content."""
+    import app.agents.judge as judge_mod
+    from app.agents.schemas import JudgeDeps
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+
+    # Create a fake RunContext-like object
+    class FakeCtx:
+        def __init__(self, deps):  # type: ignore[no-untyped-def]
+            self.deps = deps
+
+    ctx = FakeCtx(deps)
+    context_str = await judge_mod.add_evaluation_context(ctx)  # type: ignore[arg-type]
+
+    assert "Analysis date: 2026-04-14" in context_str
+    assert "--- NARRATIVE TO EVALUATE ---" in context_str
+    assert sample_narrative_result.executive_summary in context_str
+    assert "--- UNDERLYING DATA ---" in context_str
+    assert context_str.count("\n\n") >= 3  # sections joined by double newline
+    assert "XX" not in context_str
+
+
+@pytest.mark.asyncio
+async def test_validate_scores_exact_threshold_boundary(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """Score exactly at threshold does not trigger retry; one below does."""
+    from pydantic_ai import ModelRetry
+
+    from app.agents.judge import validate_scores
+    from app.agents.schemas import JudgeDeps, JudgeResult
+    from app.core.config import settings
+
+    class FakeCtx:
+        def __init__(self, deps):  # type: ignore[no-untyped-def]
+            self.deps = deps
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+    ctx = FakeCtx(deps)
+    threshold = settings.JUDGE_SCORE_THRESHOLD
+
+    # Exactly at threshold — no retry
+    at_threshold = JudgeResult(
+        actionability_score=threshold,
+        accuracy_score=threshold,
+        coherence_score=threshold,
+        overall_score=threshold,
+        feedback="Meets threshold.",
+    )
+    result = await validate_scores(ctx, at_threshold)  # type: ignore[arg-type]
+    assert result is at_threshold
+
+    # One below threshold — raises ModelRetry
+    below = JudgeResult(
+        actionability_score=threshold - 1,
+        accuracy_score=threshold,
+        coherence_score=threshold,
+        overall_score=threshold - 1,
+        feedback="Below threshold.",
+    )
+    with pytest.raises(ModelRetry):
+        await validate_scores(ctx, below)  # type: ignore[arg-type]
+
+
 def test_judge_deps_accepts_full_pipeline_inputs(
     full_group_a_result: GroupAResult,
     sample_pattern_result: PatternDetectorResult,

--- a/backend/tests/unit/agents/test_judge.py
+++ b/backend/tests/unit/agents/test_judge.py
@@ -106,6 +106,90 @@ async def test_judge_feedback_is_non_empty_string(
     assert len(result.output.feedback) > 0
 
 
+# ---------------------------------------------------------------------------
+# Cycle 2 — ModelRetry on low scores
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_judge_raises_model_retry_when_score_below_threshold(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """Result validator raises ModelRetry when any dimension score is below threshold."""
+    from pydantic_ai import ModelRetry
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+    from app.agents.judge import judge
+    from app.agents.schemas import JudgeDeps, JudgeResult
+
+    def low_score_model(messages: list, info: AgentInfo) -> object:  # type: ignore[type-arg]
+        from pydantic_ai.models.function import ModelResponse, TextPart
+
+        # Return scores all at 3 — below the default threshold of 6
+        result = JudgeResult(
+            actionability_score=3,
+            accuracy_score=3,
+            coherence_score=3,
+            overall_score=3,
+            feedback="Weak narrative.",
+        )
+        return ModelResponse(parts=[TextPart(result.model_dump_json())])
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+
+    with pytest.raises(Exception):  # MaxRetriesExceeded after retries=2
+        with judge.override(model=FunctionModel(low_score_model)):
+            await judge.run("Analyze and produce structured insights.", deps=deps)
+
+
+@pytest.mark.asyncio
+async def test_judge_no_retry_when_all_scores_above_threshold(
+    full_group_a_result: GroupAResult,
+    sample_pattern_result: PatternDetectorResult,
+    sample_narrative_result: NarrativeWriterResult,
+) -> None:
+    """No retry is triggered when all dimension scores meet the threshold."""
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+    from app.agents.judge import judge
+    from app.agents.schemas import JudgeDeps, JudgeResult
+
+    def good_score_model(messages: list, info: AgentInfo) -> object:  # type: ignore[type-arg]
+        from pydantic_ai.models.function import ModelResponse, TextPart
+
+        result = JudgeResult(
+            actionability_score=8,
+            accuracy_score=9,
+            coherence_score=7,
+            overall_score=8,
+            feedback="Strong narrative with clear grounding.",
+        )
+        return ModelResponse(parts=[TextPart(result.model_dump_json())])
+
+    deps = JudgeDeps(
+        user_id=uuid.uuid4(),
+        analysis_date=date(2026, 4, 14),
+        group_a_result=full_group_a_result,
+        pattern_result=sample_pattern_result,
+        narrative_result=sample_narrative_result,
+    )
+
+    with judge.override(model=FunctionModel(good_score_model)):
+        result = await judge.run("Analyze and produce structured insights.", deps=deps)
+
+    assert result.output.actionability_score >= 6
+    assert result.output.accuracy_score >= 6
+    assert result.output.coherence_score >= 6
+
+
 def test_judge_deps_accepts_full_pipeline_inputs(
     full_group_a_result: GroupAResult,
     sample_pattern_result: PatternDetectorResult,

--- a/backend/tests/unit/agents/test_judge.py
+++ b/backend/tests/unit/agents/test_judge.py
@@ -319,15 +319,16 @@ async def test_run_group_d_records_judge_score_metric(
     sample_narrative_result: NarrativeWriterResult,
 ) -> None:
     """run_group_d observes the overall_score in the judge_score histogram."""
-    from unittest.mock import patch
+    from unittest.mock import MagicMock, patch
 
     import app.agents.judge as judge_mod
     from app.agents.orchestrator import run_group_d
     from app.core.metrics import judge_score
 
+    mock_histogram = MagicMock()
     with (
         judge_mod.judge.override(model=_make_passing_model()),
-        patch.object(judge_score, "labels", wraps=judge_score.labels) as mock_labels,
+        patch.object(judge_score, "labels", return_value=mock_histogram) as mock_labels,
     ):
         result = await run_group_d(
             group_a_result=full_group_a_result,
@@ -338,7 +339,7 @@ async def test_run_group_d_records_judge_score_metric(
         )
 
     mock_labels.assert_called_once_with(agent_name="judge")
-    mock_labels.return_value.observe.assert_called_once_with(result.overall_score)
+    mock_histogram.observe.assert_called_once_with(result.overall_score)
 
 
 def test_judge_retry_count_metric_exists() -> None:

--- a/backend/tests/unit/agents/test_judge.py
+++ b/backend/tests/unit/agents/test_judge.py
@@ -4,24 +4,29 @@ from __future__ import annotations
 
 import uuid
 from datetime import date
+from typing import Any
 
 import pytest
 
 from app.agents.schemas import (
     GroupAResult,
+    JudgeDeps,
     NarrativeWriterResult,
     PatternDetectorResult,
 )
 
 
-def _make_passing_model():  # type: ignore[return]
+def _make_passing_model() -> Any:
     """Return a FunctionModel that always emits scores above the retry threshold."""
     from pydantic_ai.models.function import FunctionModel
 
     from app.agents.schemas import JudgeResult
 
-    def _model(messages, info):  # type: ignore[return, type-arg]
-        from pydantic_ai.models.function import ModelResponse, TextPart
+    def _model(messages: list[Any], info: Any) -> Any:
+        from pydantic_ai.models.function import (  # type: ignore[attr-defined]
+            ModelResponse,
+            TextPart,
+        )
 
         result = JudgeResult(
             actionability_score=8,
@@ -144,8 +149,11 @@ async def test_judge_raises_model_retry_when_score_below_threshold(
     from app.agents.judge import judge
     from app.agents.schemas import JudgeDeps, JudgeResult
 
-    def low_score_model(messages: list, info: AgentInfo) -> object:  # type: ignore[type-arg]
-        from pydantic_ai.models.function import ModelResponse, TextPart
+    def low_score_model(messages: list[Any], info: AgentInfo) -> Any:
+        from pydantic_ai.models.function import (  # type: ignore[attr-defined]
+            ModelResponse,
+            TextPart,
+        )
 
         # Return scores all at 3 — below the default threshold of 6
         result = JudgeResult(
@@ -182,8 +190,11 @@ async def test_judge_no_retry_when_all_scores_above_threshold(
     from app.agents.judge import judge
     from app.agents.schemas import JudgeDeps, JudgeResult
 
-    def good_score_model(messages: list, info: AgentInfo) -> object:  # type: ignore[type-arg]
-        from pydantic_ai.models.function import ModelResponse, TextPart
+    def good_score_model(messages: list[Any], info: AgentInfo) -> Any:
+        from pydantic_ai.models.function import (  # type: ignore[attr-defined]
+            ModelResponse,
+            TextPart,
+        )
 
         result = JudgeResult(
             actionability_score=8,
@@ -348,6 +359,7 @@ async def test_run_group_d_records_judge_score_metric(
             analysis_date=date(2026, 4, 14),
         )
 
+    assert result is not None
     mock_labels.assert_called_once_with(agent_name="judge")
     mock_histogram.observe.assert_called_once_with(result.overall_score)
 
@@ -588,11 +600,12 @@ async def test_add_evaluation_context_contains_narrative_sections(
 
     # Create a fake RunContext-like object
     class FakeCtx:
-        def __init__(self, deps):  # type: ignore[no-untyped-def]
-            self.deps = deps
+        def __init__(self, d: JudgeDeps) -> None:
+            self.deps = d
 
     ctx = FakeCtx(deps)
     context_str = await judge_mod.add_evaluation_context(ctx)  # type: ignore[arg-type]
+    assert isinstance(context_str, str)
 
     assert "Analysis date: 2026-04-14" in context_str
     assert "--- NARRATIVE TO EVALUATE ---" in context_str
@@ -616,8 +629,8 @@ async def test_validate_scores_exact_threshold_boundary(
     from app.core.config import settings
 
     class FakeCtx:
-        def __init__(self, deps):  # type: ignore[no-untyped-def]
-            self.deps = deps
+        def __init__(self, d: JudgeDeps) -> None:
+            self.deps = d
 
     deps = JudgeDeps(
         user_id=uuid.uuid4(),


### PR DESCRIPTION
## Summary
- Implements the Judge agent (Group D) using Gemini (`google-gla:gemini-1.5-flash`) to score Narrative Writer output on three dimensions: actionability, accuracy, and coherence (1–10 each)
- Raises `ModelRetry` when any dimension falls below the configurable `JUDGE_SCORE_THRESHOLD` (default 6), with up to 2 retries before returning `None` gracefully
- Persists scores to a new `agent_score_history` table (migration 0008) with DB-level `CheckConstraint`s enforcing the 1–10 range; records `judge_score` histogram and `judge_retry_count` counter in Prometheus
- Uses a different LLM provider than the Narrative Writer (Gemini vs. OpenAI) to avoid self-evaluation bias

## Files changed
| File | Change |
|------|--------|
| `app/agents/judge.py` | New — Judge agent with system prompt, `@instructions`, `@output_validator` |
| `app/agents/schemas.py` | New — `JudgeDeps`, `JudgeResult` |
| `app/agents/orchestrator.py` | New — `run_group_d()` |
| `app/models/agent_score_history.py` | New — ORM model with 4 `CheckConstraint`s |
| `alembic/versions/0008_add_agent_score_history_table.py` | New — migration |
| `app/core/metrics.py` | Fixed histogram buckets (1–10), added `judge_retry_count` |
| `app/core/config.py` | Added `JUDGE_SCORE_THRESHOLD` setting |
| `pyproject.toml` | Added `google-genai>=1.0.0` production dependency |
| `tests/unit/agents/test_judge.py` | New — 24 tests across 5 TDD cycles |

## Test plan
- [x] 24 unit tests pass (`pytest tests/unit/agents/test_judge.py`)
- [x] 549 total unit tests pass with no regressions
- [x] Mutation score: 93.3% (56/60 mutants killed, target ≥ 80%)
- [x] `ruff check . && ruff format .` clean
- [x] Rebased onto latest `main` (includes #40, #41) with no conflicts

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)