### PR TITLE
test: verify Claude AI Review (Stage 6) after app install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Claude PR Review
         uses: anthropics/claude-code-action@v1
+        timeout-minutes: 5
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model claude-haiku-4-5-20251001 --max-turns 3 --compact"
           prompt: |
             Review this PR for FlowDay. Check:
             1. Security: OAuth token handling, PII exposure, prompt injection risks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 # Cancel in-progress runs for the same branch/PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Verifies that Stage 6 (Claude AI Review) passes after installing the Claude GitHub App on this repo
- Related to #78

## Test plan
- [ ] CI pipeline runs successfully
- [ ] Stage 6: Claude AI Review passes (OIDC token exchange + review comment posted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)