### PR TITLE
fix(review): Y-axis for ScoreTrend + Weekly bar polish

### DIFF
--- a/frontend/src/components/ScoreTrendChart.tsx
+++ b/frontend/src/components/ScoreTrendChart.tsx
@@ -96,7 +96,11 @@ function ScoreTrendChart({ reviews }: ScoreTrendChartProps): React.JSX.Element {
               axisLine={{ stroke: COLOR_GRID }}
             />
             <YAxis
-              domain={[0, 100]}
+              // Judge scores are 1–10 per dimension (see JudgeResult schema),
+              // not 1–100. Using [0, 100] pinned every series near the
+              // bottom of the chart and hid all variance.
+              domain={[0, 10]}
+              ticks={[0, 2, 4, 6, 8, 10]}
               stroke={COLOR_AXIS}
               tick={{ fill: COLOR_AXIS, fontSize: 10, fontFamily: 'var(--font-mono)' }}
               tickLine={false}

--- a/frontend/src/components/WeeklyBarChart.tsx
+++ b/frontend/src/components/WeeklyBarChart.tsx
@@ -83,9 +83,9 @@ function WeeklyBarChart({ data }: WeeklyBarChartProps): React.JSX.Element {
           <BarChart
             layout="vertical"
             data={data}
-            margin={{ top: 6, right: 16, left: 0, bottom: 0 }}
-            barCategoryGap={14}
-            barGap={4}
+            margin={{ top: 10, right: 24, left: 8, bottom: 6 }}
+            barCategoryGap="28%"
+            barGap={3}
           >
             <CartesianGrid
               stroke={COLOR_GRID}
@@ -103,9 +103,9 @@ function WeeklyBarChart({ data }: WeeklyBarChartProps): React.JSX.Element {
             <YAxis
               type="category"
               dataKey="name"
-              width={110}
+              width={96}
               stroke={COLOR_AXIS}
-              tick={{ fill: 'rgba(255,255,255,0.72)', fontSize: 11 }}
+              tick={{ fill: 'rgba(255,255,255,0.78)', fontSize: 12 }}
               tickLine={false}
               axisLine={{ stroke: COLOR_GRID }}
             />
@@ -118,13 +118,15 @@ function WeeklyBarChart({ data }: WeeklyBarChartProps): React.JSX.Element {
               dataKey="planned"
               name="Planned"
               fill={COLOR_PLANNED}
-              radius={[0, 4, 4, 0]}
+              radius={[0, 6, 6, 0]}
+              barSize={14}
             />
             <Bar
               dataKey="actual"
               name="Actual"
               fill={COLOR_ACTUAL}
-              radius={[0, 4, 4, 0]}
+              radius={[0, 6, 6, 0]}
+              barSize={14}
             />
           </BarChart>
         </ResponsiveContainer>


### PR DESCRIPTION
- `ScoreTrendChart`: Y-axis was [0,100] but Judge scores are 1–10, so perfect-10 scores hugged the bottom of the chart. Fixed to [0,10] with [0,2,4,6,8,10] ticks.
- `WeeklyBarChart`: bars looked squeezed/indented — bumped bar size to 14px, widened corner radius, trimmed Y-axis column from 110→96px, added percentage-based category gap.

Tests (6/6) + lint pass.