### PR TITLE
feat(today): full-day 0-24h timeline + start timer on past blocks

### DIFF
--- a/frontend/src/pages/TodayPage.css
+++ b/frontend/src/pages/TodayPage.css
@@ -274,18 +274,6 @@
   background: var(--cyan);
 }
 
-.today-block-done {
-  margin-top: auto;
-  align-self: flex-start;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.1em;
-  color: var(--success);
-  padding: 3px 8px;
-  background: var(--success-dim);
-  border-radius: var(--r-sm);
-}
-
 /* ── Sidebar ────────────────────────────────────────────────── */
 .today-sidebar {
   display: flex;

--- a/frontend/src/pages/TodayPage.tsx
+++ b/frontend/src/pages/TodayPage.tsx
@@ -13,9 +13,12 @@ import type { Project } from '../types/project'
 import type { Task } from '../types/task'
 import './TodayPage.css'
 
-const WORK_START = 8
-const WORK_END = 19
-const HOUR_PX = 68 // timeline row height
+// Full-day timeline — blocks and time tracking on Today should work at any
+// hour (including late-evening catch-up). The row height stays tight so the
+// whole 24h fits comfortably on a standard laptop screen.
+const WORK_START = 0
+const WORK_END = 24
+const HOUR_PX = 44 // timeline row height
 
 function formatHour(h: number): string {
   const whole = Math.floor(h)
@@ -216,7 +219,7 @@ function TodayPage(): React.JSX.Element {
                   <div className="today-block-title">
                     {isCalendar ? 'Calendar event' : task?.title ?? 'Untitled task'}
                   </div>
-                  {!isCalendar && !isPast && (
+                  {!isCalendar && (
                     <button
                       className={`today-block-start${
                         isActiveTimer ? ' today-block-start--running' : ''
@@ -232,10 +235,9 @@ function TodayPage(): React.JSX.Element {
                       ) : (
                         <Play size={14} weight="fill" />
                       )}
-                      {isActiveTimer ? 'Running' : 'Start'}
+                      {isActiveTimer ? 'Running' : isPast ? 'Start late' : 'Start'}
                     </button>
                   )}
-                  {isPast && <span className="today-block-done">Tracked</span>}
                 </div>
               )
             })}


### PR DESCRIPTION
## Summary
Reported: user can't time blocks on Today page at night — at 10 PM every block reads "Tracked", no Start button, and the now-indicator sits below the visible timeline.

Two changes:
1. **Timeline 0-24h** (was 8-19). All blocks render regardless of hour; now-indicator always visible. `HOUR_PX` tightened `68 → 44` so the full 24 rows fit on a standard laptop screen.
2. **Remove `!isPast` guard on Start button.** Past blocks used to show a static "Tracked" span — but nothing was actually tracked, just past. Now the button is always visible on non-calendar blocks; label reads "Start late" when past so users understand the time entry will start at `now`, not back-dated.

Dropped the orphaned `.today-block-done` CSS.

## C.L.E.A.R. Self-Review

### Context
- User feedback: "在today page应该也要可以计时才行啊" + suggested "把时间轴做成0-24点"
- Scope: visual + guard on one page, no API or state changes

### Logic
- All position math uses `(hour - WORK_START) * HOUR_PX` so with `WORK_START = 0` everything anchors naturally to the top
- now-indicator condition `nowHour >= WORK_START && nowHour <= WORK_END` is now always true during normal hours — intended
- "Start late" label on past blocks signals retroactive tracking; keeps the user in control (no auto-backfill)

### Evidence
- `npx tsc --noEmit` clean
- `npx eslint src/pages/TodayPage.tsx` clean
- `npx vitest run src/pages` — 44 passing. 14 pre-existing failures are the Node v25 jsdom `localStorage.clear is not a function` env bug (same set other PRs have flagged); no regression from this change

### Architecture
- Constants stay at top of `TodayPage.tsx`, easy to tweak later
- Calendar blocks still gated by `!isCalendar` for the Start button — matches existing rule

### Risk
- Visual-only + one guard removal; no data model impact
- `HOUR_PX` change narrows rows; if tall content inside a block overflows, only cosmetic clipping (blocks already have `overflow: hidden` via existing CSS)
- If a user starts a timer on a past block, a new time entry gets created starting at now — that's the correct behaviour (not back-dating). The button label "Start late" communicates this

## Test Plan
- [x] `npx vitest run src/pages` — 44 passing
- [ ] Post-merge on Vercel preview: at any time of day, verify:
  - Full 0-24 hour timeline visible
  - Now indicator renders at current hour
  - Start button on every non-calendar block, with "Start late" label on past blocks
  - Starting a past block creates a new time entry

## Follow-ups
- If retroactive back-dating of time entries is desired later, that's a separate feature (needs UI to pick a start time)