### PR TITLE
fix(agents): bump LLM defaults to current-available models

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -43,10 +43,11 @@ class Settings(BaseSettings):
 
     # AI / LLM (provider-agnostic pydantic-ai model strings)
     # Narrative Writer and Judge MUST use different providers (CLAUDE.md).
-    LLM_MODEL: str = "openai:gpt-4o-mini"
-    # `gemini-1.5-flash` was retired on the google-gla v1beta endpoint;
-    # 2.0-flash is the stable free-tier successor.
-    LLM_JUDGE_MODEL: str = "google-gla:gemini-2.0-flash"
+    # Google retired gemini-1.5-flash and started blocking new users on
+    # gemini-2.0-flash; use 2.5-pro for Judge. Narrative Writer is on the
+    # project's standardized OpenAI nano snapshot.
+    LLM_MODEL: str = "openai:gpt-5.4-nano-2026-03-17"
+    LLM_JUDGE_MODEL: str = "google-gla:gemini-2.5-pro"
 
     # Judge agent — minimum acceptable score per dimension (1–10); triggers retry below
     JUDGE_SCORE_THRESHOLD: int = 6


### PR DESCRIPTION
Google started blocking new API keys on `gemini-2.0-flash` ("no longer available to new users"). Switched:

- `LLM_JUDGE_MODEL`: `google-gla:gemini-2.0-flash` → `google-gla:gemini-2.5-pro`
- `LLM_MODEL` (Narrative Writer): `openai:gpt-4o-mini` → `openai:gpt-5.4-nano-2026-03-17` (team standard)

Judge/Narrative provider separation preserved (openai ≠ google-gla).