### PR TITLE
feat(frontend): route API calls through VITE_API_BASE_URL (#82)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,3 +7,8 @@ VITE_GOOGLE_CLIENT_ID=
 # Authorization callback URL: http://localhost:5173/auth/github/callback
 # Also set GITHUB_REDIRECT_URI=http://localhost:5173/auth/github/callback in backend/.env
 VITE_GITHUB_CLIENT_ID=
+
+# Backend base URL. Leave empty in dev — Vite's proxy handles routing to
+# localhost:5060. In production set this to the Railway backend URL, e.g.
+# https://flowday-backend.up.railway.app
+VITE_API_BASE_URL=

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { apiClient } from './client'
+import { apiClient, buildUrl } from './client'
 import type { TokenPair, User } from '../types/auth'
 
 export async function exchangeOAuthCode(
@@ -7,7 +7,7 @@ export async function exchangeOAuthCode(
   signal?: AbortSignal,
 ): Promise<TokenPair> {
   const url = `/auth/${provider}/callback`
-  const res = await fetch(url, {
+  const res = await fetch(buildUrl(url), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ code }),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,13 @@
 import { useAuthStore } from '../stores/authStore'
 import type { TokenPair } from '../types/auth'
 
+const API_BASE: string = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
+
+export function buildUrl(path: string): string {
+  if (path.startsWith('http://') || path.startsWith('https://')) return path
+  return `${API_BASE}${path}`
+}
+
 let refreshPromise: Promise<TokenPair | null> | null = null
 
 async function attemptRefresh(): Promise<TokenPair | null> {
@@ -10,7 +17,7 @@ async function attemptRefresh(): Promise<TokenPair | null> {
     const tokens = useAuthStore.getState().tokens
     if (!tokens) return null
 
-    const res = await fetch('/auth/refresh', {
+    const res = await fetch(buildUrl('/auth/refresh'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ refresh_token: tokens.refresh_token }),
@@ -51,14 +58,14 @@ async function request(
     init.body = JSON.stringify(body)
   }
 
-  const res = await fetch(url, init)
+  const res = await fetch(buildUrl(url), init)
 
   if (res.status === 401 && tokens) {
     const newTokens = await attemptRefresh()
     if (!newTokens) return res
 
     // Retry with new access token
-    return fetch(url, {
+    return fetch(buildUrl(url), {
       ...init,
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${newTokens.access_token}` },
     })


### PR DESCRIPTION
## Summary
Closes #82.

Frontend API calls were all relative paths, which only works in dev via Vite proxy. In production on Vercel the SPA has no same-origin backend, so every call would hit the catch-all `index.html` rewrite and React Query would choke on HTML. Added a `VITE_API_BASE_URL` env var (empty default → backwards-compatible with dev), and routed all `fetch` calls through a `buildUrl` helper that prepends the base URL when set.

## Changes
- `frontend/src/api/client.ts`: export \`buildUrl\`, route all fetches through it (refresh, initial request, 401 retry)
- `frontend/src/api/auth.ts`: use \`buildUrl\` for OAuth code exchange
- `frontend/.env.example`: documented VITE_API_BASE_URL

## Test plan
- [x] ESLint clean
- [x] Behaviour unchanged in dev (VITE_API_BASE_URL unset → empty base → relative URLs → Vite proxy)
- [ ] Test failures locally are pre-existing Node v25 \`localStorage.clear\` issue; CI (Node 20) should pass — will verify in CI
- [ ] In prod Vercel env, set \`VITE_API_BASE_URL\` to Railway URL → covered by #prod-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)