### PR TITLE
feat(backend): add CORS middleware + BACKEND_CORS_ORIGINS config (#81)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,3 +26,8 @@ GITHUB_REDIRECT_URI=http://localhost:5060/auth/github/callback
 # Monitoring (optional — leave blank to disable Sentry)
 SENTRY_DSN=
 PROMETHEUS_ENABLED=true
+
+# CORS — comma-separated list of origins allowed to call the API from the
+# browser. Leave empty in dev (Vite proxy handles same-origin). Set to
+# the Vercel frontend URL in prod, e.g. https://flow-day.vercel.app
+BACKEND_CORS_ORIGINS=

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -47,9 +47,25 @@ class Settings(BaseSettings):
     # Judge agent — minimum acceptable score per dimension (1–10); triggers retry below
     JUDGE_SCORE_THRESHOLD: int = 6
 
+    # CORS — comma-separated list of origins allowed to call the API from
+    # the browser. Empty by default so production is locked down unless
+    # explicitly configured. In dev it's unnecessary because Vite proxies
+    # all API calls through the same origin.
+    BACKEND_CORS_ORIGINS: str = ""
+
     # Monitoring (optional — silently disabled when absent)
     SENTRY_DSN: str | None = None
     PROMETHEUS_ENABLED: bool = True
+
+    @property
+    def backend_cors_origins(self) -> list[str]:
+        """Parse BACKEND_CORS_ORIGINS into a whitespace-trimmed list,
+        dropping empty items."""
+        return [
+            origin.strip()
+            for origin in self.BACKEND_CORS_ORIGINS.split(",")
+            if origin.strip()
+        ]
 
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.analytics import router as analytics_router
 from app.api.auth import router as auth_router
@@ -50,6 +51,18 @@ def create_app() -> FastAPI:
 
     configure_metrics(app, enabled=settings.PROMETHEUS_ENABLED)
     app.add_middleware(SentryBreadcrumbMiddleware)  # type: ignore[arg-type]
+
+    # Allow the Vercel-hosted frontend (and any other configured origin) to
+    # call the API from the browser. Empty list in dev = no cross-origin
+    # allowlist needed because Vite proxies through the same origin.
+    if settings.backend_cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=settings.backend_cors_origins,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
 
     app.include_router(health_router)
     app.include_router(auth_router)

--- a/backend/tests/integration/test_cors.py
+++ b/backend/tests/integration/test_cors.py
@@ -8,17 +8,20 @@ the module-level `app` singleton.
 from __future__ import annotations
 
 import importlib
-from collections.abc import AsyncGenerator
+from collections.abc import Callable, Generator
 
 import pytest
+from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 
 @pytest.fixture
-def rebuild_app_with_cors(monkeypatch: pytest.MonkeyPatch):
+def rebuild_app_with_cors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[Callable[[str], FastAPI], None, None]:
     """Return a factory that rebuilds the app with a specific CORS allowlist."""
 
-    def _factory(origins: str):
+    def _factory(origins: str) -> FastAPI:
         # Reload config module so `settings = Settings()` re-reads env.
         monkeypatch.setenv("BACKEND_CORS_ORIGINS", origins)
         import app.core.config as config_module
@@ -40,16 +43,9 @@ def rebuild_app_with_cors(monkeypatch: pytest.MonkeyPatch):
     importlib.reload(main_module)
 
 
-async def _client(app) -> AsyncGenerator[AsyncClient, None]:
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as ac:
-        yield ac
-
-
 @pytest.mark.asyncio
 async def test_preflight_from_allowed_origin_gets_cors_headers(
-    rebuild_app_with_cors,
+    rebuild_app_with_cors: Callable[[str], FastAPI],
 ) -> None:
     app = rebuild_app_with_cors("https://flow-day.vercel.app")
 
@@ -74,7 +70,7 @@ async def test_preflight_from_allowed_origin_gets_cors_headers(
 
 @pytest.mark.asyncio
 async def test_preflight_from_disallowed_origin_gets_no_cors_headers(
-    rebuild_app_with_cors,
+    rebuild_app_with_cors: Callable[[str], FastAPI],
 ) -> None:
     app = rebuild_app_with_cors("https://flow-day.vercel.app")
 
@@ -98,7 +94,7 @@ async def test_preflight_from_disallowed_origin_gets_no_cors_headers(
 
 @pytest.mark.asyncio
 async def test_no_cors_middleware_when_origins_empty(
-    rebuild_app_with_cors,
+    rebuild_app_with_cors: Callable[[str], FastAPI],
 ) -> None:
     """Default prod posture: empty allowlist → no CORS middleware at all."""
     app = rebuild_app_with_cors("")

--- a/backend/tests/integration/test_cors.py
+++ b/backend/tests/integration/test_cors.py
@@ -1,0 +1,120 @@
+"""Integration tests for the CORS middleware.
+
+CORS is applied only when `BACKEND_CORS_ORIGINS` is non-empty, so we build
+a fresh app with overridden settings for each scenario rather than reusing
+the module-level `app` singleton.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import AsyncGenerator
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def rebuild_app_with_cors(monkeypatch: pytest.MonkeyPatch):
+    """Return a factory that rebuilds the app with a specific CORS allowlist."""
+
+    def _factory(origins: str):
+        # Reload config module so `settings = Settings()` re-reads env.
+        monkeypatch.setenv("BACKEND_CORS_ORIGINS", origins)
+        import app.core.config as config_module
+
+        importlib.reload(config_module)
+        import app.main as main_module
+
+        importlib.reload(main_module)
+        return main_module.create_app()
+
+    yield _factory
+
+    # Restore a clean settings module so other tests see the default.
+    import app.core.config as config_module
+
+    importlib.reload(config_module)
+    import app.main as main_module
+
+    importlib.reload(main_module)
+
+
+async def _client(app) -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_preflight_from_allowed_origin_gets_cors_headers(
+    rebuild_app_with_cors,
+) -> None:
+    app = rebuild_app_with_cors("https://flow-day.vercel.app")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.options(
+            "/health",
+            headers={
+                "Origin": "https://flow-day.vercel.app",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+
+    # Starlette's CORSMiddleware returns 200 for preflight on allowed origins
+    assert resp.status_code == 200
+    assert (
+        resp.headers.get("access-control-allow-origin") == "https://flow-day.vercel.app"
+    )
+    assert resp.headers.get("access-control-allow-credentials") == "true"
+
+
+@pytest.mark.asyncio
+async def test_preflight_from_disallowed_origin_gets_no_cors_headers(
+    rebuild_app_with_cors,
+) -> None:
+    app = rebuild_app_with_cors("https://flow-day.vercel.app")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.options(
+            "/health",
+            headers={
+                "Origin": "https://evil.example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+
+    # Starlette refuses to echo the origin back, which is what browsers
+    # use to enforce the block.
+    assert resp.headers.get("access-control-allow-origin") != (
+        "https://evil.example.com"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_cors_middleware_when_origins_empty(
+    rebuild_app_with_cors,
+) -> None:
+    """Default prod posture: empty allowlist → no CORS middleware at all."""
+    app = rebuild_app_with_cors("")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.options(
+            "/health",
+            headers={
+                "Origin": "https://flow-day.vercel.app",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+
+    # Without CORSMiddleware the OPTIONS handler either 405s or passes
+    # through without adding CORS headers — the key assertion is that no
+    # Access-Control-Allow-Origin header is set.
+    assert "access-control-allow-origin" not in {k.lower() for k in resp.headers}

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -29,9 +29,7 @@ class TestBackendCorsOrigins:
 
     def test_whitespace_around_origins_is_trimmed(self) -> None:
         s = Settings(
-            BACKEND_CORS_ORIGINS=(
-                "  https://a.com  ,  https://b.com  ,https://c.com"
-            )
+            BACKEND_CORS_ORIGINS=("  https://a.com  ,  https://b.com  ,https://c.com")
         )
         assert s.backend_cors_origins == [
             "https://a.com",
@@ -49,4 +47,3 @@ def test_default_backend_cors_origins_is_empty() -> None:
     """With no env var set, production is locked down by default."""
     s = Settings()
     assert s.backend_cors_origins == []
-

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -1,0 +1,52 @@
+"""Unit tests for `app.core.config.Settings` — especially the list-valued
+fields that are parsed from comma-separated env vars."""
+
+from __future__ import annotations
+
+from app.core.config import Settings
+
+
+class TestBackendCorsOrigins:
+    def test_empty_string_yields_empty_list(self) -> None:
+        """Unset / blank env var disables CORS (no allowed origins)."""
+        s = Settings(BACKEND_CORS_ORIGINS="")
+        assert s.backend_cors_origins == []
+
+    def test_single_origin(self) -> None:
+        s = Settings(BACKEND_CORS_ORIGINS="https://flow-day.vercel.app")
+        assert s.backend_cors_origins == ["https://flow-day.vercel.app"]
+
+    def test_multiple_origins_comma_separated(self) -> None:
+        s = Settings(
+            BACKEND_CORS_ORIGINS=(
+                "https://flow-day.vercel.app,https://staging.flow-day.app"
+            )
+        )
+        assert s.backend_cors_origins == [
+            "https://flow-day.vercel.app",
+            "https://staging.flow-day.app",
+        ]
+
+    def test_whitespace_around_origins_is_trimmed(self) -> None:
+        s = Settings(
+            BACKEND_CORS_ORIGINS=(
+                "  https://a.com  ,  https://b.com  ,https://c.com"
+            )
+        )
+        assert s.backend_cors_origins == [
+            "https://a.com",
+            "https://b.com",
+            "https://c.com",
+        ]
+
+    def test_empty_items_are_dropped(self) -> None:
+        """Trailing commas / double commas should not produce empty-string origins."""
+        s = Settings(BACKEND_CORS_ORIGINS="https://a.com,,https://b.com,")
+        assert s.backend_cors_origins == ["https://a.com", "https://b.com"]
+
+
+def test_default_backend_cors_origins_is_empty() -> None:
+    """With no env var set, production is locked down by default."""
+    s = Settings()
+    assert s.backend_cors_origins == []
+


### PR DESCRIPTION
## Summary
Closes #81.

Production frontend on Vercel and backend on Railway are different origins — browser blocks every API call without CORS. Dev was fine because Vite proxied everything to `localhost:5060` (same origin from the browser's POV).

## Changes
- `Settings.BACKEND_CORS_ORIGINS` (new): comma-separated env var, empty default so prod is locked down unless configured.
- `Settings.backend_cors_origins` (property): parses + trims + drops empty items.
- `create_app()`: conditionally registers `CORSMiddleware` only when the allowlist is non-empty. Empty list → no middleware → same-origin only (backwards-compat with dev).
- `backend/.env.example`: documented the new var.

## Test plan
- [x] 6 unit tests (config parsing edge cases): empty / single / multi / whitespace / trailing commas / default
- [x] 3 integration tests: preflight from allowed origin → correct CORS headers; from disallowed origin → origin not echoed back; empty allowlist → no CORS headers at all
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` clean
- [ ] In prod on Railway, set `BACKEND_CORS_ORIGINS=https://flow-day.vercel.app` — verified in #prod-4/#prod-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)