### PR TITLE
fix(weekly-review): commit DB transaction after pipeline completes

### DIFF
--- a/backend/app/services/weekly_review_service.py
+++ b/backend/app/services/weekly_review_service.py
@@ -87,6 +87,7 @@ async def get_or_create_review(
     )
     db.add(review)
     await db.flush()
+    await db.commit()
     return review
 
 
@@ -207,6 +208,7 @@ async def generate_review(
             "stages": stages,
         }
         await db.flush()
+        await db.commit()
         raise
 
     review.insights_json = group_a_result.model_dump()
@@ -226,4 +228,5 @@ async def generate_review(
     }
     review.status = ReviewStatus.COMPLETE
     await db.flush()
+    await db.commit()
     return review


### PR DESCRIPTION
POST /weekly-reviews/generate returned a populated review in-memory but never persisted — service only called db.flush() without db.commit(). So GET /weekly-reviews returned `[]` right after a successful generate, and the UI kept showing the pipeline animation.

Added db.commit() in 3 places in weekly_review_service.py to match the pattern other services (project/task/schedule_block) already follow.