### PR TITLE
fix(config): auto-coerce postgresql:// URLs to asyncpg driver

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -56,6 +57,25 @@ class Settings(BaseSettings):
     # Monitoring (optional — silently disabled when absent)
     SENTRY_DSN: str | None = None
     PROMETHEUS_ENABLED: bool = True
+
+    @field_validator("DATABASE_URL", mode="before")
+    @classmethod
+    def _coerce_asyncpg_scheme(cls, v: str) -> str:
+        """Rewrite `postgresql://` → `postgresql+asyncpg://`.
+
+        Managed Postgres providers (Railway, Heroku, Supabase, …) inject a
+        connection string with the bare `postgresql://` scheme, but our
+        SQLAlchemy engine is async and requires the `asyncpg` driver. Doing
+        this at config-load time means the rest of the codebase can stay
+        driver-agnostic and there's no env-var-rewriting step to remember
+        on every deploy.
+        """
+        if v.startswith("postgresql://"):
+            return "postgresql+asyncpg://" + v[len("postgresql://") :]
+        if v.startswith("postgres://"):
+            # Heroku-style shorthand, same fix
+            return "postgresql+asyncpg://" + v[len("postgres://") :]
+        return v
 
     @property
     def backend_cors_origins(self) -> list[str]:

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -47,3 +47,30 @@ def test_default_backend_cors_origins_is_empty() -> None:
     """With no env var set, production is locked down by default."""
     s = Settings()
     assert s.backend_cors_origins == []
+
+
+class TestDatabaseUrlAsyncpgCoercion:
+    """Managed Postgres providers give us `postgresql://` URLs. Our async
+    SQLAlchemy engine requires `postgresql+asyncpg://`. The validator must
+    rewrite automatically so deploy env vars don't need manual assembly.
+    """
+
+    def test_postgresql_scheme_is_rewritten(self) -> None:
+        s = Settings(DATABASE_URL="postgresql://u:p@host:5432/db")
+        assert s.DATABASE_URL == "postgresql+asyncpg://u:p@host:5432/db"
+
+    def test_postgres_shorthand_is_rewritten(self) -> None:
+        """Heroku-style `postgres://` shorthand also needs coercion."""
+        s = Settings(DATABASE_URL="postgres://u:p@host:5432/db")
+        assert s.DATABASE_URL == "postgresql+asyncpg://u:p@host:5432/db"
+
+    def test_already_asyncpg_scheme_is_left_alone(self) -> None:
+        url = "postgresql+asyncpg://u:p@host:5432/db"
+        s = Settings(DATABASE_URL=url)
+        assert s.DATABASE_URL == url
+
+    def test_query_params_preserved(self) -> None:
+        s = Settings(DATABASE_URL="postgresql://u:p@host:5432/db?sslmode=require")
+        assert s.DATABASE_URL == (
+            "postgresql+asyncpg://u:p@host:5432/db?sslmode=require"
+        )


### PR DESCRIPTION
Managed Postgres providers (Railway, Heroku, Supabase…) inject \`DATABASE_URL\` with the bare \`postgresql://\` scheme. Our async SQLAlchemy engine requires \`postgresql+asyncpg://\`. Without the rewrite, startup fails with \`NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgresql\`.

Added a Pydantic \`@field_validator\` that rewrites the scheme at config-load time:
- \`postgresql://...\` → \`postgresql+asyncpg://...\`
- \`postgres://...\` (Heroku shorthand) → same
- Already-correct URLs left alone

Env vars on Railway can now be set directly to \`\${{Postgres.DATABASE_URL}}\` without manual string surgery.

4 new unit tests cover rewrite paths; all 10 config tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)