### PR TITLE
chore: add CODEOWNERS and Feature/Bug issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,30 @@
+# FlowDay code owners
+#
+# GitHub auto-requests review from the matched owners when a PR touches
+# these paths. Last matching pattern wins — put more specific rules below
+# broader ones.
+#
+# Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+# Default — every path needs review from one of the listed owners.
+*                           @mahamayashen @EvanjyChen
+
+# Infra & CI — one owner per change is enough, changes here are fast-moving.
+/.github/                   @mahamayashen
+/docker/                    @mahamayashen
+/backend/alembic/           @mahamayashen @EvanjyChen
+
+# Backend core: routes, services, schemas, models.
+/backend/app/api/           @mahamayashen @EvanjyChen
+/backend/app/services/      @mahamayashen @EvanjyChen
+/backend/app/schemas/       @mahamayashen @EvanjyChen
+/backend/app/models/        @mahamayashen @EvanjyChen
+
+# AI agent pipeline — Judge provider / retries / LLM-as-Judge invariants.
+/backend/app/agents/        @mahamayashen @EvanjyChen
+
+# Frontend.
+/frontend/                  @mahamayashen @EvanjyChen
+
+# Docs and plans.
+/docs/                      @mahamayashen @EvanjyChen

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,50 @@
+---
+name: Bug
+about: Something is broken or behaves incorrectly
+title: "<short description of the broken behaviour>"
+labels: ["bug"]
+---
+
+<!--
+Bug issues still follow the 4-phase workflow: Explore the failure, Plan a fix
+with a regression test as the first AC, Implement via /tdd, then Commit on a
+feature branch named fix/<issue-number>-<short-name>.
+-->
+
+## What happened
+<!-- Observed behaviour. Include stack traces, screenshots, or response bodies verbatim. -->
+
+## What should have happened
+<!-- Expected behaviour and why. Reference the AC or design doc that says so if relevant. -->
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Environment
+- **Branch / commit:**
+- **Backend env:** Python version, DB state, migrations applied
+- **Frontend env:** browser, Node version
+- **Relevant feature flags:**
+
+## Impact
+- [ ] Data corruption or loss
+- [ ] Security / auth bypass
+- [ ] Crash on critical path
+- [ ] Incorrect output (no data at risk)
+- [ ] UX only / cosmetic
+
+## Regression test
+<!--
+The first acceptance criterion for any bug fix must be a failing test that
+reproduces the bug. Draft it here before implementing the fix.
+-->
+- [ ] Failing test at `<path>::<test_name>` reproduces the bug
+
+## Scope
+**In scope for the fix:**
+-
+
+**Out of scope (file separately):**
+-

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/mahamayashen/FlowDay/discussions
+    about: For open-ended questions, design discussions, and ideas that are not yet a feature or bug.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,53 @@
+---
+name: Feature
+about: A new capability or enhancement planned through the 4-phase workflow
+title: "<short imperative title>"
+labels: ["enhancement"]
+---
+
+<!--
+Feature issues drive the 4-phase workflow enforced by CLAUDE.md:
+  Explore  → /explore-issue
+  Plan     → /plan-issue (writes docs/plans/issue-<N>-<name>.md)
+  Implement → /tdd (strict RED/GREEN/REFACTOR, one cycle per AC below)
+  Commit   → feature/<issue-number>-<name> branch → PR to main
+Fill every section before moving to Phase 2.
+-->
+
+## Description
+<!-- What is this feature and why does it exist? What user / system problem does it solve? -->
+
+## Acceptance Criteria
+<!--
+One checkbox per TDD cycle. Each item must be small enough that a single
+failing test can anchor it. Avoid compound criteria joined by "and".
+-->
+- [ ]
+- [ ]
+- [ ]
+
+## Production Requirement Link
+<!-- Which of the four production requirements does this connect to? Delete rows that don't apply. -->
+- [ ] Parallel agents (Group A `asyncio.gather`, per-agent error handling)
+- [ ] LLM-as-Judge (different provider from Narrative Writer, retry on score < 80)
+- [ ] CI/CD + monitoring (Sentry breadcrumbs, Grafana metrics, mutmut ≥ 80%)
+- [ ] Security (OAuth token encryption, PII anonymisation before LLM, scoping)
+
+## Scope
+**In scope:**
+-
+
+**Out of scope (flag if encountered):**
+-
+
+## TDD Cycles
+<!-- One entry per acceptance criterion. -->
+1. **RED:** <failing test that anchors AC #1>
+   **GREEN:** <minimum implementation to pass>
+   **REFACTOR:** <cleanup target>
+2.
+3.
+
+## References
+<!-- Links to related issues, design docs, external specs. -->
+-


### PR DESCRIPTION
## Summary
- `.github/CODEOWNERS` — auto-requests review from `@mahamayashen` and `@EvanjyChen`, with tighter routing for `/.github/`, `/docker/`, `/backend/alembic/`, and the agent pipeline
- `.github/ISSUE_TEMPLATE/feature.md` — encodes the 4-phase workflow from CLAUDE.md: AC list sized for TDD cycles, production-requirement link-back, explicit in/out of scope
- `.github/ISSUE_TEMPLATE/bug.md` — requires a failing regression test as the first AC before the fix
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues and points open-ended questions to Discussions

## C.L.E.A.R. Self-Review

### Context
- [x] Follow-up to #74; same meta-infra track
- [x] Scope limited to `.github/` additions only

### Logic
- [x] CODEOWNERS patterns follow "broad default → specific paths" order so the last-match-wins rule picks the right owner
- [x] Feature template's AC section is checkbox-list so `/tdd` can walk it one cycle at a time
- [x] Bug template's regression-test AC encodes the TDD requirement that no fix lands without a failing test first

### Evidence
- [x] GitHub will render both templates on "New Issue" after merge
- [x] `config.yml` `blank_issues_enabled: false` hides the "Open a blank issue" option
- [x] Will self-exercise on the next new issue opened against `main`

### Architecture
- [x] Path conventions match GitHub's expectations (`.github/CODEOWNERS`, `.github/ISSUE_TEMPLATE/*.md`)
- [x] Frontmatter keys (`name`, `about`, `title`, `labels`) valid per GitHub schema

### Risk
- [x] Non-code change; cannot affect runtime
- [x] CODEOWNERS only affects *review requests*, not branch-protection rules — no one is auto-blocked from merging
- [x] Both listed owners exist as collaborators on the repo (verified via `gh api`)

## Test Plan
- [x] After merge: open a new issue → see Feature / Bug cards
- [x] After merge: open a PR touching `/backend/agents/` → verify both owners auto-requested

## Follow-ups
- Enable branch-protection on `main` (requires the repo settings UI — cannot be scripted from a PR). Recommended rules:
  - Require PR + ≥ 1 approval
  - Require CI status checks to pass (Lint & Type-check, tests)
  - Require conversations resolved
  - Require CODEOWNERS review for matched paths