### PR TITLE
ci: make Claude AI Review opt-in via PR label (off by default)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,12 @@ jobs:
   # ──────────────────────────────────────────────
   ai-review:
     name: "Stage 6: Claude AI Review"
-    if: github.event_name == 'pull_request'
+    # Opt-in: only runs when the PR is labelled `ai-review`. Each run
+    # consumes Anthropic API credit, so it's off by default. Add the
+    # label on PRs where a Claude review would be useful.
+    if: >-
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'ai-review')
     needs: [backend-tests, frontend-tests, e2e-tests, security-gates]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why

Each Stage 6 run consumes Anthropic API credit. Running on every PR across the team gets expensive fast, and most routine PRs don't need it.

## What

Gated \`ai-review\` job on a \`ai-review\` PR label:

\`\`\`yaml
if: >-
  github.event_name == 'pull_request' &&
  contains(github.event.pull_request.labels.*.name, 'ai-review')
\`\`\`

## Behavior

- **No label** → Stage 6 is skipped (does not block merge).
- **\`ai-review\` label applied** → Stage 6 runs on the next push to the PR (or immediately if re-run).
- Label can be created on the fly — no pre-configuration needed.

## Related

- #78 — Claude Code GitHub App still needs to be installed for Stage 6 to succeed when enabled.

## Test plan

- [x] YAML validates
- [ ] Open a no-label PR → verify Stage 6 shows as skipped
- [ ] Apply \`ai-review\` label to a PR → verify Stage 6 runs