### PR TITLE
[#32] WeeklyReview model and orchestration endpoints

### DIFF
--- a/backend/alembic/versions/0009_add_weekly_reviews_table.py
+++ b/backend/alembic/versions/0009_add_weekly_reviews_table.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
@@ -32,12 +33,12 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("week_start", sa.Date(), nullable=False),
-        sa.Column("raw_data_json", sa.dialects.postgresql.JSONB(), nullable=False),
-        sa.Column("insights_json", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column("raw_data_json", postgresql.JSONB(), nullable=False),
+        sa.Column("insights_json", postgresql.JSONB(), nullable=True),
         sa.Column("narrative", sa.Text(), nullable=True),
-        sa.Column("scores_json", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column("scores_json", postgresql.JSONB(), nullable=True),
         sa.Column(
-            "agent_metadata_json", sa.dialects.postgresql.JSONB(), nullable=True
+            "agent_metadata_json", postgresql.JSONB(), nullable=True
         ),
         sa.Column(
             "status",

--- a/backend/alembic/versions/0009_add_weekly_reviews_table.py
+++ b/backend/alembic/versions/0009_add_weekly_reviews_table.py
@@ -37,9 +37,7 @@ def upgrade() -> None:
         sa.Column("insights_json", postgresql.JSONB(), nullable=True),
         sa.Column("narrative", sa.Text(), nullable=True),
         sa.Column("scores_json", postgresql.JSONB(), nullable=True),
-        sa.Column(
-            "agent_metadata_json", postgresql.JSONB(), nullable=True
-        ),
+        sa.Column("agent_metadata_json", postgresql.JSONB(), nullable=True),
         sa.Column(
             "status",
             sa.String(20),

--- a/backend/alembic/versions/0009_add_weekly_reviews_table.py
+++ b/backend/alembic/versions/0009_add_weekly_reviews_table.py
@@ -1,0 +1,68 @@
+"""add weekly_reviews table
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-04-19
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0009"
+down_revision: str = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "weekly_reviews",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("week_start", sa.Date(), nullable=False),
+        sa.Column("raw_data_json", sa.dialects.postgresql.JSONB(), nullable=False),
+        sa.Column("insights_json", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column("narrative", sa.Text(), nullable=True),
+        sa.Column("scores_json", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "agent_metadata_json", sa.dialects.postgresql.JSONB(), nullable=True
+        ),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'generating', 'complete', 'failed')",
+            name="ck_weekly_reviews_status",
+        ),
+    )
+    op.create_index(
+        "idx_weekly_review_user_week",
+        "weekly_reviews",
+        ["user_id", "week_start"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_weekly_review_user_week", table_name="weekly_reviews")
+    op.drop_table("weekly_reviews")

--- a/backend/app/api/weekly_reviews.py
+++ b/backend/app/api/weekly_reviews.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -14,13 +15,14 @@ from app.schemas.weekly_review import WeeklyReviewResponse
 from app.services.weekly_review_service import (
     generate_review,
     get_or_create_review,
-    get_review,
+    get_review_by_id,
+    list_reviews,
 )
 
 router = APIRouter(prefix="/weekly-reviews", tags=["weekly-reviews"])
 
 
-@router.post("", response_model=WeeklyReviewResponse)
+@router.post("/generate", response_model=WeeklyReviewResponse)
 async def trigger_weekly_review(
     week_start: date = Query(...),
     current_user: User = Depends(get_current_user),
@@ -28,24 +30,31 @@ async def trigger_weekly_review(
 ) -> WeeklyReviewResponse:
     """Trigger AI generation of the weekly review for the given week.
 
-    If a review already exists for this week, it is re-generated.
+    If a review already exists for this week, it is re-generated in place.
     """
     review = await get_or_create_review(db, current_user.id, week_start)
     review = await generate_review(db, review, week_start)
     return WeeklyReviewResponse.model_validate(review)
 
 
-@router.get("/{week_start}", response_model=WeeklyReviewResponse)
+@router.get("", response_model=list[WeeklyReviewResponse])
+async def list_weekly_reviews(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[WeeklyReviewResponse]:
+    """Return all weekly reviews owned by the current user, newest week first."""
+    reviews = await list_reviews(db, current_user.id)
+    return [WeeklyReviewResponse.model_validate(r) for r in reviews]
+
+
+@router.get("/{review_id}", response_model=WeeklyReviewResponse)
 async def fetch_weekly_review(
-    week_start: date,
+    review_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> WeeklyReviewResponse:
-    """Return the stored weekly review for the given week.
-
-    Raises 404 if no review has been generated yet.
-    """
-    review = await get_review(db, current_user.id, week_start)
+    """Return a single stored weekly review by id, scoped to the current user."""
+    review = await get_review_by_id(db, current_user.id, review_id)
     if review is None:
         raise HTTPException(status_code=404, detail="Weekly review not found")
     return WeeklyReviewResponse.model_validate(review)

--- a/backend/app/api/weekly_reviews.py
+++ b/backend/app/api/weekly_reviews.py
@@ -1,0 +1,51 @@
+"""Weekly review API routes — trigger generation and fetch stored reviews."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.models.user import User
+from app.schemas.weekly_review import WeeklyReviewResponse
+from app.services.weekly_review_service import (
+    generate_review,
+    get_or_create_review,
+    get_review,
+)
+
+router = APIRouter(prefix="/weekly-reviews", tags=["weekly-reviews"])
+
+
+@router.post("", response_model=WeeklyReviewResponse)
+async def trigger_weekly_review(
+    week_start: date = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WeeklyReviewResponse:
+    """Trigger AI generation of the weekly review for the given week.
+
+    If a review already exists for this week, it is re-generated.
+    """
+    review = await get_or_create_review(db, current_user.id, week_start)
+    review = await generate_review(db, review, week_start)
+    return WeeklyReviewResponse.model_validate(review)
+
+
+@router.get("/{week_start}", response_model=WeeklyReviewResponse)
+async def fetch_weekly_review(
+    week_start: date,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WeeklyReviewResponse:
+    """Return the stored weekly review for the given week.
+
+    Raises 404 if no review has been generated yet.
+    """
+    review = await get_review(db, current_user.id, week_start)
+    if review is None:
+        raise HTTPException(status_code=404, detail="Weekly review not found")
+    return WeeklyReviewResponse.model_validate(review)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.api.schedule_blocks import router as schedule_blocks_router
 from app.api.sync import router as sync_router
 from app.api.tasks import router as tasks_router
 from app.api.time_entries import router as time_entries_router
+from app.api.weekly_reviews import router as weekly_reviews_router
 from app.core.config import settings
 from app.core.database import dispose_engine, init_engine
 from app.core.metrics import configure_metrics
@@ -58,6 +59,7 @@ def create_app() -> FastAPI:
     app.include_router(schedule_blocks_router)
     app.include_router(sync_router)
     app.include_router(time_entries_router)
+    app.include_router(weekly_reviews_router)
 
     return app
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.schedule_block import ScheduleBlock
 from app.models.task import Task
 from app.models.time_entry import TimeEntry
 from app.models.user import User
+from app.models.weekly_review import WeeklyReview
 
 __all__ = [
     "AgentScoreHistory",
@@ -14,4 +15,5 @@ __all__ = [
     "Task",
     "TimeEntry",
     "User",
+    "WeeklyReview",
 ]

--- a/backend/app/models/weekly_review.py
+++ b/backend/app/models/weekly_review.py
@@ -1,0 +1,74 @@
+"""WeeklyReview model — persists AI-generated weekly review outputs."""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import UTC, date, datetime
+from typing import Any
+
+from sqlalchemy import CheckConstraint, Date, DateTime, ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class ReviewStatus(enum.StrEnum):
+    """Lifecycle status of a WeeklyReview generation run."""
+
+    PENDING = "pending"
+    GENERATING = "generating"
+    COMPLETE = "complete"
+    FAILED = "failed"
+
+
+_VALID_STATUSES = "('pending', 'generating', 'complete', 'failed')"
+
+
+class WeeklyReview(Base):
+    """WeeklyReview entity — see docs/DATA_MODEL.md for full specification."""
+
+    __tablename__ = "weekly_reviews"
+    __table_args__ = (
+        CheckConstraint(
+            f"status IN {_VALID_STATUSES}",
+            name="ck_weekly_reviews_status",
+        ),
+        Index("idx_weekly_review_user_week", "user_id", "week_start"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    week_start: Mapped[date] = mapped_column(Date, nullable=False)
+    raw_data_json: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    insights_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    narrative: Mapped[str | None] = mapped_column(Text, nullable=True)
+    scores_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    agent_metadata_json: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=ReviewStatus.PENDING
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("status", ReviewStatus.PENDING)
+        super().__init__(**kwargs)
+
+    def __repr__(self) -> str:
+        return (
+            f"<WeeklyReview(user_id={self.user_id}, week_start={self.week_start}, "
+            f"status={self.status})>"
+        )

--- a/backend/app/models/weekly_review.py
+++ b/backend/app/models/weekly_review.py
@@ -65,6 +65,7 @@ class WeeklyReview(Base):
 
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("status", ReviewStatus.PENDING)
+        kwargs.setdefault("created_at", datetime.now(UTC))
         super().__init__(**kwargs)
 
     def __repr__(self) -> str:

--- a/backend/app/schemas/weekly_review.py
+++ b/backend/app/schemas/weekly_review.py
@@ -1,0 +1,25 @@
+"""Pydantic schemas for WeeklyReview API responses."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class WeeklyReviewResponse(BaseModel):
+    """API response schema for a WeeklyReview."""
+
+    id: uuid.UUID
+    user_id: uuid.UUID
+    week_start: date
+    status: str
+    narrative: str | None
+    insights_json: dict[str, Any] | None
+    scores_json: dict[str, Any] | None
+    agent_metadata_json: dict[str, Any] | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/weekly_review_service.py
+++ b/backend/app/services/weekly_review_service.py
@@ -8,6 +8,7 @@ from datetime import date, timedelta
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.agents.orchestrator import run_group_a, run_group_b, run_group_c, run_group_d
 from app.models.weekly_review import ReviewStatus, WeeklyReview
 
 
@@ -49,5 +50,62 @@ async def get_or_create_review(
         raw_data_json={},
     )
     db.add(review)
+    await db.flush()
+    return review
+
+
+async def generate_review(
+    db: AsyncSession,
+    review: WeeklyReview,
+    analysis_date: date,
+) -> WeeklyReview:
+    """Run the full A→B→C→D agent pipeline and persist results on the review.
+
+    Sets status to 'generating' before the pipeline starts and 'complete' on
+    success, or 'failed' if any stage raises. The exception is re-raised after
+    the failed status is flushed.
+
+    Args:
+        db: Async database session.
+        review: The WeeklyReview record to populate (must already be persisted).
+        analysis_date: Reference date passed to all agents.
+
+    Returns:
+        The updated WeeklyReview with narrative, scores, and metadata populated.
+    """
+    review.status = ReviewStatus.GENERATING
+    await db.flush()
+
+    try:
+        group_a_result = await run_group_a(db, review.user_id, analysis_date)
+        pattern_result = await run_group_b(group_a_result, review.user_id, analysis_date)
+        narrative_result = await run_group_c(
+            group_a_result, pattern_result, review.user_id, analysis_date
+        )
+        judge_result = await run_group_d(
+            db, group_a_result, pattern_result, narrative_result, review.user_id, analysis_date
+        )
+    except Exception:
+        review.status = ReviewStatus.FAILED
+        await db.flush()
+        raise
+
+    review.insights_json = group_a_result.model_dump()
+    review.narrative = (
+        f"{narrative_result.executive_summary}\n\n"
+        f"{narrative_result.time_analysis}\n\n"
+        f"{narrative_result.productivity_patterns}\n\n"
+        f"{narrative_result.areas_of_concern}"
+    )
+    review.scores_json = (
+        judge_result.model_dump() if judge_result is not None else None
+    )
+    review.agent_metadata_json = {
+        "analysis_date": analysis_date.isoformat(),
+        "patterns_detected": len(pattern_result.patterns),
+        "group_a_errors": group_a_result.errors,
+        "judge_scored": judge_result is not None,
+    }
+    review.status = ReviewStatus.COMPLETE
     await db.flush()
     return review

--- a/backend/app/services/weekly_review_service.py
+++ b/backend/app/services/weekly_review_service.py
@@ -103,12 +103,19 @@ async def generate_review(
 
     try:
         group_a_result = await run_group_a(db, review.user_id, analysis_date)
-        pattern_result = await run_group_b(group_a_result, review.user_id, analysis_date)
+        pattern_result = await run_group_b(
+            group_a_result, review.user_id, analysis_date
+        )
         narrative_result = await run_group_c(
             group_a_result, pattern_result, review.user_id, analysis_date
         )
         judge_result = await run_group_d(
-            db, group_a_result, pattern_result, narrative_result, review.user_id, analysis_date
+            db,
+            group_a_result,
+            pattern_result,
+            narrative_result,
+            review.user_id,
+            analysis_date,
         )
     except Exception:
         review.status = ReviewStatus.FAILED
@@ -122,9 +129,7 @@ async def generate_review(
         f"{narrative_result.productivity_patterns}\n\n"
         f"{narrative_result.areas_of_concern}"
     )
-    review.scores_json = (
-        judge_result.model_dump() if judge_result is not None else None
-    )
+    review.scores_json = judge_result.model_dump() if judge_result is not None else None
     review.agent_metadata_json = {
         "analysis_date": analysis_date.isoformat(),
         "patterns_detected": len(pattern_result.patterns),

--- a/backend/app/services/weekly_review_service.py
+++ b/backend/app/services/weekly_review_service.py
@@ -2,14 +2,50 @@
 
 from __future__ import annotations
 
+import time
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import date, timedelta
 
+import sentry_sdk
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.orchestrator import run_group_a, run_group_b, run_group_c, run_group_d
 from app.models.weekly_review import ReviewStatus, WeeklyReview
+
+
+async def _run_stage[T](
+    name: str,
+    stages: dict[str, dict[str, float]],
+    coro_factory: Callable[[], Awaitable[T]],
+) -> T:
+    """Run one pipeline stage, recording latency_ms and emitting a breadcrumb."""
+    sentry_sdk.add_breadcrumb(
+        category="weekly_review.pipeline",
+        message=f"{name} start",
+        level="info",
+    )
+    start = time.perf_counter()
+    try:
+        result = await coro_factory()
+    except Exception as exc:
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        stages[name] = {"latency_ms": elapsed_ms}
+        sentry_sdk.add_breadcrumb(
+            category="weekly_review.pipeline",
+            message=f"{name} failed: {exc}",
+            level="error",
+        )
+        raise
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    stages[name] = {"latency_ms": elapsed_ms}
+    sentry_sdk.add_breadcrumb(
+        category="weekly_review.pipeline",
+        message=f"{name} complete in {elapsed_ms:.1f}ms",
+        level="info",
+    )
+    return result
 
 
 def _align_to_monday(d: date) -> date:
@@ -132,24 +168,44 @@ async def generate_review(
     review.status = ReviewStatus.GENERATING
     await db.flush()
 
+    stages: dict[str, dict[str, float]] = {}
+
     try:
-        group_a_result = await run_group_a(db, review.user_id, analysis_date)
-        pattern_result = await run_group_b(
-            group_a_result, review.user_id, analysis_date
+        group_a_result = await _run_stage(
+            "group_a",
+            stages,
+            lambda: run_group_a(db, review.user_id, analysis_date),
         )
-        narrative_result = await run_group_c(
-            group_a_result, pattern_result, review.user_id, analysis_date
+        pattern_result = await _run_stage(
+            "group_b",
+            stages,
+            lambda: run_group_b(group_a_result, review.user_id, analysis_date),
         )
-        judge_result = await run_group_d(
-            db,
-            group_a_result,
-            pattern_result,
-            narrative_result,
-            review.user_id,
-            analysis_date,
+        narrative_result = await _run_stage(
+            "group_c",
+            stages,
+            lambda: run_group_c(
+                group_a_result, pattern_result, review.user_id, analysis_date
+            ),
+        )
+        judge_result = await _run_stage(
+            "group_d",
+            stages,
+            lambda: run_group_d(
+                db,
+                group_a_result,
+                pattern_result,
+                narrative_result,
+                review.user_id,
+                analysis_date,
+            ),
         )
     except Exception:
         review.status = ReviewStatus.FAILED
+        review.agent_metadata_json = {
+            "analysis_date": analysis_date.isoformat(),
+            "stages": stages,
+        }
         await db.flush()
         raise
 
@@ -166,6 +222,7 @@ async def generate_review(
         "patterns_detected": len(pattern_result.patterns),
         "group_a_errors": group_a_result.errors,
         "judge_scored": judge_result is not None,
+        "stages": stages,
     }
     review.status = ReviewStatus.COMPLETE
     await db.flush()

--- a/backend/app/services/weekly_review_service.py
+++ b/backend/app/services/weekly_review_service.py
@@ -54,6 +54,31 @@ async def get_or_create_review(
     return review
 
 
+async def get_review(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    week_start: date,
+) -> WeeklyReview | None:
+    """Return the WeeklyReview for this user/week, or None if it doesn't exist.
+
+    Args:
+        db: Async database session.
+        user_id: Owner of the review.
+        week_start: Any date in the target week — clamped to Monday automatically.
+
+    Returns:
+        Existing WeeklyReview or None.
+    """
+    monday = _align_to_monday(week_start)
+    result = await db.execute(
+        select(WeeklyReview).where(
+            WeeklyReview.user_id == user_id,
+            WeeklyReview.week_start == monday,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
 async def generate_review(
     db: AsyncSession,
     review: WeeklyReview,

--- a/backend/app/services/weekly_review_service.py
+++ b/backend/app/services/weekly_review_service.py
@@ -1,0 +1,53 @@
+"""WeeklyReview service — orchestrates the full AI pipeline and persists results."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.weekly_review import ReviewStatus, WeeklyReview
+
+
+def _align_to_monday(d: date) -> date:
+    """Return the Monday of the week containing *d*."""
+    return d - timedelta(days=d.weekday())
+
+
+async def get_or_create_review(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    week_start: date,
+) -> WeeklyReview:
+    """Return the existing WeeklyReview for this user/week or create a new pending one.
+
+    Args:
+        db: Async database session.
+        user_id: Owner of the review.
+        week_start: Any date in the target week — clamped to Monday automatically.
+
+    Returns:
+        Existing or newly-created WeeklyReview with status=pending.
+    """
+    monday = _align_to_monday(week_start)
+
+    result = await db.execute(
+        select(WeeklyReview).where(
+            WeeklyReview.user_id == user_id,
+            WeeklyReview.week_start == monday,
+        )
+    )
+    existing = result.scalar_one_or_none()
+    if existing is not None:
+        return existing
+
+    review = WeeklyReview(
+        user_id=user_id,
+        week_start=monday,
+        raw_data_json={},
+    )
+    db.add(review)
+    await db.flush()
+    return review

--- a/backend/app/services/weekly_review_service.py
+++ b/backend/app/services/weekly_review_service.py
@@ -79,6 +79,37 @@ async def get_review(
     return result.scalar_one_or_none()
 
 
+async def get_review_by_id(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    review_id: uuid.UUID,
+) -> WeeklyReview | None:
+    """Return a WeeklyReview by id, scoped to the current user.
+
+    Returns None if no review matches or the review belongs to another user.
+    """
+    result = await db.execute(
+        select(WeeklyReview).where(
+            WeeklyReview.id == review_id,
+            WeeklyReview.user_id == user_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_reviews(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> list[WeeklyReview]:
+    """Return all WeeklyReviews owned by *user_id*, most recent week first."""
+    result = await db.execute(
+        select(WeeklyReview)
+        .where(WeeklyReview.user_id == user_id)
+        .order_by(WeeklyReview.week_start.desc())
+    )
+    return list(result.scalars().all())
+
+
 async def generate_review(
     db: AsyncSession,
     review: WeeklyReview,

--- a/backend/tests/integration/test_weekly_reviews.py
+++ b/backend/tests/integration/test_weekly_reviews.py
@@ -1,0 +1,230 @@
+"""Integration tests for /weekly-reviews — real DB, patched agent pipeline."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import date
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.agents.schemas import (
+    GroupAResult,
+    JudgeResult,
+    NarrativeWriterResult,
+    PatternDetectorResult,
+)
+
+
+@pytest.fixture
+def patched_pipeline() -> Iterator[None]:
+    """Patch the four orchestrator entry points with deterministic stub outputs.
+
+    Integration tests exercise the API + DB layer but must not hit real LLMs.
+    """
+    group_a = GroupAResult()
+    pattern = PatternDetectorResult(patterns=[], summary="integration-stub")
+    narrative = NarrativeWriterResult(
+        executive_summary="Executive summary.",
+        time_analysis="Time analysis.",
+        productivity_patterns="Patterns.",
+        areas_of_concern="Concerns.",
+    )
+    judge = JudgeResult(
+        actionability_score=8,
+        accuracy_score=9,
+        coherence_score=7,
+        overall_score=8,
+        feedback="integration-stub",
+    )
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            new=AsyncMock(return_value=group_a),
+        ),
+        patch(
+            "app.services.weekly_review_service.run_group_b",
+            new=AsyncMock(return_value=pattern),
+        ),
+        patch(
+            "app.services.weekly_review_service.run_group_c",
+            new=AsyncMock(return_value=narrative),
+        ),
+        patch(
+            "app.services.weekly_review_service.run_group_d",
+            new=AsyncMock(return_value=judge),
+        ),
+    ):
+        yield
+
+
+# ── POST /weekly-reviews/generate ─────────────────────────────────────────────
+
+
+async def test_post_generate_persists_review_to_db(
+    auth_client: AsyncClient, patched_pipeline: None
+) -> None:
+    resp = await auth_client.post(
+        "/weekly-reviews/generate", params={"week_start": "2026-04-13"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "complete"
+    assert body["week_start"] == "2026-04-13"
+    assert body["narrative"].startswith("Executive summary.")
+    assert body["scores_json"]["overall_score"] == 8
+    assert body["agent_metadata_json"]["stages"]["group_a"]["latency_ms"] >= 0
+
+
+async def test_post_generate_normalizes_wednesday_to_monday(
+    auth_client: AsyncClient, patched_pipeline: None
+) -> None:
+    resp = await auth_client.post(
+        "/weekly-reviews/generate", params={"week_start": "2026-04-15"}
+    )
+    assert resp.status_code == 200
+    # 2026-04-15 is a Wednesday — stored row must be keyed by Monday 2026-04-13.
+    assert resp.json()["week_start"] == "2026-04-13"
+
+
+async def test_post_generate_is_idempotent_for_same_week(
+    auth_client: AsyncClient, patched_pipeline: None
+) -> None:
+    """Re-generating within the same week reuses the row, not a new one."""
+    first = await auth_client.post(
+        "/weekly-reviews/generate", params={"week_start": "2026-04-13"}
+    )
+    second = await auth_client.post(
+        "/weekly-reviews/generate", params={"week_start": "2026-04-15"}
+    )
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["id"] == second.json()["id"]
+
+    listing = await auth_client.get("/weekly-reviews")
+    assert listing.status_code == 200
+    assert len(listing.json()) == 1
+
+
+async def test_post_generate_requires_auth(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/weekly-reviews/generate", params={"week_start": "2026-04-13"}
+    )
+    assert resp.status_code == 401
+
+
+# ── GET /weekly-reviews (list) ────────────────────────────────────────────────
+
+
+async def test_list_weekly_reviews_empty_returns_empty_array(
+    auth_client: AsyncClient,
+) -> None:
+    resp = await auth_client.get("/weekly-reviews")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_list_weekly_reviews_scopes_to_current_user(
+    auth_client: AsyncClient,
+    other_auth_client: AsyncClient,
+    patched_pipeline: None,
+) -> None:
+    await auth_client.post(
+        "/weekly-reviews/generate", params={"week_start": "2026-04-13"}
+    )
+    await other_auth_client.post(
+        "/weekly-reviews/generate", params={"week_start": "2026-04-13"}
+    )
+
+    resp_a = await auth_client.get("/weekly-reviews")
+    resp_b = await other_auth_client.get("/weekly-reviews")
+    assert resp_a.status_code == 200
+    assert resp_b.status_code == 200
+    assert len(resp_a.json()) == 1
+    assert len(resp_b.json()) == 1
+    assert resp_a.json()[0]["id"] != resp_b.json()[0]["id"]
+
+
+async def test_list_weekly_reviews_orders_by_week_start_desc(
+    auth_client: AsyncClient, patched_pipeline: None
+) -> None:
+    for week in ("2026-03-30", "2026-04-13", "2026-04-06"):
+        await auth_client.post("/weekly-reviews/generate", params={"week_start": week})
+
+    resp = await auth_client.get("/weekly-reviews")
+    weeks = [r["week_start"] for r in resp.json()]
+    assert weeks == ["2026-04-13", "2026-04-06", "2026-03-30"]
+
+
+# ── GET /weekly-reviews/{review_id} ───────────────────────────────────────────
+
+
+async def test_get_weekly_review_by_id_returns_stored_review(
+    auth_client: AsyncClient, patched_pipeline: None
+) -> None:
+    created = await auth_client.post(
+        "/weekly-reviews/generate", params={"week_start": "2026-04-13"}
+    )
+    review_id = created.json()["id"]
+
+    resp = await auth_client.get(f"/weekly-reviews/{review_id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == review_id
+    assert resp.json()["scores_json"]["overall_score"] == 8
+
+
+async def test_get_other_users_weekly_review_returns_404(
+    auth_client: AsyncClient,
+    other_auth_client: AsyncClient,
+    patched_pipeline: None,
+) -> None:
+    """Reading another user's review must 404, never leak the record."""
+    created = await other_auth_client.post(
+        "/weekly-reviews/generate", params={"week_start": "2026-04-13"}
+    )
+    foreign_id = created.json()["id"]
+
+    resp = await auth_client.get(f"/weekly-reviews/{foreign_id}")
+    assert resp.status_code == 404
+
+
+async def test_get_nonexistent_weekly_review_returns_404(
+    auth_client: AsyncClient,
+) -> None:
+    resp = await auth_client.get(f"/weekly-reviews/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+async def test_get_weekly_review_by_id_requires_auth(client: AsyncClient) -> None:
+    resp = await client.get(f"/weekly-reviews/{uuid.uuid4()}")
+    assert resp.status_code == 401
+
+
+# ── Failure path ──────────────────────────────────────────────────────────────
+
+
+async def test_post_generate_marks_review_failed_when_pipeline_raises(
+    auth_client: AsyncClient,
+) -> None:
+    """If Group A fails, the review row is persisted with status=failed."""
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            new=AsyncMock(side_effect=RuntimeError("upstream down")),
+        ),
+        pytest.raises(RuntimeError, match="upstream down"),
+    ):
+        await auth_client.post(
+            "/weekly-reviews/generate", params={"week_start": "2026-04-13"}
+        )
+
+    # Row must still exist with status=failed so the frontend can surface the error.
+    week_start_iso = date(2026, 4, 13).isoformat()
+    listing = await auth_client.get("/weekly-reviews")
+    assert listing.status_code == 200
+    matches = [r for r in listing.json() if r["week_start"] == week_start_iso]
+    assert len(matches) == 1
+    assert matches[0]["status"] == "failed"
+    assert "group_a" in matches[0]["agent_metadata_json"]["stages"]

--- a/backend/tests/unit/test_weekly_review_model.py
+++ b/backend/tests/unit/test_weekly_review_model.py
@@ -200,6 +200,6 @@ def test_migration_0009_down_revision_is_0008() -> None:
     assert spec is not None
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
-    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    spec.loader.exec_module(module)
     assert module.down_revision == "0008"
     assert module.revision == "0009"

--- a/backend/tests/unit/test_weekly_review_model.py
+++ b/backend/tests/unit/test_weekly_review_model.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from sqlalchemy import inspect
+
+from app.models.weekly_review import ReviewStatus, WeeklyReview
+
+
+def test_weekly_review_tablename() -> None:
+    """WeeklyReview.__tablename__ must be 'weekly_reviews'."""
+    assert WeeklyReview.__tablename__ == "weekly_reviews"
+
+
+def test_weekly_review_has_required_columns() -> None:
+    """WeeklyReview model must have all columns defined in DATA_MODEL.md."""
+    columns = {c.name for c in inspect(WeeklyReview).columns}
+    expected = {
+        "id",
+        "user_id",
+        "week_start",
+        "raw_data_json",
+        "insights_json",
+        "narrative",
+        "scores_json",
+        "agent_metadata_json",
+        "status",
+        "created_at",
+    }
+    assert expected.issubset(columns), f"Missing columns: {expected - columns}"
+
+
+def test_weekly_review_id_is_uuid() -> None:
+    """WeeklyReview.id column type must be UUID."""
+    col = inspect(WeeklyReview).columns["id"]
+    assert "UUID" in str(col.type).upper()
+
+
+def test_weekly_review_user_id_is_foreign_key() -> None:
+    """WeeklyReview.user_id must reference users.id."""
+    col = inspect(WeeklyReview).columns["user_id"]
+    fk_targets = {fk.target_fullname for fk in col.foreign_keys}
+    assert "users.id" in fk_targets
+
+
+def test_weekly_review_user_id_not_nullable() -> None:
+    """WeeklyReview.user_id must be NOT NULL."""
+    col = inspect(WeeklyReview).columns["user_id"]
+    assert col.nullable is False
+
+
+def test_weekly_review_week_start_not_nullable() -> None:
+    """WeeklyReview.week_start must be NOT NULL."""
+    col = inspect(WeeklyReview).columns["week_start"]
+    assert col.nullable is False
+
+
+def test_weekly_review_raw_data_json_not_nullable() -> None:
+    """WeeklyReview.raw_data_json must be NOT NULL."""
+    col = inspect(WeeklyReview).columns["raw_data_json"]
+    assert col.nullable is False
+
+
+def test_weekly_review_raw_data_json_is_jsonb() -> None:
+    """WeeklyReview.raw_data_json must be JSONB."""
+    col = inspect(WeeklyReview).columns["raw_data_json"]
+    assert "JSONB" in str(col.type).upper()
+
+
+def test_weekly_review_insights_json_nullable() -> None:
+    """WeeklyReview.insights_json must be NULLABLE."""
+    col = inspect(WeeklyReview).columns["insights_json"]
+    assert col.nullable is True
+
+
+def test_weekly_review_narrative_nullable() -> None:
+    """WeeklyReview.narrative must be NULLABLE."""
+    col = inspect(WeeklyReview).columns["narrative"]
+    assert col.nullable is True
+
+
+def test_weekly_review_scores_json_nullable() -> None:
+    """WeeklyReview.scores_json must be NULLABLE."""
+    col = inspect(WeeklyReview).columns["scores_json"]
+    assert col.nullable is True
+
+
+def test_weekly_review_agent_metadata_json_nullable() -> None:
+    """WeeklyReview.agent_metadata_json must be NULLABLE."""
+    col = inspect(WeeklyReview).columns["agent_metadata_json"]
+    assert col.nullable is True
+
+
+def test_weekly_review_status_not_nullable() -> None:
+    """WeeklyReview.status must be NOT NULL."""
+    col = inspect(WeeklyReview).columns["status"]
+    assert col.nullable is False
+
+
+def test_weekly_review_status_defaults_to_pending() -> None:
+    """WeeklyReview.status must default to 'pending'."""
+    col = inspect(WeeklyReview).columns["status"]
+    assert col.default is not None
+    assert col.default.arg == ReviewStatus.PENDING  # type: ignore[attr-defined]
+
+
+def test_weekly_review_created_at_not_nullable() -> None:
+    """WeeklyReview.created_at must be NOT NULL."""
+    col = inspect(WeeklyReview).columns["created_at"]
+    assert col.nullable is False
+
+
+def test_weekly_review_created_at_is_datetime_tz() -> None:
+    """WeeklyReview.created_at must be timezone-aware."""
+    from sqlalchemy import DateTime as SADateTime
+
+    col = inspect(WeeklyReview).columns["created_at"]
+    assert isinstance(col.type, SADateTime)
+    assert col.type.timezone is True
+
+
+def test_weekly_review_has_status_check_constraint() -> None:
+    """WeeklyReview must have a CHECK constraint on status."""
+    constraints = {c.name for c in WeeklyReview.__table__.constraints}  # type: ignore[attr-defined]
+    assert "ck_weekly_reviews_status" in constraints
+
+
+def test_weekly_review_has_user_week_index() -> None:
+    """WeeklyReview must have idx_weekly_review_user_week index."""
+    indexes = {idx.name for idx in WeeklyReview.__table__.indexes}  # type: ignore[attr-defined]
+    assert "idx_weekly_review_user_week" in indexes
+
+
+def test_weekly_review_defaults() -> None:
+    """Instantiating WeeklyReview sets status=pending, nullable fields to None."""
+    obj = WeeklyReview(
+        user_id=uuid.uuid4(),
+        week_start=date(2026, 4, 14),
+        raw_data_json={},
+    )
+    assert obj.status == ReviewStatus.PENDING
+    assert obj.narrative is None
+    assert obj.scores_json is None
+    assert obj.insights_json is None
+    assert obj.agent_metadata_json is None
+
+
+def test_weekly_review_repr() -> None:
+    """WeeklyReview.__repr__ must include user_id and week_start."""
+    uid = uuid.uuid4()
+    obj = WeeklyReview(
+        user_id=uid,
+        week_start=date(2026, 4, 14),
+        raw_data_json={},
+    )
+    r = repr(obj)
+    assert str(uid) in r
+    assert "2026-04-14" in r
+
+
+def test_review_status_enum_values() -> None:
+    """ReviewStatus enum must have pending/generating/complete/failed."""
+    assert ReviewStatus.PENDING.value == "pending"
+    assert ReviewStatus.GENERATING.value == "generating"
+    assert ReviewStatus.COMPLETE.value == "complete"
+    assert ReviewStatus.FAILED.value == "failed"

--- a/backend/tests/unit/test_weekly_review_model.py
+++ b/backend/tests/unit/test_weekly_review_model.py
@@ -165,3 +165,41 @@ def test_review_status_enum_values() -> None:
     assert ReviewStatus.GENERATING.value == "generating"
     assert ReviewStatus.COMPLETE.value == "complete"
     assert ReviewStatus.FAILED.value == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — Migration tests
+# ---------------------------------------------------------------------------
+
+
+def test_migration_0009_file_exists() -> None:
+    """Migration file 0009_add_weekly_reviews_table.py must exist."""
+    import os
+
+    migration_path = os.path.join(
+        os.path.dirname(__file__),
+        "../../alembic/versions/0009_add_weekly_reviews_table.py",
+    )
+    assert os.path.exists(os.path.normpath(migration_path)), (
+        "Migration 0009_add_weekly_reviews_table.py not found"
+    )
+
+
+def test_migration_0009_down_revision_is_0008() -> None:
+    """Migration 0009 must chain from revision 0008."""
+    import importlib.util
+    import os
+
+    migration_path = os.path.normpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "../../alembic/versions/0009_add_weekly_reviews_table.py",
+        )
+    )
+    spec = importlib.util.spec_from_file_location("migration_0009", migration_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    assert module.down_revision == "0008"
+    assert module.revision == "0009"

--- a/backend/tests/unit/test_weekly_review_routes.py
+++ b/backend/tests/unit/test_weekly_review_routes.py
@@ -68,15 +68,15 @@ def _clear_overrides() -> None:
 
 
 # ---------------------------------------------------------------------------
-# POST /weekly-reviews
+# POST /weekly-reviews/generate
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_post_weekly_review_triggers_generation_and_returns_response(
+async def test_post_generate_triggers_generation_and_returns_response(
     client: AsyncClient,
 ) -> None:
-    """POST /weekly-reviews returns 200 with review fields populated."""
+    """POST /weekly-reviews/generate returns 200 with review fields populated."""
     _setup_overrides()
     review = _make_review()
     try:
@@ -93,7 +93,7 @@ async def test_post_weekly_review_triggers_generation_and_returns_response(
             ),
         ):
             resp = await client.post(
-                "/weekly-reviews", params={"week_start": "2026-04-13"}
+                "/weekly-reviews/generate", params={"week_start": "2026-04-13"}
             )
     finally:
         _clear_overrides()
@@ -106,25 +106,27 @@ async def test_post_weekly_review_triggers_generation_and_returns_response(
 
 
 @pytest.mark.asyncio
-async def test_post_weekly_review_requires_auth(client: AsyncClient) -> None:
-    """POST /weekly-reviews without auth returns 401."""
+async def test_post_generate_requires_auth(client: AsyncClient) -> None:
+    """POST /weekly-reviews/generate without auth returns 401."""
 
     async def override_db() -> AsyncMock:  # type: ignore[misc]
         yield AsyncMock()
 
     app.dependency_overrides[get_db] = override_db
     try:
-        resp = await client.post("/weekly-reviews", params={"week_start": "2026-04-13"})
+        resp = await client.post(
+            "/weekly-reviews/generate", params={"week_start": "2026-04-13"}
+        )
     finally:
         app.dependency_overrides.clear()
     assert resp.status_code == 401
 
 
 @pytest.mark.asyncio
-async def test_post_weekly_review_accepts_week_start_query_param(
+async def test_post_generate_accepts_week_start_query_param(
     client: AsyncClient,
 ) -> None:
-    """POST /weekly-reviews passes the correct week_start date to the service."""
+    """POST /weekly-reviews/generate passes week_start to the service."""
     _setup_overrides()
     review = _make_review()
     captured: list[date] = []
@@ -145,7 +147,9 @@ async def test_post_weekly_review_accepts_week_start_query_param(
                 return_value=review,
             ),
         ):
-            await client.post("/weekly-reviews", params={"week_start": "2026-04-15"})
+            await client.post(
+                "/weekly-reviews/generate", params={"week_start": "2026-04-15"}
+            )
     finally:
         _clear_overrides()
 
@@ -154,42 +158,106 @@ async def test_post_weekly_review_accepts_week_start_query_param(
 
 
 # ---------------------------------------------------------------------------
-# GET /weekly-reviews/{week_start}
+# GET /weekly-reviews (list)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_get_weekly_review_returns_stored_review(client: AsyncClient) -> None:
-    """GET /weekly-reviews/{week_start} returns 200 with the stored review."""
+async def test_list_weekly_reviews_returns_user_reviews(client: AsyncClient) -> None:
+    """GET /weekly-reviews returns a list of the current user's reviews."""
     _setup_overrides()
-    review = _make_review()
+    reviews = [_make_review()]
     try:
         with patch(
-            "app.api.weekly_reviews.get_review",
+            "app.api.weekly_reviews.list_reviews",
             new_callable=AsyncMock,
-            return_value=review,
+            return_value=reviews,
         ):
-            resp = await client.get("/weekly-reviews/2026-04-13")
+            resp = await client.get("/weekly-reviews")
     finally:
         _clear_overrides()
 
     assert resp.status_code == 200
-    assert resp.json()["week_start"] == "2026-04-13"
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["id"] == str(REVIEW_ID)
 
 
 @pytest.mark.asyncio
-async def test_get_weekly_review_returns_404_when_not_found(
-    client: AsyncClient,
-) -> None:
-    """GET /weekly-reviews/{week_start} returns 404 when no review exists."""
+async def test_list_weekly_reviews_returns_empty_when_none(client: AsyncClient) -> None:
+    """GET /weekly-reviews returns [] when the user has no reviews."""
     _setup_overrides()
     try:
         with patch(
-            "app.api.weekly_reviews.get_review",
+            "app.api.weekly_reviews.list_reviews",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            resp = await client.get("/weekly-reviews")
+    finally:
+        _clear_overrides()
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_weekly_reviews_requires_auth(client: AsyncClient) -> None:
+    """GET /weekly-reviews without auth returns 401."""
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        resp = await client.get("/weekly-reviews")
+    finally:
+        app.dependency_overrides.clear()
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /weekly-reviews/{review_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_weekly_review_by_id_returns_stored_review(
+    client: AsyncClient,
+) -> None:
+    """GET /weekly-reviews/{id} returns 200 with the stored review."""
+    _setup_overrides()
+    review = _make_review()
+    try:
+        with patch(
+            "app.api.weekly_reviews.get_review_by_id",
+            new_callable=AsyncMock,
+            return_value=review,
+        ):
+            resp = await client.get(f"/weekly-reviews/{REVIEW_ID}")
+    finally:
+        _clear_overrides()
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == str(REVIEW_ID)
+    assert data["scores_json"]["overall_score"] == 8
+
+
+@pytest.mark.asyncio
+async def test_get_weekly_review_by_id_returns_404_when_not_found(
+    client: AsyncClient,
+) -> None:
+    """GET /weekly-reviews/{id} returns 404 when no review exists."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.weekly_reviews.get_review_by_id",
             new_callable=AsyncMock,
             return_value=None,
         ):
-            resp = await client.get("/weekly-reviews/2026-04-13")
+            resp = await client.get(f"/weekly-reviews/{REVIEW_ID}")
     finally:
         _clear_overrides()
 
@@ -197,15 +265,15 @@ async def test_get_weekly_review_returns_404_when_not_found(
 
 
 @pytest.mark.asyncio
-async def test_get_weekly_review_requires_auth(client: AsyncClient) -> None:
-    """GET /weekly-reviews/{week_start} without auth returns 401."""
+async def test_get_weekly_review_by_id_requires_auth(client: AsyncClient) -> None:
+    """GET /weekly-reviews/{id} without auth returns 401."""
 
     async def override_db() -> AsyncMock:  # type: ignore[misc]
         yield AsyncMock()
 
     app.dependency_overrides[get_db] = override_db
     try:
-        resp = await client.get("/weekly-reviews/2026-04-13")
+        resp = await client.get(f"/weekly-reviews/{REVIEW_ID}")
     finally:
         app.dependency_overrides.clear()
     assert resp.status_code == 401

--- a/backend/tests/unit/test_weekly_review_routes.py
+++ b/backend/tests/unit/test_weekly_review_routes.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.main import app
+from app.models.weekly_review import ReviewStatus, WeeklyReview
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+REVIEW_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+
+
+def _make_fake_user() -> MagicMock:
+    fake = MagicMock()
+    fake.id = USER_ID
+    fake.email = "test@example.com"
+    fake.name = "Test User"
+    return fake
+
+
+def _make_review(status: str = ReviewStatus.COMPLETE) -> WeeklyReview:
+    review = WeeklyReview(
+        user_id=USER_ID,
+        week_start=date(2026, 4, 13),
+        raw_data_json={},
+        status=status,
+    )
+    review.id = REVIEW_ID
+    review.narrative = "Executive summary.\n\nTime analysis.\n\nPatterns.\n\nConcerns."
+    review.scores_json = {
+        "actionability_score": 8,
+        "accuracy_score": 9,
+        "coherence_score": 7,
+        "overall_score": 8,
+        "feedback": "good",
+    }
+    review.insights_json = {}
+    review.agent_metadata_json = {"analysis_date": "2026-04-13", "judge_scored": True}
+    return review
+
+
+@pytest.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+def _setup_overrides() -> None:
+    app.dependency_overrides[get_current_user] = _make_fake_user
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+
+
+def _clear_overrides() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /weekly-reviews
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_weekly_review_triggers_generation_and_returns_response(
+    client: AsyncClient,
+) -> None:
+    """POST /weekly-reviews returns 200 with review fields populated."""
+    _setup_overrides()
+    review = _make_review()
+    try:
+        with (
+            patch(
+                "app.api.weekly_reviews.get_or_create_review",
+                new_callable=AsyncMock,
+                return_value=review,
+            ),
+            patch(
+                "app.api.weekly_reviews.generate_review",
+                new_callable=AsyncMock,
+                return_value=review,
+            ),
+        ):
+            resp = await client.post(
+                "/weekly-reviews", params={"week_start": "2026-04-13"}
+            )
+    finally:
+        _clear_overrides()
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == ReviewStatus.COMPLETE
+    assert data["week_start"] == "2026-04-13"
+    assert "narrative" in data
+
+
+@pytest.mark.asyncio
+async def test_post_weekly_review_requires_auth(client: AsyncClient) -> None:
+    """POST /weekly-reviews without auth returns 401."""
+    resp = await client.post("/weekly-reviews", params={"week_start": "2026-04-13"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_post_weekly_review_accepts_week_start_query_param(
+    client: AsyncClient,
+) -> None:
+    """POST /weekly-reviews passes the correct week_start date to the service."""
+    _setup_overrides()
+    review = _make_review()
+    captured: list[date] = []
+
+    async def fake_get_or_create(db, user_id, week_start):  # type: ignore[no-untyped-def]
+        captured.append(week_start)
+        return review
+
+    try:
+        with (
+            patch(
+                "app.api.weekly_reviews.get_or_create_review",
+                side_effect=fake_get_or_create,
+            ),
+            patch(
+                "app.api.weekly_reviews.generate_review",
+                new_callable=AsyncMock,
+                return_value=review,
+            ),
+        ):
+            await client.post(
+                "/weekly-reviews", params={"week_start": "2026-04-15"}
+            )
+    finally:
+        _clear_overrides()
+
+    # week_start 2026-04-15 (Wednesday) → service receives Wednesday; service normalizes to Monday
+    assert captured[0] == date(2026, 4, 15)
+
+
+# ---------------------------------------------------------------------------
+# GET /weekly-reviews/{week_start}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_weekly_review_returns_stored_review(client: AsyncClient) -> None:
+    """GET /weekly-reviews/{week_start} returns 200 with the stored review."""
+    _setup_overrides()
+    review = _make_review()
+    try:
+        with patch(
+            "app.api.weekly_reviews.get_review",
+            new_callable=AsyncMock,
+            return_value=review,
+        ):
+            resp = await client.get("/weekly-reviews/2026-04-13")
+    finally:
+        _clear_overrides()
+
+    assert resp.status_code == 200
+    assert resp.json()["week_start"] == "2026-04-13"
+
+
+@pytest.mark.asyncio
+async def test_get_weekly_review_returns_404_when_not_found(
+    client: AsyncClient,
+) -> None:
+    """GET /weekly-reviews/{week_start} returns 404 when no review exists."""
+    _setup_overrides()
+    try:
+        with patch(
+            "app.api.weekly_reviews.get_review",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            resp = await client.get("/weekly-reviews/2026-04-13")
+    finally:
+        _clear_overrides()
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_weekly_review_requires_auth(client: AsyncClient) -> None:
+    """GET /weekly-reviews/{week_start} without auth returns 401."""
+    resp = await client.get("/weekly-reviews/2026-04-13")
+    assert resp.status_code == 401

--- a/backend/tests/unit/test_weekly_review_routes.py
+++ b/backend/tests/unit/test_weekly_review_routes.py
@@ -108,7 +108,15 @@ async def test_post_weekly_review_triggers_generation_and_returns_response(
 @pytest.mark.asyncio
 async def test_post_weekly_review_requires_auth(client: AsyncClient) -> None:
     """POST /weekly-reviews without auth returns 401."""
-    resp = await client.post("/weekly-reviews", params={"week_start": "2026-04-13"})
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        resp = await client.post("/weekly-reviews", params={"week_start": "2026-04-13"})
+    finally:
+        app.dependency_overrides.clear()
     assert resp.status_code == 401
 
 
@@ -193,5 +201,13 @@ async def test_get_weekly_review_returns_404_when_not_found(
 @pytest.mark.asyncio
 async def test_get_weekly_review_requires_auth(client: AsyncClient) -> None:
     """GET /weekly-reviews/{week_start} without auth returns 401."""
-    resp = await client.get("/weekly-reviews/2026-04-13")
+
+    async def override_db() -> AsyncMock:  # type: ignore[misc]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        resp = await client.get("/weekly-reviews/2026-04-13")
+    finally:
+        app.dependency_overrides.clear()
     assert resp.status_code == 401

--- a/backend/tests/unit/test_weekly_review_routes.py
+++ b/backend/tests/unit/test_weekly_review_routes.py
@@ -145,13 +145,11 @@ async def test_post_weekly_review_accepts_week_start_query_param(
                 return_value=review,
             ),
         ):
-            await client.post(
-                "/weekly-reviews", params={"week_start": "2026-04-15"}
-            )
+            await client.post("/weekly-reviews", params={"week_start": "2026-04-15"})
     finally:
         _clear_overrides()
 
-    # week_start 2026-04-15 (Wednesday) → service receives Wednesday; service normalizes to Monday
+    # Wednesday 2026-04-15 → passed as-is; service normalizes to Monday
     assert captured[0] == date(2026, 4, 15)
 
 

--- a/backend/tests/unit/test_weekly_review_service.py
+++ b/backend/tests/unit/test_weekly_review_service.py
@@ -555,3 +555,150 @@ async def test_generate_review_calls_run_group_d() -> None:
     assert judge_called, "run_group_d was not called"
     assert result.scores_json is not None
     assert result.scores_json["overall_score"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Cycle — per-stage observability (latency + Sentry breadcrumbs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_review_records_per_stage_latency() -> None:
+    """agent_metadata_json.stages must include latency_ms for each pipeline stage."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    review = _make_review()
+
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            new_callable=AsyncMock,
+        ) as mock_a,
+        patch(
+            "app.services.weekly_review_service.run_group_b",
+            new_callable=AsyncMock,
+        ) as mock_b,
+        patch(
+            "app.services.weekly_review_service.run_group_c",
+            new_callable=AsyncMock,
+        ) as mock_c,
+        patch(
+            "app.services.weekly_review_service.run_group_d",
+            new_callable=AsyncMock,
+        ) as mock_d,
+    ):
+        from app.agents.schemas import (
+            GroupAResult,
+            JudgeResult,
+            NarrativeWriterResult,
+            PatternDetectorResult,
+        )
+
+        mock_a.return_value = GroupAResult()
+        mock_b.return_value = PatternDetectorResult(patterns=[], summary="ok")
+        mock_c.return_value = NarrativeWriterResult(
+            executive_summary="s",
+            time_analysis="t",
+            productivity_patterns="p",
+            areas_of_concern="a",
+        )
+        mock_d.return_value = JudgeResult(
+            actionability_score=8,
+            accuracy_score=9,
+            coherence_score=7,
+            overall_score=8,
+            feedback="good",
+        )
+        result = await generate_review(db, review, date(2026, 4, 13))
+
+    meta = result.agent_metadata_json
+    assert meta is not None
+    stages = meta.get("stages")
+    assert stages is not None, "agent_metadata_json must include a 'stages' mapping"
+    for name in ("group_a", "group_b", "group_c", "group_d"):
+        assert name in stages, f"missing stage entry for {name}"
+        assert "latency_ms" in stages[name], f"{name} missing latency_ms"
+        assert isinstance(stages[name]["latency_ms"], int | float)
+        assert stages[name]["latency_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_generate_review_emits_sentry_breadcrumb_per_stage() -> None:
+    """Each pipeline stage must emit a Sentry breadcrumb tagged with its name."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    review = _make_review()
+
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            new_callable=AsyncMock,
+        ) as mock_a,
+        patch(
+            "app.services.weekly_review_service.run_group_b",
+            new_callable=AsyncMock,
+        ) as mock_b,
+        patch(
+            "app.services.weekly_review_service.run_group_c",
+            new_callable=AsyncMock,
+        ) as mock_c,
+        patch(
+            "app.services.weekly_review_service.run_group_d",
+            new_callable=AsyncMock,
+        ) as mock_d,
+        patch(
+            "app.services.weekly_review_service.sentry_sdk.add_breadcrumb"
+        ) as mock_crumb,
+    ):
+        from app.agents.schemas import (
+            GroupAResult,
+            JudgeResult,
+            NarrativeWriterResult,
+            PatternDetectorResult,
+        )
+
+        mock_a.return_value = GroupAResult()
+        mock_b.return_value = PatternDetectorResult(patterns=[], summary="ok")
+        mock_c.return_value = NarrativeWriterResult(
+            executive_summary="s",
+            time_analysis="t",
+            productivity_patterns="p",
+            areas_of_concern="a",
+        )
+        mock_d.return_value = JudgeResult(
+            actionability_score=8,
+            accuracy_score=9,
+            coherence_score=7,
+            overall_score=8,
+            feedback="good",
+        )
+        await generate_review(db, review, date(2026, 4, 13))
+
+    messages = [c.kwargs.get("message", "") for c in mock_crumb.call_args_list]
+    joined = " | ".join(messages)
+    for name in ("group_a", "group_b", "group_c", "group_d"):
+        assert name in joined, f"no breadcrumb emitted for {name} (got: {joined!r})"
+
+
+@pytest.mark.asyncio
+async def test_generate_review_emits_failed_breadcrumb_on_exception() -> None:
+    """On pipeline failure a breadcrumb with level=error must be emitted."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    review = _make_review()
+
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ),
+        patch(
+            "app.services.weekly_review_service.sentry_sdk.add_breadcrumb"
+        ) as mock_crumb,
+    ):
+        with pytest.raises(RuntimeError):
+            await generate_review(db, review, date(2026, 4, 13))
+
+    levels = [c.kwargs.get("level") for c in mock_crumb.call_args_list]
+    assert "error" in levels, f"expected an error-level breadcrumb, got {levels!r}"

--- a/backend/tests/unit/test_weekly_review_service.py
+++ b/backend/tests/unit/test_weekly_review_service.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.weekly_review import ReviewStatus, WeeklyReview
+from app.services.weekly_review_service import _align_to_monday, get_or_create_review
+
+USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — _align_to_monday helper
+# ---------------------------------------------------------------------------
+
+
+def test_align_to_monday_already_monday() -> None:
+    assert _align_to_monday(date(2026, 4, 13)) == date(2026, 4, 13)
+
+
+def test_align_to_monday_from_wednesday() -> None:
+    assert _align_to_monday(date(2026, 4, 15)) == date(2026, 4, 13)
+
+
+def test_align_to_monday_from_sunday() -> None:
+    assert _align_to_monday(date(2026, 4, 19)) == date(2026, 4, 13)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — get_or_create_review
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_review_creates_new() -> None:
+    """When no review exists, a new one is created with status=pending."""
+    db = MagicMock()
+    # Simulate SELECT returning no result
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=mock_result)
+    db.flush = AsyncMock()
+
+    week_start = date(2026, 4, 13)
+    review = await get_or_create_review(db, USER_ID, week_start)
+
+    assert review.user_id == USER_ID
+    assert review.week_start == week_start
+    assert review.status == ReviewStatus.PENDING
+    db.add.assert_called_once()
+    db.flush.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_review_returns_existing() -> None:
+    """When a review exists, the existing one is returned without creating a new one."""
+    existing = WeeklyReview(
+        user_id=USER_ID,
+        week_start=date(2026, 4, 13),
+        raw_data_json={},
+        status=ReviewStatus.COMPLETE,
+    )
+    db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = existing
+    db.execute = AsyncMock(return_value=mock_result)
+
+    review = await get_or_create_review(db, USER_ID, date(2026, 4, 13))
+
+    assert review is existing
+    db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_review_normalizes_week_start_to_monday() -> None:
+    """Input date mid-week is clamped to Monday before lookup and storage."""
+    db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=mock_result)
+    db.flush = AsyncMock()
+
+    # Wednesday → should store as Monday 2026-04-13
+    review = await get_or_create_review(db, USER_ID, date(2026, 4, 15))
+
+    assert review.week_start == date(2026, 4, 13)

--- a/backend/tests/unit/test_weekly_review_service.py
+++ b/backend/tests/unit/test_weekly_review_service.py
@@ -119,6 +119,7 @@ async def test_generate_review_sets_generating_before_pipeline() -> None:
     async def fake_run_group_a(*args, **kwargs):  # type: ignore[no-untyped-def]
         status_at_call.append(review.status)
         from app.agents.schemas import GroupAResult
+
         return GroupAResult()
 
     with (

--- a/backend/tests/unit/test_weekly_review_service.py
+++ b/backend/tests/unit/test_weekly_review_service.py
@@ -11,6 +11,7 @@ from app.services.weekly_review_service import (
     _align_to_monday,
     generate_review,
     get_or_create_review,
+    get_review,
 )
 
 USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
@@ -79,6 +80,31 @@ async def test_get_or_create_review_returns_existing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_review_queries_by_user_id() -> None:
+    """DB query must filter by the correct user_id, not another user."""
+
+    async def fake_execute(stmt):  # type: ignore[no-untyped-def]
+        # Only return a result if the query is for the correct user
+        whereclause = str(stmt.whereclause)
+        # Both user_id and week_start conditions must be == (not !=)
+        if "!=" in whereclause:
+            mock_r = MagicMock()
+            mock_r.scalar_one_or_none.return_value = None
+            return mock_r
+        mock_r = MagicMock()
+        mock_r.scalar_one_or_none.return_value = None
+        return mock_r
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=fake_execute)
+    db.flush = AsyncMock()
+
+    # Should create a new review for USER_ID, not find the other user's review
+    review = await get_or_create_review(db, USER_ID, date(2026, 4, 13))
+    assert review.user_id == USER_ID
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_review_normalizes_week_start_to_monday() -> None:
     """Input date mid-week is clamped to Monday before lookup and storage."""
     db = MagicMock()
@@ -105,6 +131,49 @@ def _make_review(status: str = ReviewStatus.PENDING) -> WeeklyReview:
         raw_data_json={},
         status=status,
     )
+
+
+@pytest.mark.asyncio
+async def test_get_review_returns_existing() -> None:
+    """get_review returns the stored review when found."""
+    existing = WeeklyReview(
+        user_id=USER_ID,
+        week_start=date(2026, 4, 13),
+        raw_data_json={},
+    )
+    db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = existing
+    db.execute = AsyncMock(return_value=mock_result)
+
+    result = await get_review(db, USER_ID, date(2026, 4, 13))
+    assert result is existing
+
+
+@pytest.mark.asyncio
+async def test_get_review_returns_none_when_not_found() -> None:
+    """get_review returns None when no review exists for the user/week."""
+    db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=mock_result)
+
+    result = await get_review(db, USER_ID, date(2026, 4, 13))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_review_normalizes_week_start_to_monday() -> None:
+    """get_review normalizes any date to Monday before querying."""
+    db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=mock_result)
+
+    # Sunday — should query for Monday 2026-04-13
+    await get_review(db, USER_ID, date(2026, 4, 19))
+    # Verify execute was called (query happened, not skipped)
+    db.execute.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -276,3 +345,213 @@ async def test_generate_review_stores_agent_metadata() -> None:
 
     assert result.agent_metadata_json is not None
     assert "analysis_date" in result.agent_metadata_json
+
+
+@pytest.mark.asyncio
+async def test_generate_review_populates_insights_from_group_a() -> None:
+    """insights_json must be populated from group_a_result, not None."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    review = _make_review()
+
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            new_callable=AsyncMock,
+        ) as mock_a,
+        patch(
+            "app.services.weekly_review_service.run_group_b",
+            new_callable=AsyncMock,
+        ) as mock_b,
+        patch(
+            "app.services.weekly_review_service.run_group_c",
+            new_callable=AsyncMock,
+        ) as mock_c,
+        patch(
+            "app.services.weekly_review_service.run_group_d",
+            new_callable=AsyncMock,
+        ) as mock_d,
+    ):
+        from app.agents.schemas import (
+            GroupAResult,
+            NarrativeWriterResult,
+            PatternDetectorResult,
+        )
+
+        mock_a.return_value = GroupAResult()
+        mock_b.return_value = PatternDetectorResult(patterns=[], summary="ok")
+        mock_c.return_value = NarrativeWriterResult(
+            executive_summary="s",
+            time_analysis="t",
+            productivity_patterns="p",
+            areas_of_concern="a",
+        )
+        mock_d.return_value = None
+        result = await generate_review(db, review, date(2026, 4, 13))
+
+    assert result.insights_json is not None
+    assert isinstance(result.insights_json, dict)
+
+
+@pytest.mark.asyncio
+async def test_generate_review_narrative_contains_all_sections() -> None:
+    """narrative must concatenate all four NarrativeWriterResult sections."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    review = _make_review()
+
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            new_callable=AsyncMock,
+        ) as mock_a,
+        patch(
+            "app.services.weekly_review_service.run_group_b",
+            new_callable=AsyncMock,
+        ) as mock_b,
+        patch(
+            "app.services.weekly_review_service.run_group_c",
+            new_callable=AsyncMock,
+        ) as mock_c,
+        patch(
+            "app.services.weekly_review_service.run_group_d",
+            new_callable=AsyncMock,
+        ) as mock_d,
+    ):
+        from app.agents.schemas import (
+            GroupAResult,
+            NarrativeWriterResult,
+            PatternDetectorResult,
+        )
+
+        mock_a.return_value = GroupAResult()
+        mock_b.return_value = PatternDetectorResult(patterns=[], summary="ok")
+        mock_c.return_value = NarrativeWriterResult(
+            executive_summary="EXEC_SUMMARY",
+            time_analysis="TIME_ANALYSIS",
+            productivity_patterns="PRODUCTIVITY",
+            areas_of_concern="CONCERNS",
+        )
+        mock_d.return_value = None
+        result = await generate_review(db, review, date(2026, 4, 13))
+
+    assert result.narrative is not None
+    assert "EXEC_SUMMARY" in result.narrative
+    assert "TIME_ANALYSIS" in result.narrative
+    assert "PRODUCTIVITY" in result.narrative
+    assert "CONCERNS" in result.narrative
+
+
+@pytest.mark.asyncio
+async def test_generate_review_metadata_has_required_keys() -> None:
+    """agent_metadata_json must have patterns_detected, group_a_errors, judge_scored."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    review = _make_review()
+
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            new_callable=AsyncMock,
+        ) as mock_a,
+        patch(
+            "app.services.weekly_review_service.run_group_b",
+            new_callable=AsyncMock,
+        ) as mock_b,
+        patch(
+            "app.services.weekly_review_service.run_group_c",
+            new_callable=AsyncMock,
+        ) as mock_c,
+        patch(
+            "app.services.weekly_review_service.run_group_d",
+            new_callable=AsyncMock,
+        ) as mock_d,
+    ):
+        from app.agents.schemas import (
+            GroupAResult,
+            JudgeResult,
+            NarrativeWriterResult,
+            PatternDetectorResult,
+        )
+
+        mock_a.return_value = GroupAResult()
+        mock_b.return_value = PatternDetectorResult(patterns=[], summary="ok")
+        mock_c.return_value = NarrativeWriterResult(
+            executive_summary="s",
+            time_analysis="t",
+            productivity_patterns="p",
+            areas_of_concern="a",
+        )
+        mock_d.return_value = JudgeResult(
+            actionability_score=8,
+            accuracy_score=9,
+            coherence_score=7,
+            overall_score=8,
+            feedback="good",
+        )
+        result = await generate_review(db, review, date(2026, 4, 13))
+
+    meta = result.agent_metadata_json
+    assert meta is not None
+    assert "patterns_detected" in meta
+    assert "group_a_errors" in meta
+    assert meta["judge_scored"] is True
+
+
+@pytest.mark.asyncio
+async def test_generate_review_calls_run_group_d() -> None:
+    """run_group_d must be called — skipping it is not acceptable."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    review = _make_review()
+    judge_called = []
+
+    async def fake_run_group_d(*args, **kwargs):  # type: ignore[no-untyped-def]
+        judge_called.append(True)
+        from app.agents.schemas import JudgeResult
+
+        return JudgeResult(
+            actionability_score=7,
+            accuracy_score=8,
+            coherence_score=9,
+            overall_score=8,
+            feedback="solid",
+        )
+
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            new_callable=AsyncMock,
+        ) as mock_a,
+        patch(
+            "app.services.weekly_review_service.run_group_b",
+            new_callable=AsyncMock,
+        ) as mock_b,
+        patch(
+            "app.services.weekly_review_service.run_group_c",
+            new_callable=AsyncMock,
+        ) as mock_c,
+        patch(
+            "app.services.weekly_review_service.run_group_d",
+            side_effect=fake_run_group_d,
+        ),
+    ):
+        from app.agents.schemas import (
+            GroupAResult,
+            NarrativeWriterResult,
+            PatternDetectorResult,
+        )
+
+        mock_a.return_value = GroupAResult()
+        mock_b.return_value = PatternDetectorResult(patterns=[], summary="ok")
+        mock_c.return_value = NarrativeWriterResult(
+            executive_summary="s",
+            time_analysis="t",
+            productivity_patterns="p",
+            areas_of_concern="a",
+        )
+        result = await generate_review(db, review, date(2026, 4, 13))
+
+    assert judge_called, "run_group_d was not called"
+    assert result.scores_json is not None
+    assert result.scores_json["overall_score"] == 8

--- a/backend/tests/unit/test_weekly_review_service.py
+++ b/backend/tests/unit/test_weekly_review_service.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.models.weekly_review import ReviewStatus, WeeklyReview
-from app.services.weekly_review_service import _align_to_monday, get_or_create_review
+from app.services.weekly_review_service import (
+    _align_to_monday,
+    generate_review,
+    get_or_create_review,
+)
 
 USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 
@@ -87,3 +91,187 @@ async def test_get_or_create_review_normalizes_week_start_to_monday() -> None:
     review = await get_or_create_review(db, USER_ID, date(2026, 4, 15))
 
     assert review.week_start == date(2026, 4, 13)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — generate_review
+# ---------------------------------------------------------------------------
+
+
+def _make_review(status: str = ReviewStatus.PENDING) -> WeeklyReview:
+    return WeeklyReview(
+        user_id=USER_ID,
+        week_start=date(2026, 4, 13),
+        raw_data_json={},
+        status=status,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_review_sets_generating_before_pipeline() -> None:
+    """Status must flip to 'generating' before any agent runs."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    review = _make_review()
+
+    status_at_call: list[str] = []
+
+    async def fake_run_group_a(*args, **kwargs):  # type: ignore[no-untyped-def]
+        status_at_call.append(review.status)
+        from app.agents.schemas import GroupAResult
+        return GroupAResult()
+
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            side_effect=fake_run_group_a,
+        ),
+        patch(
+            "app.services.weekly_review_service.run_group_b",
+            new_callable=AsyncMock,
+        ) as mock_b,
+        patch(
+            "app.services.weekly_review_service.run_group_c",
+            new_callable=AsyncMock,
+        ) as mock_c,
+        patch(
+            "app.services.weekly_review_service.run_group_d",
+            new_callable=AsyncMock,
+        ) as mock_d,
+    ):
+        from app.agents.schemas import (
+            NarrativeWriterResult,
+            PatternDetectorResult,
+        )
+
+        mock_b.return_value = PatternDetectorResult(patterns=[], summary="ok")
+        mock_c.return_value = NarrativeWriterResult(
+            executive_summary="s",
+            time_analysis="t",
+            productivity_patterns="p",
+            areas_of_concern="a",
+        )
+        mock_d.return_value = None
+
+        await generate_review(db, review, date(2026, 4, 13))
+
+    assert status_at_call == [ReviewStatus.GENERATING]
+
+
+@pytest.mark.asyncio
+async def test_generate_review_sets_status_complete_on_success() -> None:
+    """After a successful pipeline run, status must be 'complete'."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    review = _make_review()
+
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            new_callable=AsyncMock,
+        ) as mock_a,
+        patch(
+            "app.services.weekly_review_service.run_group_b",
+            new_callable=AsyncMock,
+        ) as mock_b,
+        patch(
+            "app.services.weekly_review_service.run_group_c",
+            new_callable=AsyncMock,
+        ) as mock_c,
+        patch(
+            "app.services.weekly_review_service.run_group_d",
+            new_callable=AsyncMock,
+        ) as mock_d,
+    ):
+        from app.agents.schemas import (
+            GroupAResult,
+            JudgeResult,
+            NarrativeWriterResult,
+            PatternDetectorResult,
+        )
+
+        mock_a.return_value = GroupAResult()
+        mock_b.return_value = PatternDetectorResult(patterns=[], summary="ok")
+        mock_c.return_value = NarrativeWriterResult(
+            executive_summary="summary",
+            time_analysis="time",
+            productivity_patterns="patterns",
+            areas_of_concern="concerns",
+        )
+        mock_d.return_value = JudgeResult(
+            actionability_score=8,
+            accuracy_score=9,
+            coherence_score=7,
+            overall_score=8,
+            feedback="good",
+        )
+
+        result = await generate_review(db, review, date(2026, 4, 13))
+
+    assert result.status == ReviewStatus.COMPLETE
+    assert result.narrative is not None
+    assert result.scores_json is not None
+
+
+@pytest.mark.asyncio
+async def test_generate_review_sets_status_failed_on_exception() -> None:
+    """If run_group_a raises, status must be set to 'failed'."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    review = _make_review()
+
+    with patch(
+        "app.services.weekly_review_service.run_group_a",
+        side_effect=RuntimeError("agent exploded"),
+    ):
+        with pytest.raises(RuntimeError, match="agent exploded"):
+            await generate_review(db, review, date(2026, 4, 13))
+
+    assert review.status == ReviewStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_generate_review_stores_agent_metadata() -> None:
+    """agent_metadata_json must be populated after a successful run."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    review = _make_review()
+
+    with (
+        patch(
+            "app.services.weekly_review_service.run_group_a",
+            new_callable=AsyncMock,
+        ) as mock_a,
+        patch(
+            "app.services.weekly_review_service.run_group_b",
+            new_callable=AsyncMock,
+        ) as mock_b,
+        patch(
+            "app.services.weekly_review_service.run_group_c",
+            new_callable=AsyncMock,
+        ) as mock_c,
+        patch(
+            "app.services.weekly_review_service.run_group_d",
+            new_callable=AsyncMock,
+        ) as mock_d,
+    ):
+        from app.agents.schemas import (
+            GroupAResult,
+            NarrativeWriterResult,
+            PatternDetectorResult,
+        )
+
+        mock_a.return_value = GroupAResult()
+        mock_b.return_value = PatternDetectorResult(patterns=[], summary="ok")
+        mock_c.return_value = NarrativeWriterResult(
+            executive_summary="s",
+            time_analysis="t",
+            productivity_patterns="p",
+            areas_of_concern="a",
+        )
+        mock_d.return_value = None
+
+        result = await generate_review(db, review, date(2026, 4, 13))
+
+    assert result.agent_metadata_json is not None
+    assert "analysis_date" in result.agent_metadata_json


### PR DESCRIPTION
## Summary
- WeeklyReview SQLAlchemy model + Alembic migration 0009
- POST /weekly-reviews/generate, GET /weekly-reviews (list), GET /weekly-reviews/{review_id} endpoints — user-scoped, JWT-auth
- generate_review orchestrates Group A → B → C → D pipeline, records per-stage `latency_ms` under `agent_metadata_json.stages` and emits Sentry breadcrumbs at each stage (including an error-level crumb on failure)
- Unit tests (model, service, routes) + integration tests hitting real Postgres with the agent pipeline patched to deterministic stubs

Closes #32.

### Scope notes
- Token usage and retry count are **not** yet recorded in `agent_metadata_json` — pydantic-ai's `run_with_metrics` drops `RunResult.usage()` before returning, so threading those through the orchestrator is left as a follow-up rather than ballooning this PR.
- API paths drop the `/api` prefix to match the rest of the codebase (projects, tasks, etc.).

## Test plan
- [x] `pytest tests/unit/test_weekly_review_{model,service,routes}.py` — 53 passing
- [x] `pytest tests/integration/test_weekly_reviews.py` — 12 passing against docker Postgres
- [x] `ruff check . && ruff format --check .`
- [x] `mypy .`
- [ ] CI green on push