### PR TITLE
fix(agents): bump Judge default model to gemini-2.0-flash

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -42,8 +42,11 @@ class Settings(BaseSettings):
     GITHUB_SYNC_REDIRECT_URI: str = "http://localhost:5060/sync/github/callback"
 
     # AI / LLM (provider-agnostic pydantic-ai model strings)
+    # Narrative Writer and Judge MUST use different providers (CLAUDE.md).
     LLM_MODEL: str = "openai:gpt-4o-mini"
-    LLM_JUDGE_MODEL: str = "google-gla:gemini-1.5-flash"
+    # `gemini-1.5-flash` was retired on the google-gla v1beta endpoint;
+    # 2.0-flash is the stable free-tier successor.
+    LLM_JUDGE_MODEL: str = "google-gla:gemini-2.0-flash"
 
     # Judge agent — minimum acceptable score per dimension (1–10); triggers retry below
     JUDGE_SCORE_THRESHOLD: int = 6


### PR DESCRIPTION
Closes #99. Google retired `gemini-1.5-flash` on the v1beta endpoint, breaking `POST /weekly-reviews/generate` in prod with 404 NOT_FOUND. Default bumped to `gemini-2.0-flash`. Judge/Narrative provider separation preserved (openai vs google-gla).