### PR TITLE
fix(planner): use local calendar date for ScheduleBlock (#98)

### DIFF
--- a/frontend/src/stores/plannerStore.test.ts
+++ b/frontend/src/stores/plannerStore.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { usePlannerStore } from './plannerStore'
+import { formatLocalDate } from '../utils/reviewUtils'
 
 function todayString(): string {
-  return new Date().toISOString().slice(0, 10)
+  // Must match plannerStore's internal calculation (local calendar date,
+  // not UTC). Using toISOString().slice(0,10) would return UTC and fail
+  // in negative-offset timezones after ~5pm local.
+  return formatLocalDate(new Date())
 }
 
 beforeEach(() => {

--- a/frontend/src/stores/plannerStore.ts
+++ b/frontend/src/stores/plannerStore.ts
@@ -1,13 +1,22 @@
 import { create } from 'zustand'
+import { formatLocalDate } from '../utils/reviewUtils'
+
+// A ScheduleBlock's `date` is a user-facing calendar day, not a timestamp.
+// Always derive it from the user's *local* clock so "today" means the day
+// the user sees on the wall. Using `toISOString().slice(0, 10)` would
+// return UTC, which is ahead of local in negative-offset timezones after
+// ~5pm local — leading to blocks saved under the wrong date and Today
+// queries returning empty.
 
 function todayString(): string {
-  return new Date().toISOString().slice(0, 10)
+  return formatLocalDate(new Date())
 }
 
 function shiftDate(dateStr: string, days: number): string {
-  const d = new Date(dateStr + 'T12:00:00Z')
-  d.setUTCDate(d.getUTCDate() + days)
-  return d.toISOString().slice(0, 10)
+  // Parse the stored string as local midnight and shift in local time.
+  const d = new Date(dateStr + 'T00:00:00')
+  d.setDate(d.getDate() + days)
+  return formatLocalDate(d)
 }
 
 interface PlannerState {


### PR DESCRIPTION
Closes #98. Before: `plannerStore.todayString()` used `toISOString().slice(0,10)` (UTC) while `TodayPage` used `formatLocalDate` (local). In PDT after ~5pm local, UTC was tomorrow — blocks saved under one date, Today queried the other, so scheduled blocks didn't appear on the Today tab.

Fix: unify on local calendar date throughout the store. 7/7 store tests pass.