### PR TITLE
fix(today,planner): scrollable Today, midnight label, 0-24 planner hours

### DIFF
--- a/frontend/src/pages/TodayPage.css
+++ b/frontend/src/pages/TodayPage.css
@@ -3,6 +3,12 @@
   max-width: 1400px;
   margin: 0 auto;
   color: var(--text-1);
+  /* Parent .app-main sets overflow: hidden, so every page has to manage
+     its own scroll container. Without this the 0-24h timeline gets clipped
+     below the viewport and the user can't reach late-afternoon blocks. */
+  flex: 1;
+  overflow-y: auto;
+  width: 100%;
 }
 
 /* ── Header ─────────────────────────────────────────────────── */

--- a/frontend/src/pages/TodayPage.tsx
+++ b/frontend/src/pages/TodayPage.tsx
@@ -21,8 +21,10 @@ const WORK_END = 24
 const HOUR_PX = 44 // timeline row height
 
 function formatHour(h: number): string {
-  const whole = Math.floor(h)
-  const mins = Math.round((h - whole) * 60)
+  // Normalise 24 -> 0 so "end of day" renders as midnight, not "12:00 PM".
+  const normalised = h >= 24 ? h - 24 : h
+  const whole = Math.floor(normalised)
+  const mins = Math.round((normalised - whole) * 60)
   const display = whole === 0 ? 12 : whole > 12 ? whole - 12 : whole
   const ampm = whole >= 12 ? 'PM' : 'AM'
   return mins === 0

--- a/frontend/src/stores/plannerStore.ts
+++ b/frontend/src/stores/plannerStore.ts
@@ -31,8 +31,10 @@ interface PlannerState {
 
 export const usePlannerStore = create<PlannerState>((set, get) => ({
   selectedDate: todayString(),
-  workHoursStart: 8,
-  workHoursEnd: 18,
+  // Full-day timeline — users schedule and track outside 9-5 too, so the
+  // planner grid now spans the whole day. Matches Today page (0-24h).
+  workHoursStart: 0,
+  workHoursEnd: 24,
   setSelectedDate: (date) => set({ selectedDate: date }),
   goToNextDay: () => set({ selectedDate: shiftDate(get().selectedDate, 1) }),
   goToPrevDay: () => set({ selectedDate: shiftDate(get().selectedDate, -1) }),


### PR DESCRIPTION
## Summary
Three bugs from the previous Today-page 24h change:

1. **Today couldn't scroll past ~2 PM** — `.app-main` hides overflow; each page owns its scroll. Today was missing it, so the 0-24h timeline got clipped. Added `flex: 1; overflow-y: auto; width: 100%;` on `.today-page` (same pattern PlannerPage already uses via `.timeline-grid`).
2. **Last label said \"12:00 PM\" not \"12:00 AM\"** — `formatHour(24)` hit the `whole >= 12 → PM` branch. Normalise `h >= 24` to `h - 24` before the AM/PM math.
3. **Planner still stuck at 8 AM – 6 PM** — `plannerStore` defaults bumped `8/18 → 0/24` so blocks can be dragged onto any hour. `.timeline-grid { overflow-y: auto }` already scrolls the 24×60=1440px stack.

## Evidence
- `npx tsc --noEmit` clean
- `npx eslint` clean on touched files
- `npx vitest run src/stores/plannerStore.test.ts src/components/TimelineGrid.test.tsx` → 12/12 passing

## Test Plan
- [x] tsc + eslint + vitest green
- [ ] Post-merge: on Vercel preview, Today page scrolls from 12 AM → next-day midnight; Plan page lets you drop a task at any hour