### PR TITLE
infra: add Railway deployment config + configurable Dockerfile PORT (#83)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,4 +31,5 @@ USER appuser
 
 EXPOSE 5060
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5060"]
+# $PORT is set by Railway at runtime; fall back to 5060 for local runs.
+CMD sh -c "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-5060}"

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,12 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "backend/Dockerfile"
+
+[deploy]
+# Apply pending migrations, then start the FastAPI app.
+# Railway injects $PORT; fall back to 5060 for local docker-compose parity.
+startCommand = "sh -c 'alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-5060}'"
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
Closes #83.

- New `railway.toml` tells Railway to build from `backend/Dockerfile` (not Nixpacks) and to run `alembic upgrade head` before `uvicorn` on every deploy.
- Dockerfile CMD uses `${PORT:-5060}` so Railway's injected `$PORT` is honored, while local `docker run` and docker-compose still default to 5060.

## Test plan
- [x] `railway.toml` parses as valid TOML
- [x] `docker build` succeeds
- [x] Container binds to `$PORT` when set, defaults to 5060 otherwise
- [ ] Verified on Railway itself — covered by #prod-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)