### PR TITLE
fix(infra): co-locate railway.toml with backend Dockerfile (#84)

### DIFF
--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -1,6 +1,10 @@
 [build]
 builder = "DOCKERFILE"
-dockerfilePath = "backend/Dockerfile"
+# Paths are relative to the service's Root Directory (`backend`).
+# Set Root Directory = `backend` in Railway → Service → Settings → Source.
+# Otherwise Railway treats the repo root as the build context and the
+# Dockerfile's `COPY pyproject.toml ./` fails with "file not found".
+dockerfilePath = "Dockerfile"
 
 [deploy]
 # Apply pending migrations, then start the FastAPI app.


### PR DESCRIPTION
## Problem

Railway's first deploy failed during docker build:

\`\`\`
[builder 4/7] COPY pyproject.toml ./
failed to calculate checksum of ref ... pyproject.toml: not found
\`\`\`

Railway treated the repo root as the Docker build context, but \`backend/Dockerfile\` was written assuming the context is \`backend/\` (so \`COPY pyproject.toml ./\` resolves to \`backend/pyproject.toml\`).

## Fix

Two parts:

**Code (this PR):**
- Move \`railway.toml\` → \`backend/railway.toml\` so Railway reads it under the service's Root Directory.
- \`dockerfilePath\`: \`backend/Dockerfile\` → \`Dockerfile\` (now relative to Root Directory).
- Documented the requirement in a comment.

**Dashboard (user action — not code):**
- Railway → FlowDay service → Settings → Source → **Root Directory = \`backend\`**

With Root Directory = \`backend\`, Railway clones the repo and \`cd backend/\` before everything. Build context becomes the backend dir, the Dockerfile's relative paths resolve correctly, and \`backend/railway.toml\` is picked up as the service config.

Local \`docker build -t flowday-backend backend/\` is unaffected.

## Test plan
- [x] TOML parses
- [ ] After merge + Root Directory set: Railway build succeeds through \`[builder 4/7] COPY pyproject.toml ./\`
- [ ] Container starts, \`alembic upgrade head\` runs, \`/health\` returns 200/503

🤖 Generated with [Claude Code](https://claude.com/claude-code)