### PR TITLE
chore: add PR template with C.L.E.A.R. self-review checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,57 @@
+<!--
+Thanks for opening a PR! Fill each section before requesting review.
+Every PR in FlowDay is reviewed against the C.L.E.A.R. framework — use the
+checklist to self-review before handing off.
+-->
+
+## Summary
+
+<!-- 1–3 bullets: what changed and why. Link the issue. -->
+- Closes #
+-
+
+## C.L.E.A.R. Self-Review
+
+### Context — why does this change exist?
+- [ ] Linked to an issue with clear acceptance criteria
+- [ ] PR description explains the *why*, not just the *what*
+- [ ] Scope matches the issue (no silent scope creep)
+
+### Logic — is the implementation correct?
+- [ ] Happy path covered
+- [ ] Edge cases considered (empty input, concurrent writes, upstream failure, timezone, pagination, …)
+- [ ] Async / transactional semantics sound (no unawaited coroutines, no partial commits)
+
+### Evidence — how do we know it works?
+- [ ] Unit tests added / updated
+- [ ] Integration tests hit real dependencies (Postgres, Redis) — no mocked DB
+- [ ] `pytest` green locally
+- [ ] `ruff check .` and `ruff format --check .` clean
+- [ ] `mypy .` clean
+- [ ] `mutmut run` ≥ 80% (for changes to `services/` or `agents/`)
+- [ ] Manual verification or screenshot attached for UI / API changes
+
+### Architecture — does it fit the codebase?
+- [ ] Route handlers stay thin (validate → service → schema)
+- [ ] No raw SQL in routes; all DB access via service layer
+- [ ] Pydantic schemas used for every API boundary (no ORM models returned)
+- [ ] Agent dependencies injected via `RunContext`, not imported directly
+- [ ] Naming / path conventions consistent with surrounding code
+
+### Risk — what could go wrong?
+- [ ] Alembic migration is reversible (downgrade tested, or explicitly note why not)
+- [ ] User-scoping enforced — no cross-user data leaks (return 404, not 403, for foreign ids)
+- [ ] Secrets / OAuth tokens encrypted at rest; no PII sent to LLMs unsanitised
+- [ ] Sentry breadcrumbs added for new endpoints and agent pipeline stages
+- [ ] Known limitations / follow-ups captured as issues
+
+## Test Plan
+
+<!-- Concrete commands + what passing looks like. -->
+- [ ]
+- [ ]
+
+## Follow-ups
+
+<!-- Anything deliberately out of scope, linked to a tracking issue. -->
+-


### PR DESCRIPTION
## Summary
- Adds `.github/pull_request_template.md`
- Enforces C.L.E.A.R. framework (Context, Logic, Evidence, Architecture, Risk) as the self-review rubric on every PR
- Encodes project-specific rules from CLAUDE.md directly into the checklist (thin routes, no raw SQL in handlers, Pydantic schemas at API boundaries, reversible migrations, Sentry breadcrumbs, cross-user scoping, 80% mutmut floor on services/agents)

## C.L.E.A.R. Self-Review

### Context
- [x] Meta change to repo infrastructure — no issue needed, tracked in conversation
- [x] Scope limited to the template file only

### Logic
- [x] Checklist items all map to concrete conventions in CLAUDE.md / backend CLAUDE.md

### Evidence
- [x] Markdown preview renders correctly on GitHub
- [x] Will self-exercise on the next PR

### Architecture
- [x] Lives under `.github/` per GitHub convention
- [x] Comment preamble marked HTML so the intro text doesn't render into the PR body

### Risk
- [x] Non-code change; cannot affect runtime
- [x] Does not auto-close any issues

## Test Plan
- [x] Open this PR — template should populate the body automatically on fresh PRs after merge

## Follow-ups
- Consider a CODEOWNERS file so reviewers are auto-requested on relevant paths