### PR TITLE
feat(review): scope day nav to Planned-vs-Actual, week nav to Weekly-by-Project

### DIFF
--- a/frontend/src/pages/ReviewPage.css
+++ b/frontend/src/pages/ReviewPage.css
@@ -60,35 +60,65 @@
   flex: 1;
   overflow-y: auto;
   padding: 24px;
-}
-
-.review-content {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  max-width: 900px;
+  gap: 28px;
+  max-width: 1000px;
 }
 
 .review-section {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 18px 20px 22px;
+}
+
+.review-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.review-section-title-block {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
 }
 
 .review-section-title {
   font-family: var(--font-head);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
-  color: var(--text-2);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  color: var(--text-1);
+  margin: 0;
 }
 
+.loading-text,
+.error-text {
+  font-size: 12px;
+  color: var(--text-3);
+  padding: 16px 0;
+  text-align: center;
+}
+
+.empty-state {
+  font-size: 13px;
+  color: var(--text-3);
+  text-align: center;
+  padding: 28px 0;
+}
+
+/* Legacy — kept for backwards compatibility with any component that
+   still wraps itself in .review-chart-card. */
 .review-chart-card {
-  background: var(--bg-1);
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  padding: 20px;
+  width: 100%;
 }
 
 /* ── AI daily summary card ────────────────────── */

--- a/frontend/src/pages/ReviewPage.test.tsx
+++ b/frontend/src/pages/ReviewPage.test.tsx
@@ -65,24 +65,28 @@ describe('ReviewPage', () => {
     expect(screen.getByTestId('next-week')).toBeInTheDocument()
   })
 
-  it('shows loading state while data is loading', () => {
+  it('shows per-section loading states while data is loading', () => {
     vi.mocked(usePlannedVsActual).mockReturnValue({ data: undefined, isLoading: true } as ReturnType<typeof usePlannedVsActual>)
     vi.mocked(useWeeklyStats).mockReturnValue({ data: undefined, isLoading: true } as ReturnType<typeof useWeeklyStats>)
     render(<ReviewPage />, { wrapper })
-    expect(screen.getByTestId('review-loading')).toBeInTheDocument()
+    expect(screen.getByTestId('day-loading')).toBeInTheDocument()
+    expect(screen.getByTestId('week-loading')).toBeInTheDocument()
   })
 
-  it('shows empty state when both queries return empty lists', () => {
+  it('shows per-section empty states when queries return empty lists', () => {
     render(<ReviewPage />, { wrapper })
-    expect(screen.getByTestId('review-empty')).toBeInTheDocument()
+    expect(screen.getByTestId('day-empty')).toBeInTheDocument()
+    expect(screen.getByTestId('week-empty')).toBeInTheDocument()
   })
 
-  it('shows error state when a query fails', () => {
+  it('shows per-section error state when a query fails', () => {
     vi.mocked(usePlannedVsActual).mockReturnValue({ data: undefined, isLoading: false, isError: true } as ReturnType<typeof usePlannedVsActual>)
     vi.mocked(useWeeklyStats).mockReturnValue({ data: undefined, isLoading: false, isError: false } as ReturnType<typeof useWeeklyStats>)
     render(<ReviewPage />, { wrapper })
-    expect(screen.getByTestId('review-error')).toBeInTheDocument()
-    expect(screen.queryByTestId('review-empty')).not.toBeInTheDocument()
+    expect(screen.getByTestId('day-error')).toBeInTheDocument()
+    // week section should still render its own (empty) state independently
+    expect(screen.getByTestId('week-empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('day-empty')).not.toBeInTheDocument()
   })
 
   it('navigates to the next day when next-day button is clicked', async () => {

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -17,6 +17,24 @@ function today(): string {
   return formatLocalDate(new Date())
 }
 
+function formatWeekRange(weekStartStr: string): string {
+  const start = new Date(weekStartStr + 'T00:00:00')
+  const end = new Date(start)
+  end.setDate(start.getDate() + 6)
+  const fmt = (d: Date) =>
+    d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return `${fmt(start)} – ${fmt(end)}`
+}
+
+function formatDateLabel(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00')
+  return d.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
 function ReviewPage(): React.JSX.Element {
   const [selectedDate, setSelectedDate] = useState<string>(today)
   const [weekStart, setWeekStart] = useState<string>(() => getWeekStart(today()))
@@ -24,75 +42,11 @@ function ReviewPage(): React.JSX.Element {
   const dailyQuery = usePlannedVsActual(selectedDate)
   const weeklyQuery = useWeeklyStats(weekStart)
 
-  const isLoading = dailyQuery.isLoading || weeklyQuery.isLoading
-  const hasError = dailyQuery.isError || weeklyQuery.isError
-
   const tasks = dailyQuery.data?.tasks ?? []
   const projects = weeklyQuery.data?.projects ?? []
-  const isEmpty = !isLoading && !hasError && tasks.length === 0 && projects.length === 0
 
   return (
     <main data-testid="page-review" className="review-page">
-      {/* Header */}
-      <div className="review-header">
-        <div className="review-nav-row">
-          {/* Day navigator */}
-          <div className="review-nav-group">
-            <span className="review-nav-label">Day</span>
-            <div className="review-nav-controls">
-              <button
-                data-testid="prev-day"
-                className="date-nav-btn"
-                onClick={() => setSelectedDate((d) => addDays(d, -1))}
-                aria-label="Previous day"
-              >
-                <CaretLeft size={14} />
-              </button>
-              <span data-testid="selected-date" className="review-date-display">
-                {selectedDate}
-              </span>
-              <button
-                data-testid="next-day"
-                className="date-nav-btn"
-                onClick={() => setSelectedDate((d) => addDays(d, 1))}
-                aria-label="Next day"
-              >
-                <CaretRight size={14} />
-              </button>
-            </div>
-          </div>
-
-          <div className="review-nav-divider" />
-
-          {/* Week navigator */}
-          <div className="review-nav-group">
-            <span className="review-nav-label">Week</span>
-            <div className="review-nav-controls">
-              <button
-                data-testid="prev-week"
-                className="date-nav-btn"
-                onClick={() => setWeekStart((w) => addDays(w, -7))}
-                aria-label="Previous week"
-              >
-                <CaretLeft size={14} />
-              </button>
-              <span data-testid="selected-week" className="review-date-display">
-                {weekStart}
-              </span>
-              <button
-                data-testid="next-week"
-                className="date-nav-btn"
-                onClick={() => setWeekStart((w) => addDays(w, 7))}
-                aria-label="Next week"
-              >
-                <CaretRight size={14} />
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Body */}
       <div className="review-body">
         {/* AI summary pointer — FlowDay's AI review is weekly, not daily */}
         <section className="review-ai-card" data-testid="review-ai-summary">
@@ -112,38 +66,105 @@ function ReviewPage(): React.JSX.Element {
           </Link>
         </section>
 
-        {isLoading && (
-          <p data-testid="review-loading" className="loading-text">Loading...</p>
-        )}
-
-        {hasError && (
-          <p data-testid="review-error" className="error-text">
-            Failed to load data. Please try again.
-          </p>
-        )}
-
-        {isEmpty && (
-          <div data-testid="review-empty" className="empty-state">
-            No tracked data for this period yet.<br />
-            <span>Start a timer from Today to see planned-vs-actual here.</span>
-          </div>
-        )}
-
-        {!isLoading && !hasError && !isEmpty && (
-          <div className="review-content">
-            <section className="review-section">
+        {/* ── Day-scoped section ───────────────────────────────── */}
+        <section className="review-section">
+          <header className="review-section-head">
+            <div className="review-section-title-block">
+              <span className="review-nav-label">Day</span>
               <h2 className="review-section-title">Planned vs actual</h2>
-              <DailyComparisonView tasks={tasks} />
-            </section>
+            </div>
+            <div className="review-nav-controls">
+              <button
+                data-testid="prev-day"
+                className="date-nav-btn"
+                onClick={() => setSelectedDate((d) => addDays(d, -1))}
+                aria-label="Previous day"
+              >
+                <CaretLeft size={14} />
+              </button>
+              <span data-testid="selected-date" className="review-date-display">
+                {formatDateLabel(selectedDate)}
+              </span>
+              <button
+                data-testid="next-day"
+                className="date-nav-btn"
+                onClick={() => setSelectedDate((d) => addDays(d, 1))}
+                aria-label="Next day"
+              >
+                <CaretRight size={14} />
+              </button>
+            </div>
+          </header>
 
-            <section className="review-section">
+          {dailyQuery.isLoading && (
+            <p data-testid="day-loading" className="loading-text">
+              Loading daily comparison…
+            </p>
+          )}
+          {dailyQuery.isError && (
+            <p data-testid="day-error" className="error-text">
+              Failed to load daily data.
+            </p>
+          )}
+          {!dailyQuery.isLoading && !dailyQuery.isError && tasks.length === 0 && (
+            <div data-testid="day-empty" className="empty-state">
+              No tasks tracked or scheduled on this day.
+            </div>
+          )}
+          {!dailyQuery.isLoading && !dailyQuery.isError && tasks.length > 0 && (
+            <DailyComparisonView tasks={tasks} />
+          )}
+        </section>
+
+        {/* ── Week-scoped section ──────────────────────────────── */}
+        <section className="review-section">
+          <header className="review-section-head">
+            <div className="review-section-title-block">
+              <span className="review-nav-label">Week</span>
               <h2 className="review-section-title">Weekly by project</h2>
-              <div className="review-chart-card">
-                <WeeklyBarChart data={toWeeklyChartData(projects)} />
-              </div>
-            </section>
-          </div>
-        )}
+            </div>
+            <div className="review-nav-controls">
+              <button
+                data-testid="prev-week"
+                className="date-nav-btn"
+                onClick={() => setWeekStart((w) => addDays(w, -7))}
+                aria-label="Previous week"
+              >
+                <CaretLeft size={14} />
+              </button>
+              <span data-testid="selected-week" className="review-date-display">
+                {formatWeekRange(weekStart)}
+              </span>
+              <button
+                data-testid="next-week"
+                className="date-nav-btn"
+                onClick={() => setWeekStart((w) => addDays(w, 7))}
+                aria-label="Next week"
+              >
+                <CaretRight size={14} />
+              </button>
+            </div>
+          </header>
+
+          {weeklyQuery.isLoading && (
+            <p data-testid="week-loading" className="loading-text">
+              Loading weekly stats…
+            </p>
+          )}
+          {weeklyQuery.isError && (
+            <p data-testid="week-error" className="error-text">
+              Failed to load weekly data.
+            </p>
+          )}
+          {!weeklyQuery.isLoading && !weeklyQuery.isError && projects.length === 0 && (
+            <div data-testid="week-empty" className="empty-state">
+              No projects with tracked or planned hours in this week.
+            </div>
+          )}
+          {!weeklyQuery.isLoading && !weeklyQuery.isError && projects.length > 0 && (
+            <WeeklyBarChart data={toWeeklyChartData(projects)} />
+          )}
+        </section>
       </div>
     </main>
   )


### PR DESCRIPTION
Before: one sticky header held both Day and Week navigators, even though they drove different charts. Users couldn't tell which navigator affected which section.

Now each section owns its own inline navigator + scope label:
- **Day** section → 'Planned vs actual' chart
- **Week** section → 'Weekly by project' chart

Extra touches:
- Date label now reads `Mon, Apr 20` (was `2026-04-20`); week shows range `Apr 20 – Apr 26`
- Per-section loading/error/empty states (one section failing doesn't blank the other)
- Nested chart-card wrapper removed; the section itself is the card now
- Tests migrated to new `day-*` / `week-*` testids, 8/8 pass